### PR TITLE
Simple UI Switch for Continued Training

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -104,6 +104,10 @@ class GenericTrainer(BaseTrainer):
                 else:  # fine-tunes
                     base_model_name = last_backup_path
 
+                print(f"Continuing training from backup '{last_backup_path}'...")
+            else:
+                print(f"No backup found, continuing without backup...")
+
         self.callbacks.on_update_status("loading the model")
         self.model = self.model_loader.load(
             model_type=self.args.model_type,
@@ -156,13 +160,11 @@ class GenericTrainer(BaseTrainer):
         if os.path.exists(backup_dirpath):
             backup_directories = sorted(
                 [dirpath for dirpath in os.listdir(backup_dirpath) if os.path.isdir(os.path.join(backup_dirpath, dirpath))],
-                key=lambda x: datetime.strptime(x, '%Y-%m-%d_%H-%M-%S'),
                 reverse=True,
             )
-        
+
             if backup_directories:
                 last_backup_dirpath = backup_directories[0]
-                print(f"Continuing training on backup '{last_backup_dirpath}'...")
                 return os.path.join(backup_dirpath, last_backup_dirpath)
             
         return None

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -139,23 +139,28 @@ class TrainUI(ctk.CTk):
                          tooltip="The directory where cached data is saved")
         components.dir_entry(master, 1, 1, self.ui_state, "cache_dir")
 
+        # continue from previous backup
+        components.label(master, 2, 0, "Continue from last backup",
+                         tooltip="Automatically continues training from the last backup saved in <workspace>/run/backup")
+        components.switch(master, 2, 1, self.ui_state, "continue_last_backup")
+
         # only cache
-        components.label(master, 2, 0, "Only Cache",
+        components.label(master, 3, 0, "Only Cache",
                          tooltip="Only populate the cache, without any training")
-        components.switch(master, 2, 1, self.ui_state, "only_cache")
+        components.switch(master, 3, 1, self.ui_state, "only_cache")
 
         # debug
-        components.label(master, 3, 0, "Debug mode",
+        components.label(master, 4, 0, "Debug mode",
                          tooltip="Save debug information during the training into the debug directory")
-        components.switch(master, 3, 1, self.ui_state, "debug_mode")
+        components.switch(master, 4, 1, self.ui_state, "debug_mode")
 
-        components.label(master, 4, 0, "Debug Directory",
+        components.label(master, 5, 0, "Debug Directory",
                          tooltip="The directory where debug data is saved")
-        components.dir_entry(master, 4, 1, self.ui_state, "debug_dir")
+        components.dir_entry(master, 5, 1, self.ui_state, "debug_dir")
 
-        components.label(master, 5, 0, "Tensorboard",
+        components.label(master, 6, 0, "Tensorboard",
                          tooltip="Starts the Tensorboard Web UI during training")
-        components.switch(master, 5, 1, self.ui_state, "tensorboard")
+        components.switch(master, 6, 1, self.ui_state, "tensorboard")
 
     def model_tab(self, master):
         master.grid_columnconfigure(0, weight=0)

--- a/modules/util/args/TrainArgs.py
+++ b/modules/util/args/TrainArgs.py
@@ -22,6 +22,7 @@ class TrainArgs(BaseArgs):
     workspace_dir: str
     cache_dir: str
     tensorboard: bool
+    continue_last_backup: bool
 
     # model settings
     base_model_name: str
@@ -140,6 +141,7 @@ class TrainArgs(BaseArgs):
         parser.add_argument("--workspace-dir", type=str, required=True, dest="workspace_dir", help="directory to use as a workspace")
         parser.add_argument("--cache-dir", type=str, required=True, dest="cache_dir", help="The directory used for caching")
         parser.add_argument("--tensorboard", required=False, action='store_true', dest="tensorboard", help="Start a tensorboard interface during training. The web server will run on port 6006")
+        parser.add_argument("--continue-last-backup", required=False, action='store_true', dest="continue_last_backup", help="Continues training from the last backup in <workspace>/run/backup")
 
         # model settings
         parser.add_argument("--base-model-name", type=str, required=True, dest="base_model_name", help="The base model to start training from")
@@ -231,6 +233,7 @@ class TrainArgs(BaseArgs):
         args["workspace_dir"] = "workspace/run"
         args["cache_dir"] = "workspace-cache/run"
         args["tensorboard"] = True
+        args["continue_last_backup"] = False
 
         # model settings
         args["base_model_name"] = "runwayml/stable-diffusion-v1-5"

--- a/training_presets/#sd 1.5 LoRA.json
+++ b/training_presets/#sd 1.5 LoRA.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15",
     "base_model_name": "runwayml/stable-diffusion-v1-5",
     "extra_model_name": "",

--- a/training_presets/#sd 1.5 embedding.json
+++ b/training_presets/#sd 1.5 embedding.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15",
     "base_model_name": "runwayml/stable-diffusion-v1-5",
     "extra_model_name": "",

--- a/training_presets/#sd 1.5 inpaint masked.json
+++ b/training_presets/#sd 1.5 inpaint masked.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15_INPAINTING",
     "base_model_name": "runwayml/stable-diffusion-inpainting",
     "extra_model_name": "",

--- a/training_presets/#sd 1.5 inpaint.json
+++ b/training_presets/#sd 1.5 inpaint.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15_INPAINTING",
     "base_model_name": "runwayml/stable-diffusion-inpainting",
     "extra_model_name": "",

--- a/training_presets/#sd 1.5 masked.json
+++ b/training_presets/#sd 1.5 masked.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15",
     "base_model_name": "runwayml/stable-diffusion-v1-5",
     "extra_model_name": "",

--- a/training_presets/#sd 1.5.json
+++ b/training_presets/#sd 1.5.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_15",
     "base_model_name": "runwayml/stable-diffusion-v1-5",
     "extra_model_name": "",

--- a/training_presets/#sd 2.0 inpaint LoRA.json
+++ b/training_presets/#sd 2.0 inpaint LoRA.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_20_INPAINTING",
     "base_model_name": "stabilityai/stable-diffusion-2-inpainting",
     "extra_model_name": "",

--- a/training_presets/#sd 2.0 inpaint.json
+++ b/training_presets/#sd 2.0 inpaint.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_20_INPAINTING",
     "base_model_name": "stabilityai/stable-diffusion-2-inpainting",
     "extra_model_name": "",

--- a/training_presets/#sd 2.1 LoRA.json
+++ b/training_presets/#sd 2.1 LoRA.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_21",
     "base_model_name": "stabilityai/stable-diffusion-2-1",
     "extra_model_name": "",

--- a/training_presets/#sd 2.1 embedding.json
+++ b/training_presets/#sd 2.1 embedding.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_21",
     "base_model_name": "stabilityai/stable-diffusion-2-1",
     "extra_model_name": "",

--- a/training_presets/#sd 2.1.json
+++ b/training_presets/#sd 2.1.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_21",
     "base_model_name": "stabilityai/stable-diffusion-2-1",
     "extra_model_name": "",

--- a/training_presets/#sdxl 1.0 LoRA.json
+++ b/training_presets/#sdxl 1.0 LoRA.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_XL_10_BASE",
     "base_model_name": "stabilityai/stable-diffusion-xl-base-1.0",
     "extra_model_name": "",

--- a/training_presets/#sdxl 1.0 inpaint LoRA.json
+++ b/training_presets/#sdxl 1.0 inpaint LoRA.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_XL_10_BASE_INPAINTING",
     "base_model_name": "diffusers/stable-diffusion-xl-1.0-inpainting-0.1",
     "extra_model_name": "",

--- a/training_presets/#sdxl 1.0.json
+++ b/training_presets/#sdxl 1.0.json
@@ -5,6 +5,7 @@
     "workspace_dir": "workspace/run",
     "cache_dir": "workspace-cache/run",
     "tensorboard": true,
+    "continue_last_backup": false,
     "model_type": "STABLE_DIFFUSION_XL_10_BASE",
     "base_model_name": "stabilityai/stable-diffusion-xl-base-1.0",
     "extra_model_name": "",


### PR DESCRIPTION
UI switch for enabling the continued training of the last backup in the workspace folder. This switch follows all the proper UI syntax, with a tooltip, and saving correctly the JSON file. As well as working when starting directly from the /scripts.

If no backup is found, `base_model_name` and `extra_model_name` are left untouched.

![UI Preview Image](https://i.imgur.com/fT9JwOi.png)