### PR TITLE
Use list of arguments instead of a string for Popen()

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -62,7 +62,14 @@ class GenericTrainer(BaseTrainer):
             tensorboard_executable = os.path.join(os.path.dirname(sys.executable), "tensorboard")
 
             self.tensorboard_subprocess = subprocess.Popen(
-                f"{tensorboard_executable} --logdir {tensorboard_log_dir} --port 6006 --samples_per_plugin=images=100"
+                [
+                    tensorboard_executable,
+                    "--logdir",
+                    tensorboard_log_dir,
+                    "--port",
+                    "6006",
+                    "--samples_per_plugin=images=100"
+                ]
             )
         self.one_step_trained = False
 


### PR DESCRIPTION
On Ubuntu 20.04, using a string gives this error:

FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/miniconda/bin/tensorboard --logdir workspace/tensorboard --port 6006 --samples_per_plugin=images=100'