### PR TITLE
Fix prediction type change while training Stable Diffusion

### DIFF
--- a/modules/model/StableDiffusionModel.py
+++ b/modules/model/StableDiffusionModel.py
@@ -170,11 +170,11 @@ class StableDiffusionModel(BaseModel):
 
     def force_v_prediction(self):
         self.noise_scheduler.config.prediction_type = 'v_prediction'
-        self.sd_config['model']['config']['parameterization'] = 'v'
+        self.sd_config['model']['parameterization'] = 'v'
 
     def force_epsilon_prediction(self):
         self.noise_scheduler.config.prediction_type = 'epsilon'
-        self.sd_config['model']['config']['parameterization'] = 'epsilon'
+        self.sd_config['model']['parameterization'] = 'epsilon'
 
     def rescale_noise_scheduler_to_zero_terminal_snr(self):
         rescale_noise_scheduler_to_zero_terminal_snr(self.noise_scheduler)

--- a/modules/model/StableDiffusionModel.py
+++ b/modules/model/StableDiffusionModel.py
@@ -170,11 +170,11 @@ class StableDiffusionModel(BaseModel):
 
     def force_v_prediction(self):
         self.noise_scheduler.config.prediction_type = 'v_prediction'
-        self.sd_config['model']['parameterization'] = 'v'
+        self.sd_config['model']['params']['parameterization'] = 'v'
 
     def force_epsilon_prediction(self):
         self.noise_scheduler.config.prediction_type = 'epsilon'
-        self.sd_config['model']['parameterization'] = 'epsilon'
+        self.sd_config['model']['params']['parameterization'] = 'epsilon'
 
     def rescale_noise_scheduler_to_zero_terminal_snr(self):
         rescale_noise_scheduler_to_zero_terminal_snr(self.noise_scheduler)


### PR DESCRIPTION
Without this change, training with zero-terminal snr/v-predicion (and I guess epsilon predicion) won't start due to error below.
```
Traceback (most recent call last):
  File "G:\sdnext\OneTrainer\modules\ui\TrainUI.py", line 471, in __training_thread_function
    trainer.start()
  File "G:\sdnext\OneTrainer\modules\trainer\GenericTrainer.py", line 130, in start
    self.model_setup.setup_model(self.model, self.config)
  File "G:\sdnext\OneTrainer\modules\modelSetup\StableDiffusionFineTuneSetup.py", line 77, in setup_model
    model.force_v_prediction()
  File "G:\sdnext\OneTrainer\modules\model\StableDiffusionModel.py", line 173, in force_v_prediction
    self.sd_config['model']['config']['parameterization'] = 'v'
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'config'
```