### PR TITLE
Allow python and venv paths to be specified.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
+# Let user specify python and venv directly.
+if [[ -z "${python_cmd}" ]]; then
+    python_cmd="python"
+fi
+if [[ -z "${python_venv}" ]]; then
+    python_venv=venv
+fi
+
 #change the environment name for conda to use
 conda_env=ot
 #change the environment name for python to use (only needed if Anaconda3 or miniconda is not installed)
-python_venv=venv
 
-if ! [ -x "$(command -v python)" ]; then
+if ! [ -x "$(command -v ${python_cmd})" ]; then
 	echo 'error: python not installed or found!'
-elif [ -x "$(command -v python)" ]; then
-	major=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
-	minor=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
+elif [ -x "$(command -v ${python_cmd})" ]; then
+	major=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
+	minor=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
 
 	#check major version of python
 	if [[ "$major" -eq "3" ]];
@@ -20,22 +27,22 @@ elif [ -x "$(command -v python)" ]; then
 					if ! [ -x "$(command -v conda)" ]; then
 						echo 'conda not found; python version correct; use native python'
 						if ! [ -d $python_venv ]; then
-							python -m venv $python_venv
+							${python_cmd} -m venv $python_venv
 						fi
 						source $python_venv/bin/activate
 						if [[ -z "$VIRTUAL_ENV" ]]; then
     							echo "warning: No VIRTUAL_ENV set. exiting."
 						else
-    							python -m pip install -r requirements.txt
+    							${python_cmd} -m pip install -r requirements.txt
 						fi
 					elif [ -x "$(command -v conda)" ]; then
 						#check for venv
 						if conda info --envs | grep -q ${conda_env}; 
 							then
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; python -m pip install -r requirements.txt")
+								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; ${python_cmd} -m pip install -r requirements.txt")
 							else 
 								conda create -y -n $conda_env python==3.10;
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; python -m pip install -r requirements.txt")
+								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; ${python_cmd} -m pip install -r requirements.txt")
 						fi
 					fi
 				else


### PR DESCRIPTION
Ubuntu systems have python = python2, not python3. This lets you specify exactly which python you want to use, very helpful for these systems or any where you have multiple pythons installed (a user in the discord had exactly this problem). Also let venv path be specified while I was at it.