### PR TITLE
Feature/use gpu for onnxruntime

### DIFF
--- a/modules/module/RembgModel.py
+++ b/modules/module/RembgModel.py
@@ -42,7 +42,11 @@ class RembgModel(BaseImageMaskModel):
             progressbar=True,
         )
 
-        return onnxruntime.InferenceSession(os.path.join(path, filename))
+        if self.device.type == 'cpu':
+            provider = "CPUExecutionProvider"
+        else:
+            provider = "CUDAExecutionProvider" if "CUDAExecutionProvider" in onnxruntime.get_available_providers() else "CPUExecutionProvider"
+        return onnxruntime.InferenceSession(os.path.join(path, filename), providers=[provider])
 
     def __create_average_kernel(self, kernel_radius: Optional[int]):
         if kernel_radius is None:

--- a/modules/module/WDModel.py
+++ b/modules/module/WDModel.py
@@ -16,7 +16,11 @@ class WDModel(BaseImageCaptionModel):
         model_path = huggingface_hub.hf_hub_download(
             "SmilingWolf/wd-v1-4-vit-tagger-v2", "model.onnx"
         )
-        self.model = onnxruntime.InferenceSession(model_path)
+        if device.type == 'cpu':
+            provider = "CPUExecutionProvider"
+        else:
+            provider = "CUDAExecutionProvider" if "CUDAExecutionProvider" in onnxruntime.get_available_providers() else "CPUExecutionProvider"
+        self.model = onnxruntime.InferenceSession(model_path, providers=[provider])
 
         label_path = huggingface_hub.hf_hub_download(
             "SmilingWolf/wd-v1-4-vit-tagger-v2", "selected_tags.csv"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ omegaconf==2.3.0 # needed to load stable diffusion from single ckpt files
 invisible-watermark==0.2.0 # needed for the SDXL pipeline
 
 # other models
-onnxruntime==1.15.1
+onnxruntime-gpu==1.16.3
 pooch==1.7.0
 open-clip-torch==2.22.0
 


### PR DESCRIPTION
Despite setting `args.device` to 'CUDA', `WDModel` was not utilizing GPU. 
Modified `WDModel` to use "CUDAExecutionProvider" when the device is set to GPU. 

As I'm still learning about CUDA and `onnxruntime`, please feel free to close or modify this if there are any oversights on my part."