### PR TITLE
add missing import os

### DIFF
--- a/scripts/create_train_files.py
+++ b/scripts/create_train_files.py
@@ -2,6 +2,7 @@ from util.import_util import script_imports
 
 script_imports()
 
+import os
 import json
 
 from pathlib import Path


### PR DESCRIPTION
create_train_files script does not have explict `import os` and its using it which causes runtime errors on some python versions.