### PR TITLE
Implement minimum SNR gamma

### DIFF
--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -427,6 +427,7 @@ class BasePixArtAlphaSetup(
                                 train_progress.global_step
                             )
 
+        model_output_data['prediction_type'] = model.noise_scheduler.config.prediction_type
         return model_output_data
 
     def calculate_loss(

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -156,7 +156,6 @@ class BaseStableDiffusionSetup(
                 timestep_high = int(config.align_prop_steps * config.max_noising_strength)
                 timestep_low = \
                     int(config.align_prop_steps * config.max_noising_strength * (1.0 - config.align_prop_truncate_steps))
-
                 truncate_timestep_index = config.align_prop_steps - rand.randint(timestep_low, timestep_high)
 
                 checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device)
@@ -392,6 +391,7 @@ class BaseStableDiffusionSetup(
                                 train_progress.global_step
                             )
 
+            model_output_data['prediction_type'] = model.noise_scheduler.config.prediction_type
             return model_output_data
 
     def calculate_loss(

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -276,6 +276,7 @@ class BaseStableDiffusionSetup(
                 if model.noise_scheduler.config.prediction_type == 'epsilon':
                     model_output_data = {
                         'loss_type': 'target',
+                        'timestep': timestep,
                         'predicted': predicted_latent_noise,
                         'target': latent_noise,
                     }
@@ -283,6 +284,7 @@ class BaseStableDiffusionSetup(
                     target_velocity = model.noise_scheduler.get_velocity(scaled_latent_image, latent_noise, timestep)
                     model_output_data = {
                         'loss_type': 'target',
+                        'timestep': timestep,
                         'predicted': predicted_latent_noise,
                         'target': target_velocity,
                     }

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -349,6 +349,7 @@ class BaseStableDiffusionXLSetup(
                 if model.noise_scheduler.config.prediction_type == 'epsilon':
                     model_output_data = {
                         'loss_type': 'target',
+                        'timestep': timestep,
                         'predicted': predicted_latent_noise,
                         'target': latent_noise,
                     }
@@ -356,6 +357,7 @@ class BaseStableDiffusionXLSetup(
                     target_velocity = model.noise_scheduler.get_velocity(scaled_latent_image, latent_noise, timestep)
                     model_output_data = {
                         'loss_type': 'target',
+                        'timestep': timestep,
                         'predicted': predicted_latent_noise,
                         'target': target_velocity,
                     }

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -443,6 +443,7 @@ class BaseStableDiffusionXLSetup(
                             True
                         )
 
+        model_output_data['prediction_type'] = model.noise_scheduler.config.prediction_type
         return model_output_data
 
     def calculate_loss(

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -129,6 +129,7 @@ class BaseWuerstchenSetup(
             model_output_data = {
                 'loss_type': 'target',
                 'predicted': predicted_latent_noise,
+                'prediction_type': model.prior_noise_scheduler.config.prediction_type,
                 'target': latent_noise,
                 'timestep': timestep,
             }

--- a/modules/modelSetup/StableDiffusionFineTuneVaeSetup.py
+++ b/modules/modelSetup/StableDiffusionFineTuneVaeSetup.py
@@ -112,6 +112,7 @@ class StableDiffusionFineTuneVaeSetup(BaseStableDiffusionSetup):
                     train_progress.global_step
                 )
 
+        model_output_data['prediction_type'] = model.noise_scheduler.config.prediction_type
         return model_output_data
 
     def after_optimizer_step(

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -199,7 +199,7 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
 
         # Apply minimum SNR weighting.
         if config.min_snr_gamma:
-            v_pred = data.get('prediction_type', '') is 'v'
+            v_pred = data.get('prediction_type', '') == 'v'
             snr_weight = self.__min_snr_weight(data['timestep'], config.min_snr_gamma, v_pred, losses.device)
             losses *= snr_weight
 

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -198,7 +198,7 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
         losses *= loss_weight.to(device=losses.device)
 
         # Apply minimum SNR weighting.
-        if config.min_snr_gamma and not data['loss_type'] == 'align_prop':
+        if config.min_snr_gamma and 'timestep' in data and not data['loss_type'] == 'align_prop':
             v_pred = data.get('prediction_type', '') == 'v'
             snr_weight = self.__min_snr_weight(data['timestep'], config.min_snr_gamma, v_pred, losses.device)
             losses *= snr_weight

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -148,14 +148,14 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
     def __min_snr_weight(
             self,
             timesteps: Tensor,
-            gamma: int,
+            gamma: float,
             v_prediction: bool,
             device: torch.device
     ):
         all_snr = (self.__coefficients.sqrt_alphas_cumprod /
                    self.__coefficients.sqrt_one_minus_alphas_cumprod) ** 2
         all_snr.to(device)
-        snr = torch.stack([all_snr[t] for t in timesteps])
+        snr = all_snr[timesteps]
         min_snr_gamma = torch.minimum(snr, torch.full_like(snr, gamma))
         # Denominator of the snr_weight increased by 1 if v-prediction is being used.
         if v_prediction:

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -198,7 +198,7 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
         losses *= loss_weight.to(device=losses.device)
 
         # Apply minimum SNR weighting.
-        if config.min_snr_gamma:
+        if config.min_snr_gamma and not data['loss_type'] == 'align_prop':
             v_pred = data.get('prediction_type', '') == 'v'
             snr_weight = self.__min_snr_weight(data['timestep'], config.min_snr_gamma, v_pred, losses.device)
             losses *= snr_weight

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -450,8 +450,13 @@ class TrainingTab:
                              tooltip="Variational lower-bound strength for custom loss settings. Should be set to 1 for variational diffusion models")
             components.entry(frame, 2, 1, self.ui_state, "vb_loss_strength")
 
+        # Minimum SNR Gamma
+        components.label(frame, 3, 0, "Min SNR Gamma",
+                         tooltip="Minimum SNR gamma. Can help the model learn details more accurately. 0 disables, 20 maximum, ~5 is the usual setting")
+        components.entry(frame, 3, 1, self.ui_state, "min_snr_gamma")
+
         # Loss Scaler
-        components.label(frame, 3, 0, "Loss Scaler",
+        components.label(frame, 4, 0, "Loss Scaler",
                          tooltip="Selects the type of loss scaling to use during training. Functionally equated as: Loss * selection")
         components.options(frame, 3, 1, [str(x) for x in list(LossScaler)], self.ui_state, "loss_scaler")
 

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -458,7 +458,7 @@ class TrainingTab:
         # Loss Scaler
         components.label(frame, 4, 0, "Loss Scaler",
                          tooltip="Selects the type of loss scaling to use during training. Functionally equated as: Loss * selection")
-        components.options(frame, 3, 1, [str(x) for x in list(LossScaler)], self.ui_state, "loss_scaler")
+        components.options(frame, 4, 1, [str(x) for x in list(LossScaler)], self.ui_state, "loss_scaler")
 
     def __open_optimizer_params_window(self):
         window = OptimizerParamsWindow(self.master, self.train_config, self.ui_state)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -181,7 +181,7 @@ class TrainConfig(BaseConfig):
     mse_strength: float
     mae_strength: float
     vb_loss_strength: float
-    min_snr_gamma: int
+    min_snr_gamma: float
     loss_scaler: LossScaler
     learning_rate_scaler: LearningRateScaler
 
@@ -417,7 +417,7 @@ class TrainConfig(BaseConfig):
         data.append(("mse_strength", 1.0, float, False))
         data.append(("mae_strength", 0.0, float, False))
         data.append(("vb_loss_strength", 1.0, float, False))
-        data.append(("min_snr_gamma", 0, int, False))
+        data.append(("min_snr_gamma", 0, float, False))
         data.append(("loss_scaler", LossScaler.NONE, LossScaler, False))
         data.append(("learning_rate_scaler", LearningRateScaler.NONE, LearningRateScaler, False))
 

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -181,6 +181,7 @@ class TrainConfig(BaseConfig):
     mse_strength: float
     mae_strength: float
     vb_loss_strength: float
+    min_snr_gamma: int
     loss_scaler: LossScaler
     learning_rate_scaler: LearningRateScaler
 
@@ -416,6 +417,7 @@ class TrainConfig(BaseConfig):
         data.append(("mse_strength", 1.0, float, False))
         data.append(("mae_strength", 0.0, float, False))
         data.append(("vb_loss_strength", 1.0, float, False))
+        data.append(("min_snr_gamma", 0, int, False))
         data.append(("loss_scaler", LossScaler.NONE, LossScaler, False))
         data.append(("learning_rate_scaler", LearningRateScaler.NONE, LearningRateScaler, False))
 


### PR DESCRIPTION
This implements minimum SNR gamma, based off of the paper "Efficient Diffusion Training via Min-SNR Weighting Strategy" and referenced to the implementation in Kohya's sd-scripts.

Due to my own hardware limitations I am only able to test this on SD 1.5, and I don't exactly have any diverse datasets. I highly suggest testing this on other models, and further SD 1.5 testing, before merging. In the future it would be good to have some known test tensors to check loss modifications against, but that's a PR for another time.