### PR TITLE
Use less vram ram on save and fix minor issue where the model isn't saved if backup before save is disabled

### DIFF
--- a/modules/modelSaver/BaseModelSaver.py
+++ b/modules/modelSaver/BaseModelSaver.py
@@ -17,7 +17,7 @@ class BaseModelSaver(metaclass=ABCMeta):
             if isinstance(value, dict):
                 converted_state_dict[key] = BaseModelSaver._convert_state_dict_dtype(value, dtype)
             else:
-                converted_state_dict[key] = value.to(dtype=dtype)
+                converted_state_dict[key] = value.to(device='cpu', dtype=dtype)
 
         return converted_state_dict
 

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -580,8 +580,7 @@ class TrainUI(ctk.CTk):
             error_caught = True
             traceback.print_exc()
 
-        if self.train_args.backup_before_save:
-            trainer.end()
+        trainer.end()
 
         torch.cuda.empty_cache()
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -25,7 +25,7 @@ def main():
     except KeyboardInterrupt:
         canceled = True
 
-    if not canceled:
+    if not canceled or args.backup_before_save:
         trainer.end()
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -25,7 +25,7 @@ def main():
     except KeyboardInterrupt:
         canceled = True
 
-    if not canceled or args.backup_before_save:
+    if not canceled:
         trainer.end()
 
 


### PR DESCRIPTION
By putting converted values on the cpu we can avoid the slight bump in vram usage right before saving, which lets me fine tune SDXL in batches of 1 w/accumulation steps at 1024px on 24GB of vram.
Note - I'm running 532.03 which doesn't automatically swap vram to cpu when vram is low.

The other change was a small bug, `trainer.end()` is already checking the backup_before_save flag internally and skipping `trainer.end()` prevents the model from being saved.

Might fix https://github.com/Nerogar/OneTrainer/issues/28

Also, thanks for continuing on the StableTuner spirit, this is so much easier to hack about than kohya_ss.