### PR TITLE
Add support for long concept names in the concept tab

### DIFF
--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -60,7 +60,7 @@ class ConceptWidget(ctk.CTkFrame):
         image_label.grid(row=0, column=0)
 
         # name
-        self.name_label = components.label(self, 1, 0, self.__get_display_name(), pad=5)
+        self.name_label = components.label(self, 1, 0, self.__get_display_name(), pad=5, wraplength=140)
 
         # close button
         close_button = ctk.CTkButton(

--- a/modules/util/ui/components.py
+++ b/modules/util/ui/components.py
@@ -27,8 +27,8 @@ def app_title(master, row, column):
     label_component.grid(row=0, column=1, padx=(0, PAD), pady=PAD)
 
 
-def label(master, row, column, text, pad=PAD, tooltip=None, wide_tooltip=False):
-    component = ctk.CTkLabel(master, text=text)
+def label(master, row, column, text, pad=PAD, tooltip=None, wide_tooltip=False, wraplength=0):
+    component = ctk.CTkLabel(master, text=text, wraplength=wraplength)
     component.grid(row=row, column=column, padx=pad, pady=pad, sticky="nw")
     if tooltip:
         ToolTip(component, tooltip, wide=wide_tooltip)


### PR DESCRIPTION
This PR adds support for wrapping text in labels within the concept widget boxes. Previously, long concept names would extend beyond the UI boundaries, causing display issues. The addition of the `wraplength` parameter to label components ensures that text is appropriately wrapped, maintaining the UI's integrity and improving readability.
