### PR TITLE
Add CosineAnnealingLR for Prodigy

### DIFF
--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -5,7 +5,7 @@ import transformers
 from diffusers import DDIMScheduler, EulerDiscreteScheduler, EulerAncestralDiscreteScheduler, \
     DPMSolverMultistepScheduler, UniPCMultistepScheduler, SchedulerMixin
 from torch.nn import Parameter
-from torch.optim.lr_scheduler import LambdaLR, LRScheduler
+from torch.optim.lr_scheduler import LambdaLR, LRScheduler, CosineAnnealingLR
 
 from modules.dataLoader.StableDiffusionEmbeddingDataLoader import StableDiffusionEmbeddingDataLoader
 from modules.dataLoader.StableDiffusionFineTuneDataLoader import StableDiffusionFineTuneDataLoader
@@ -685,6 +685,8 @@ def create_lr_scheduler(
                 optimizer,
                 initial_lr=optimizer.state_dict()['param_groups'][0]['initial_lr'],
             )
+        case LearningRateScheduler.COSINE_ANNEALING:
+            return CosineAnnealingLR(optimizer, scheduler_steps)
         case _:
             lr_lambda = lr_lambda_constant()
 

--- a/modules/util/enum/LearningRateScheduler.py
+++ b/modules/util/enum/LearningRateScheduler.py
@@ -9,6 +9,7 @@ class LearningRateScheduler(Enum):
     COSINE_WITH_HARD_RESTARTS = 'COSINE_WITH_HARD_RESTARTS'
     REX = 'REX'
     ADAFACTOR = 'ADAFACTOR'
+    COSINE_ANNEALING = 'COSINE_ANNEALING'
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
As noted by the README of the Prodigy scheduler, they recommend using either no scheduler or CosineAnnealingLR. I'm not sure how no scheduler would be implemented (constant?), but I generally have used ConsineAnnealingLR to great success as per the designer's suggestion. Since it's already built into torch, it's simply a tiny tweak to add the option.

Source:
https://github.com/konstmish/prodigy#scheduler