### PR TITLE
Add ! to the start of all unix scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 #change the environment name for conda to use
 conda_env=ot

--- a/start-ui.sh
+++ b/start-ui.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 #change the environment name for conda to use
 conda_env=ot

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 #change the environment name for conda to use
 conda_env=ot


### PR DESCRIPTION
The "#!" is required at the start of scripts that run on unix-like systems. https://en.wikipedia.org/wiki/Shebang_(Unix). Without the !, "#/bin/bash" was being interpreted as a comment for whatever shell was currently running. On macOS, zsh is the default shell and so the script was running in zsh. The script is slightly incompatible with zsh so it was getting an error. Adding the ! fixes this.