### PR TITLE
Add quick and dirty SDXL latent2rgb conversion

### DIFF
--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -243,12 +243,13 @@ class BaseStableDiffusionXLSetup(
                 if self.debug_mode:
                     with torch.no_grad():
                         # predicted image
-                        predicted_image = self._project_latent_to_image(scaled_noisy_latent_image).clamp(-1, 1)
+                        predicted_image = self._project_latent_to_image_sdxl(scaled_noisy_latent_image)
                         self._save_image(
                             predicted_image,
                             args.debug_dir + "/training_batches",
                             "2-predicted_image_" + str(step),
-                            train_progress.global_step
+                            train_progress.global_step,
+                            True
                         )
 
             predicted_latent_image = scaled_noisy_latent_image / vae_scaling_factor
@@ -345,26 +346,29 @@ class BaseStableDiffusionXLSetup(
             with torch.no_grad():
                 # noise
                 self._save_image(
-                    self._project_latent_to_image(latent_noise).clamp(-1, 1),
+                    self._project_latent_to_image_sdxl(latent_noise),
                     args.debug_dir + "/training_batches",
                     "1-noise",
-                    train_progress.global_step
+                    train_progress.global_step,
+                    True
                 )
 
                 # predicted noise
                 self._save_image(
-                    self._project_latent_to_image(predicted_latent_noise).clamp(-1, 1),
+                    self._project_latent_to_image_sdxl(predicted_latent_noise),
                     args.debug_dir + "/training_batches",
                     "2-predicted_noise",
-                    train_progress.global_step
+                    train_progress.global_step,
+                    True
                 )
 
                 # noisy image
                 self._save_image(
-                    self._project_latent_to_image(scaled_noisy_latent_image).clamp(-1, 1),
+                    self._project_latent_to_image_sdxl(scaled_noisy_latent_image),
                     args.debug_dir + "/training_batches",
                     "3-noisy_image",
-                    train_progress.global_step
+                    train_progress.global_step,
+                    True
                 )
 
                 # predicted image
@@ -379,18 +383,20 @@ class BaseStableDiffusionXLSetup(
                     (scaled_noisy_latent_image - predicted_latent_noise * sqrt_one_minus_alpha_prod) \
                     / sqrt_alpha_prod
                 self._save_image(
-                    self._project_latent_to_image(scaled_predicted_latent_image).clamp(-1, 1),
+                    self._project_latent_to_image_sdxl(scaled_predicted_latent_image),
                     args.debug_dir + "/training_batches",
                     "4-predicted_image",
-                    model.train_progress.global_step
+                    model.train_progress.global_step,
+                    True
                 )
 
                 # image
                 self._save_image(
-                    self._project_latent_to_image(scaled_latent_image).clamp(-1, 1),
+                    self._project_latent_to_image_sdxl(scaled_latent_image),
                     args.debug_dir + "/training_batches",
                     "5-image",
-                    model.train_progress.global_step
+                    model.train_progress.global_step,
+                    True
                 )
 
         return model_output_data

--- a/modules/modelSetup/mixin/ModelSetupDebugMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDebugMixin.py
@@ -2,9 +2,10 @@ import os
 from abc import ABCMeta
 
 import torch
-from torch import Tensor
 from PIL import Image
+from torch import Tensor
 from torchvision import transforms
+
 
 class ModelSetupDebugMixin(metaclass=ABCMeta):
     def __init__(self):
@@ -16,38 +17,38 @@ class ModelSetupDebugMixin(metaclass=ABCMeta):
             os.makedirs(directory)
 
         if fromarray:
-          image = Image.fromarray(image_tensor)
+            image = Image.fromarray(image_tensor)
         else:
-          t = transforms.ToPILImage()
+            t = transforms.ToPILImage()
 
-          image_tensor = image_tensor[0].unsqueeze(0)
+            image_tensor = image_tensor[0].unsqueeze(0)
 
-          range_min = -1
-          range_max = 1
-          image_tensor = (image_tensor - range_min) / (range_max - range_min)
+            range_min = -1
+            range_max = 1
+            image_tensor = (image_tensor - range_min) / (range_max - range_min)
 
-          image = t(image_tensor.squeeze())
+            image = t(image_tensor.squeeze())
 
         image.save(path)
 
     # Decodes 4-channel latent to 3-channel RGB - technique appropriated from 
     # https://huggingface.co/blog/TimothyAlexisVass/explaining-the-sdxl-latent-space
     # Uses linear approximation based on first three channels of latent image (luminance, cyan/red, lime/purple)
-
     def _project_latent_to_image_sdxl(self, latent_tensor: Tensor):
-      weights = (
-          (60, -60, 25, -70),
-          (60,  -5, 15, -50),
-          (60,  10, -5, -35)
-      )
+        weights = (
+            (60, -60, 25, -70),
+            (60, -5, 15, -50),
+            (60, 10, -5, -35)
+        )
 
-      weights_tensor = torch.t(torch.tensor(weights, dtype=latent_tensor.dtype).to(latent_tensor.device))
-      biases_tensor = torch.tensor((150, 140, 130), dtype=latent_tensor.dtype).to(latent_tensor.device)
-      rgb_tensor = torch.einsum("...lxy,lr -> ...rxy", latent_tensor, weights_tensor) + biases_tensor.unsqueeze(-1).unsqueeze(-1)
-      image_array = rgb_tensor.clamp(0, 255)[0].byte().cpu().numpy()
-      image_array = image_array.transpose(1, 2, 0)
+        weights_tensor = torch.t(torch.tensor(weights, dtype=latent_tensor.dtype).to(latent_tensor.device))
+        biases_tensor = torch.tensor((150, 140, 130), dtype=latent_tensor.dtype).to(latent_tensor.device)
+        rgb_tensor = torch.einsum("...lxy,lr -> ...rxy", latent_tensor, weights_tensor) \
+                     + biases_tensor.unsqueeze(-1).unsqueeze(-1)
+        image_array = rgb_tensor.clamp(0, 255)[0].byte().cpu().numpy()
+        image_array = image_array.transpose(1, 2, 0)
 
-      return image_array
+        return image_array
 
     def _project_latent_to_image(self, latent_tensor: Tensor):
         generator = torch.Generator(device=latent_tensor.device)

--- a/modules/modelSetup/mixin/ModelSetupDebugMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDebugMixin.py
@@ -3,28 +3,51 @@ from abc import ABCMeta
 
 import torch
 from torch import Tensor
+from PIL import Image
 from torchvision import transforms
-
 
 class ModelSetupDebugMixin(metaclass=ABCMeta):
     def __init__(self):
         super(ModelSetupDebugMixin, self).__init__()
 
-    def _save_image(self, image_tensor: Tensor, directory: str, name: str, step: int):
+    def _save_image(self, image_tensor: Tensor, directory: str, name: str, step: int, fromarray: bool = False):
         path = os.path.join(directory, "step-" + str(step) + "-" + name + ".png")
         if not os.path.exists(directory):
             os.makedirs(directory)
 
-        t = transforms.ToPILImage()
+        if fromarray:
+          image = Image.fromarray(image_tensor)
+        else:
+          t = transforms.ToPILImage()
 
-        image_tensor = image_tensor[0].unsqueeze(0)
+          image_tensor = image_tensor[0].unsqueeze(0)
 
-        range_min = -1
-        range_max = 1
-        image_tensor = (image_tensor - range_min) / (range_max - range_min)
+          range_min = -1
+          range_max = 1
+          image_tensor = (image_tensor - range_min) / (range_max - range_min)
 
-        image = t(image_tensor.squeeze())
+          image = t(image_tensor.squeeze())
+
         image.save(path)
+
+    # Decodes 4-channel latent to 3-channel RGB - technique appropriated from 
+    # https://huggingface.co/blog/TimothyAlexisVass/explaining-the-sdxl-latent-space
+    # Uses linear approximation based on first three channels of latent image (luminance, cyan/red, lime/purple)
+
+    def _project_latent_to_image_sdxl(self, latent_tensor: Tensor):
+      weights = (
+          (60, -60, 25, -70),
+          (60,  -5, 15, -50),
+          (60,  10, -5, -35)
+      )
+
+      weights_tensor = torch.t(torch.tensor(weights, dtype=latent_tensor.dtype).to(latent_tensor.device))
+      biases_tensor = torch.tensor((150, 140, 130), dtype=latent_tensor.dtype).to(latent_tensor.device)
+      rgb_tensor = torch.einsum("...lxy,lr -> ...rxy", latent_tensor, weights_tensor) + biases_tensor.unsqueeze(-1).unsqueeze(-1)
+      image_array = rgb_tensor.clamp(0, 255)[0].byte().cpu().numpy()
+      image_array = image_array.transpose(1, 2, 0)
+
+      return image_array
 
     def _project_latent_to_image(self, latent_tensor: Tensor):
         generator = torch.Generator(device=latent_tensor.device)


### PR DESCRIPTION
Uses quick and dirty (but functioning!) method for latent-to-RGB conversion described here:
https://huggingface.co/blog/TimothyAlexisVass/explaining-the-sdxl-latent-space#direct-conversion-of-sdxl-latents-to-rgb-with-a-linear-approximation

I created a separate method for it to keep everything non-SDXL related intact (hopefully).