### PR TITLE
Add profiling section for CPU profiles and stack dump

### DIFF
--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -1,0 +1,31 @@
+import faulthandler
+import customtkinter as ctk
+
+from modules.util.ui import components
+
+
+class ProfilingWindow(ctk.CTkToplevel):
+    def __init__(self, parent, *args, **kwargs):
+        ctk.CTkToplevel.__init__(self, parent, *args, **kwargs)
+        self.parent = parent
+
+        self.title("Profiling")
+        self.geometry("1200x800")
+        self.resizable(True, True)
+        self.wait_visibility()
+        self.focus_set()
+
+        self.grid_rowconfigure(0, weight=0)
+        self.grid_rowconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=0)
+        #self.grid_columnconfigure(1, weight=1)
+
+        components.button(self, 0, 0, "Dump stack", self.dump_stack)
+        components.button(self, 1, 0, "Do something", self.do_nothing)
+
+    def do_nothing(self):
+        pass
+
+    def dump_stack(self):
+        with open('stacks.txt', 'w') as f:
+            faulthandler.dump_traceback(f)

--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -1,3 +1,4 @@
+import cProfile
 import faulthandler
 import customtkinter as ctk
 
@@ -10,22 +11,43 @@ class ProfilingWindow(ctk.CTkToplevel):
         self.parent = parent
 
         self.title("Profiling")
-        self.geometry("1200x800")
+        self.geometry("512x512")
         self.resizable(True, True)
         self.wait_visibility()
         self.focus_set()
 
         self.grid_rowconfigure(0, weight=0)
-        self.grid_rowconfigure(1, weight=1)
-        self.grid_columnconfigure(0, weight=0)
-        #self.grid_columnconfigure(1, weight=1)
+        self.grid_rowconfigure(1, weight=0)
+        self.grid_rowconfigure(2, weight=1)
+        self.grid_columnconfigure(0, weight=1)
 
-        components.button(self, 0, 0, "Dump stack", self.dump_stack)
-        components.button(self, 1, 0, "Do something", self.do_nothing)
+        components.button(self, 0, 0, "Dump stack", self._dump_stack)
+        self._profile_button = components.button(
+            self, 1, 0, "Start CPU Profiling", self._start_cpu_profiler)
 
-    def do_nothing(self):
-        pass
+        # Bottom bar
+        self._bottom_bar = ctk.CTkFrame(master=self, corner_radius=0)
+        self._bottom_bar.grid(row=2, column=0, sticky="sew")
+        self._message_label = components.label(self._bottom_bar, 0, 0, "Inactive")
+        self._bottom_bar
 
-    def dump_stack(self):
+    def _dump_stack(self):
         with open('stacks.txt', 'w') as f:
             faulthandler.dump_traceback(f)
+        self._message_label.configure(text='Stack dumped to stacks.txt')
+
+    def _end_cpu_profiler(self):
+        self._active_profile.create_stats()
+        self._active_profile.dump_stats('cpu_profile.txt')
+
+        self._message_label.configure(text='Profile dumped to cpu_profile.txt')
+        self._profile_button.configure(text='Start CPU Profiling')
+        self._profile_button.configure(command=self._start_cpu_profiler)
+
+    def _start_cpu_profiler(self):
+        self._active_profile = cProfile.Profile()
+        self._active_profile.enable()
+
+        self._message_label.configure(text='Profiling active...')
+        self._profile_button.configure(text='End CPU Profiling')
+        self._profile_button.configure(command=self._end_cpu_profiler)

--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -31,6 +31,9 @@ class ProfilingWindow(ctk.CTkToplevel):
         self._message_label = components.label(self._bottom_bar, 0, 0, "Inactive")
         self._bottom_bar
 
+        self.protocol("WM_DELETE_WINDOW", self.withdraw)
+        self.withdraw()
+
     def _dump_stack(self):
         with open('stacks.txt', 'w') as f:
             faulthandler.dump_traceback(f)

--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -24,7 +24,7 @@ class ProfilingWindow(ctk.CTkToplevel):
 
         components.button(self, 0, 0, "Dump stack", self._dump_stack)
         self._profile_button = components.button(
-            self, 1, 0, "Start CPU Profiling", self._start_cpu_profiler)
+            self, 1, 0, "Start Profiling", self._start_profiler)
 
         # Bottom bar
         self._bottom_bar = ctk.CTkFrame(master=self, corner_radius=0)
@@ -40,16 +40,16 @@ class ProfilingWindow(ctk.CTkToplevel):
             faulthandler.dump_traceback(f)
         self._message_label.configure(text='Stack dumped to stacks.txt')
 
-    def _end_cpu_profiler(self):
+    def _end_profiler(self):
         scalene_profiler.stop()
 
-        self._message_label.configure(text='Profile dumped to profile.html')
-        self._profile_button.configure(text='Start CPU Profiling')
-        self._profile_button.configure(command=self._start_cpu_profiler)
+        self._message_label.configure(text='Inactive')
+        self._profile_button.configure(text='Start Profiling')
+        self._profile_button.configure(command=self._start_profiler)
 
-    def _start_cpu_profiler(self):
+    def _start_profiler(self):
         scalene_profiler.start()
 
         self._message_label.configure(text='Profiling active...')
-        self._profile_button.configure(text='End CPU Profiling')
-        self._profile_button.configure(command=self._end_cpu_profiler)
+        self._profile_button.configure(text='End Profiling')
+        self._profile_button.configure(command=self._end_profiler)

--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -24,13 +24,13 @@ class ProfilingWindow(ctk.CTkToplevel):
 
         components.button(self, 0, 0, "Dump stack", self._dump_stack)
         self._profile_button = components.button(
-            self, 1, 0, "Start Profiling", self._start_profiler)
+            self, 1, 0, "Start Profiling", self._start_profiler,
+            tooltip="Turns on/off Scalene profiling. Only works when OneTrainer is launched with Scalene!")
 
         # Bottom bar
         self._bottom_bar = ctk.CTkFrame(master=self, corner_radius=0)
         self._bottom_bar.grid(row=2, column=0, sticky="sew")
         self._message_label = components.label(self._bottom_bar, 0, 0, "Inactive")
-        self._bottom_bar
 
         self.protocol("WM_DELETE_WINDOW", self.withdraw)
         self.withdraw()

--- a/modules/ui/ProfilingWindow.py
+++ b/modules/ui/ProfilingWindow.py
@@ -1,6 +1,7 @@
-import cProfile
 import faulthandler
+
 import customtkinter as ctk
+from scalene import scalene_profiler
 
 from modules.util.ui import components
 
@@ -40,16 +41,14 @@ class ProfilingWindow(ctk.CTkToplevel):
         self._message_label.configure(text='Stack dumped to stacks.txt')
 
     def _end_cpu_profiler(self):
-        self._active_profile.create_stats()
-        self._active_profile.dump_stats('cpu_profile.txt')
+        scalene_profiler.stop()
 
-        self._message_label.configure(text='Profile dumped to cpu_profile.txt')
+        self._message_label.configure(text='Profile dumped to profile.html')
         self._profile_button.configure(text='Start CPU Profiling')
         self._profile_button.configure(command=self._start_cpu_profiler)
 
     def _start_cpu_profiler(self):
-        self._active_profile = cProfile.Profile()
-        self._active_profile.enable()
+        scalene_profiler.start()
 
         self._message_label.configure(text='Profiling active...')
         self._profile_button.configure(text='End CPU Profiling')

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -1,3 +1,4 @@
+import faulthandler
 import json
 import threading
 import traceback
@@ -99,6 +100,10 @@ class TrainUI(ctk.CTk):
         # export button
         self.export_button = components.button(frame, 0, 5, "Export", self.export_training,
                                                tooltip="Export the current configuration as a script to run without a UI")
+
+        # Stackdump button
+        components.button(frame, 0, 6,"Dump Stack", self.dump_stack)
+
 
         return frame
 
@@ -421,6 +426,10 @@ class TrainUI(ctk.CTk):
             self.lora_tab(self.tabview.add("LoRA"))
         if training_method == TrainingMethod.EMBEDDING and "embedding" not in self.tabview._tab_dict:
             self.embedding_tab(self.tabview.add("embedding"))
+
+    def dump_stack(self):
+        with open('stacks.txt', 'w') as f:
+            faulthandler.dump_traceback(f)
 
     def open_tensorboard(self):
         webbrowser.open("http://localhost:6006/", new=0, autoraise=False)

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -1,4 +1,3 @@
-import faulthandler
 import json
 import threading
 import traceback
@@ -14,6 +13,7 @@ from modules.ui.CaptionUI import CaptionUI
 from modules.ui.ConceptTab import ConceptTab
 from modules.ui.ConvertModelUI import ConvertModelUI
 from modules.ui.ModelTab import ModelTab
+from modules.ui.ProfilingWindow import ProfilingWindow
 from modules.ui.SampleWindow import SampleWindow
 from modules.ui.SamplingTab import SamplingTab
 from modules.ui.TopBar import TopBar
@@ -100,9 +100,6 @@ class TrainUI(ctk.CTk):
         # export button
         self.export_button = components.button(frame, 0, 5, "Export", self.export_training,
                                                tooltip="Export the current configuration as a script to run without a UI")
-
-        # Stackdump button
-        components.button(frame, 0, 6,"Dump Stack", self.dump_stack)
 
 
         return frame
@@ -401,6 +398,10 @@ class TrainUI(ctk.CTk):
                          tooltip="Open the model sampling tool")
         components.button(master, 2, 1, "Open", self.open_sampling_tool)
 
+        components.label(master, 3, 0, "Profiling Tool",
+                         tooltip="Open the profiling tools.")
+        components.button(master, 3, 1, "Open", self.open_profiling_tool)
+
         return master
 
     def change_model_type(self, model_type: ModelType):
@@ -426,10 +427,6 @@ class TrainUI(ctk.CTk):
             self.lora_tab(self.tabview.add("LoRA"))
         if training_method == TrainingMethod.EMBEDDING and "embedding" not in self.tabview._tab_dict:
             self.embedding_tab(self.tabview.add("embedding"))
-
-    def dump_stack(self):
-        with open('stacks.txt', 'w') as f:
-            faulthandler.dump_traceback(f)
 
     def open_tensorboard(self):
         webbrowser.open("http://localhost:6006/", new=0, autoraise=False)
@@ -458,6 +455,10 @@ class TrainUI(ctk.CTk):
         )
         self.wait_window(window)
         torch_gc()
+
+    def open_profiling_tool(self):
+        window = ProfilingWindow(self)
+        self.wait_window(window)
 
     def open_sample_ui(self):
         training_callbacks = self.training_callbacks

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -73,6 +73,9 @@ class TrainUI(ctk.CTk):
         self.training_callbacks = None
         self.training_commands = None
 
+        # Persistent profiling window.
+        self.profiling_window = ProfilingWindow(self)
+
     def close(self):
         self.top_bar_component.save_default()
 
@@ -457,8 +460,7 @@ class TrainUI(ctk.CTk):
         torch_gc()
 
     def open_profiling_tool(self):
-        window = ProfilingWindow(self)
-        self.wait_window(window)
+        self.profiling_window.deiconify()
 
     def open_sample_ui(self):
         training_callbacks = self.training_callbacks

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -31,5 +31,8 @@ dadaptation==3.2 # dadaptation optimizers
 lion-pytorch==0.1.2 # lion optimizer
 prodigyopt==1.0 # prodigy optimizer
 
+# Profiling
+scalene
+
 # ui
 customtkinter==5.2.1

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -32,7 +32,7 @@ lion-pytorch==0.1.2 # lion optimizer
 prodigyopt==1.0 # prodigy optimizer
 
 # Profiling
-scalene
+scalene==1.5.39
 
 # ui
 customtkinter==5.2.1

--- a/start-ui.bat
+++ b/start-ui.bat
@@ -12,6 +12,8 @@ goto :end
 :activate_venv
 echo activating venv %VENV_DIR%
 set PYTHON="%VENV_DIR%\Scripts\python.exe"
+if defined PROFILE (set PYTHON=%PYTHON% -m scalene --off --cpu --gpu --profile-all --no-browser)
+echo Using Python %PYTHON%
 
 :launch
 %PYTHON% scripts\train_ui.py


### PR DESCRIPTION
We needed to get this diagnostic for a deadlock and most people are on Windows and unable to run normal profilers as a result. This is a quick workaround that should let us get a stack dump as long as the UI is able to run.

I put it to the right of "Export", but you might not like that, feel free to move the button wherever (or even have it trigger when you click the OneTrainer icon, so it's completely out of the way).