### PR TITLE
Optionally bundle joint-trained embeddings into LoRAs

### DIFF
--- a/modules/modelSaver/PixArtAlphaLoRAModelSaver.py
+++ b/modules/modelSaver/PixArtAlphaLoRAModelSaver.py
@@ -26,7 +26,8 @@ class PixArtAlphaLoRAModelSaver(
         embedding_model_saver = PixArtAlphaEmbeddingSaver()
 
         lora_model_saver.save(model, output_model_format, output_model_destination, dtype)
-        embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+        if not model.train_config.bundle_additional_embeddings:
+            embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
 
         if output_model_format == ModelFormat.INTERNAL:
             self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/StableDiffusionLoRAModelSaver.py
+++ b/modules/modelSaver/StableDiffusionLoRAModelSaver.py
@@ -26,7 +26,8 @@ class StableDiffusionLoRAModelSaver(
         embedding_model_saver = StableDiffusionEmbeddingSaver()
 
         lora_model_saver.save(model, output_model_format, output_model_destination, dtype)
-        embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+        if not model.train_config.bundle_additional_embeddings:
+            embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
 
         if output_model_format == ModelFormat.INTERNAL:
             self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/StableDiffusionXLLoRAModelSaver.py
+++ b/modules/modelSaver/StableDiffusionXLLoRAModelSaver.py
@@ -26,7 +26,8 @@ class StableDiffusionXLLoRAModelSaver(
         embedding_model_saver = StableDiffusionXLEmbeddingSaver()
 
         lora_model_saver.save(model, output_model_format, output_model_destination, dtype)
-        embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+        if not model.train_config.bundle_additional_embeddings:
+            embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
 
         if output_model_format == ModelFormat.INTERNAL:
             self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/WuerstchenLoRAModelSaver.py
+++ b/modules/modelSaver/WuerstchenLoRAModelSaver.py
@@ -26,7 +26,8 @@ class WuerstchenLoRAModelSaver(
         embedding_model_saver = WuerstchenEmbeddingSaver()
 
         lora_model_saver.save(model, output_model_format, output_model_destination, dtype)
-        embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+        if not model.train_config.bundle_additional_embeddings:
+            embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
 
         if output_model_format == ModelFormat.INTERNAL:
             self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/pixartAlpha/PixArtAlphaLoRASaver.py
+++ b/modules/modelSaver/pixartAlpha/PixArtAlphaLoRASaver.py
@@ -26,6 +26,10 @@ class PixArtAlphaLoRASaver(
         if model.lora_state_dict is not None:
             state_dict |= model.lora_state_dict
 
+        if model.additional_embeddings and model.train_config.bundle_additional_embeddings:
+            for embedding in model.additional_embeddings:
+                state_dict[f"bundle_emb.{embedding.placeholder}.t5"] = embedding.text_encoder_vector
+
         return state_dict
 
     def __save_ckpt(

--- a/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
@@ -29,8 +29,9 @@ class StableDiffusionLoRASaver(
         if model.additional_embeddings:
             embedding_dict = {}
             for embedding in model.additional_embeddings:
-                embedding_dict[embedding.placeholder]['string_to_param']['*'] = \
-                    embedding.text_encoder_vector.to(device="cpu")
+                embedding_dict[embedding.placeholder] = {
+                    'string_to_param': {'*': embedding.text_encoder_vector.to(device="cpu")}
+                }
             state_dict['bundle_emb'] = embedding_dict
 
         return state_dict

--- a/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
@@ -27,12 +27,8 @@ class StableDiffusionLoRASaver(
             state_dict |= model.lora_state_dict
 
         if model.additional_embeddings:
-            embedding_dict = {}
             for embedding in model.additional_embeddings:
-                embedding_dict[embedding.placeholder] = {
-                    'string_to_param': {'*': embedding.text_encoder_vector.to(device="cpu")}
-                }
-            state_dict['bundle_emb'] = embedding_dict
+                state_dict[f"bundle_emb.{embedding.placeholder}.string_to_param.*"] = embedding.text_encoder_vector
 
         return state_dict
 

--- a/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
@@ -26,7 +26,7 @@ class StableDiffusionLoRASaver(
         if model.lora_state_dict is not None:
             state_dict |= model.lora_state_dict
 
-        if model.additional_embeddings:
+        if model.additional_embeddings and model.train_config.bundle_additional_embeddings:
             for embedding in model.additional_embeddings:
                 state_dict[f"bundle_emb.{embedding.placeholder}.string_to_param.*"] = embedding.text_encoder_vector
 

--- a/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
@@ -26,6 +26,13 @@ class StableDiffusionLoRASaver(
         if model.lora_state_dict is not None:
             state_dict |= model.lora_state_dict
 
+        if model.additional_embeddings:
+            embedding_dict = {}
+            for embedding in model.additional_embeddings:
+                embedding_dict[embedding.placeholder]['string_to_param']['*'] = \
+                    embedding.text_encoder_vector.to(device="cpu")
+            state_dict['bundle_emb'] = embedding_dict
+
         return state_dict
 
     def __save_ckpt(

--- a/modules/modelSaver/stableDiffusionXL/StableDiffusionXLLoRASaver.py
+++ b/modules/modelSaver/stableDiffusionXL/StableDiffusionXLLoRASaver.py
@@ -28,6 +28,11 @@ class StableDiffusionXLLoRASaver(
         if model.lora_state_dict is not None:
             state_dict |= model.lora_state_dict
 
+        if model.additional_embeddings and model.train_config.bundle_additional_embeddings:
+            for embedding in model.additional_embeddings:
+                state_dict[f"bundle_emb.{embedding.placeholder}.clip_l"] = embedding.text_encoder_1_vector
+                state_dict[f"bundle_emb.{embedding.placeholder}.clip_g"] = embedding.text_encoder_2_vector
+
         return state_dict
 
     def __save_ckpt(

--- a/modules/modelSaver/wuerstchen/WuerstchenLoRASaver.py
+++ b/modules/modelSaver/wuerstchen/WuerstchenLoRASaver.py
@@ -28,6 +28,10 @@ class WuerstchenLoRASaver(
         if model.lora_state_dict is not None:
             state_dict |= model.lora_state_dict
 
+        if model.additional_embeddings and model.train_config.bundle_additional_embeddings:
+            for embedding in model.additional_embeddings:
+                state_dict[f"bundle_emb.{embedding.placeholder}.clip_g"] = embedding.prior_text_encoder_vector
+
         return state_dict
 
     def __save_ckpt(

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -349,12 +349,17 @@ class TrainUI(ctk.CTk):
         components.entry(master, 3, 1, self.ui_state, "dropout_probability")
 
         # lora weight dtype
-        components.label(master, 5, 0, "LoRA Weight Data Type",
+        components.label(master, 4, 0, "LoRA Weight Data Type",
                          tooltip="The LoRA weight data type used for training. This can reduce memory consumption, but reduces precision")
-        components.options_kv(master, 5, 1, [
+        components.options_kv(master, 4, 1, [
             ("float32", DataType.FLOAT_32),
             ("bfloat16", DataType.BFLOAT_16),
         ], self.ui_state, "lora_weight_dtype")
+
+        # For use with additional embeddings.
+        components.label(master, 5, 0, "Bundle Embeddings",
+                         tooltip="Bundles any additional embeddings into the LoRA output file, rather than as separate files")
+        components.switch(master, 5, 1, self.ui_state, "bundle_additional_embeddings")
 
         return master
 

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -310,6 +310,7 @@ class TrainConfig(BaseConfig):
     lora_rank: int
     lora_alpha: float
     lora_weight_dtype: DataType
+    bundle_additional_embeddings: bool
 
     # optimizer
     optimizer: TrainOptimizerConfig
@@ -697,6 +698,7 @@ class TrainConfig(BaseConfig):
         data.append(("lora_rank", 16, int, False))
         data.append(("lora_alpha", 1.0, float, False))
         data.append(("lora_weight_dtype", DataType.FLOAT_32, DataType, False))
+        data.append(("bundle_additional_embeddings", True, bool, False))
 
         # optimizer
         data.append(("optimizer", TrainOptimizerConfig.default_values(), TrainOptimizerConfig, False))


### PR DESCRIPTION
This uses the format defined by https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13568. I tested it for SD1.5; I can't run any of the others on my machine so did not test those.

Currently A1111 only supports SD1.5/SD2/SDXL. There's no Wuerstchen or Pixart support in anything to actually use the bundled embeddings. That said, there was no reason to not extend the format to them.

I only write out the embeddings under `model.additional_embeddings` rather than anything in `model.additional_embedding_states`, with the idea that just because an embedding is present in training doesn't mean it should be shipped with the model. If I've misunderstood something about how `model.additional_embedding_states` is used, please correct me on this.