### PR TITLE
Added automation tab with folder and mustache support

### DIFF
--- a/modules/ui/AutomationTab.py
+++ b/modules/ui/AutomationTab.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import customtkinter as ctk
+
+from modules.util.config.TrainConfig import TrainConfig
+from modules.util.enum.ConfigPart import ConfigPart
+from modules.util.replacement_util import parse_directory_for_folders, process_parsed_directories, replace_text_in_trainconfig
+from modules.util.ui import components
+from modules.util.ui.UIState import UIState
+
+
+class AutomationTab:
+
+    def __init__(self, master, train_config: TrainConfig, ui_state: UIState):
+        super(AutomationTab, self).__init__()
+        self.init_load = True
+        self.master = master
+        self.train_config = train_config
+        self.ui_state = ui_state
+
+        master.grid_rowconfigure(0, weight=1)
+        master.grid_columnconfigure(0, weight=1)
+
+        self.scroll_frame = None
+
+        self.__setup_ui()
+
+    def refresh_ui(self):
+        if self.init_load_finished:
+            if self.scroll_frame:
+                self.scroll_frame.destroy()
+            self.__setup_ui()
+        
+    def __setup_ui(self):
+        self.scroll_frame = ctk.CTkScrollableFrame(self.master, fg_color="transparent")
+        self.scroll_frame.grid(row=0, column=0, sticky="nsew")
+
+        self.scroll_frame.grid_columnconfigure(0, weight=0)
+        self.scroll_frame.grid_columnconfigure(1, weight=10)
+        self.scroll_frame.grid_columnconfigure(2, minsize=50)
+        self.scroll_frame.grid_columnconfigure(3, weight=0)
+        self.scroll_frame.grid_columnconfigure(4, weight=1)
+        self.init_load = False
+        
+        row = 0
+        # row = self.__create_base_dtype_components(row)
+        row = self.__create_base_components(
+            row,
+            automation_enabled=True,
+            automation_replacement_keyword="",
+            automation_replacement_text=""
+        )
+        
+        self.init_load_finished = True;
+
+    def __create_base_components(
+            self,
+            row: int,
+            automation_enabled: bool = False,
+            automation_replacement_keyword: str = "",
+            automation_replacement_text: str = ""
+    ) -> int:
+        components.label(self.scroll_frame, row, 0, "Enabled Directory Automation",
+                        tooltip="Enable replacement automation through {{replacement text}}")
+        components.switch(self.scroll_frame, row, 1, self.ui_state, "automation_directory_enabled")
+
+        row += 1
+        components.label(self.scroll_frame, row, 0, "Queued Work Directory",
+                            tooltip="The directory where queued work is organized into folders that can have keywords in the folder name.")
+        components.dir_entry(self.scroll_frame, row, 1, self.ui_state, "automation_queued_dir")
+            
+        row += 1
+        components.label(self.scroll_frame, row, 0, "Test Dir Parsing",
+                        tooltip="Test the parsing of the directory and string replacement")
+        components.button(self.scroll_frame, row, 1, "Test Dir", self.test_dir_replacement)
+        
+    def test_dir_replacement(self):
+        directories = parse_directory_for_folders(self.train_config.automation_queued_dir, self.train_config)
+        results = process_parsed_directories(directories, self.train_config, True)
+        for r in results:
+            print(r.to_dict())
+            
+
+       

--- a/modules/ui/AutomationTab.py
+++ b/modules/ui/AutomationTab.py
@@ -4,7 +4,7 @@ import customtkinter as ctk
 
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ConfigPart import ConfigPart
-from modules.util.replacement_util import parse_directory_for_folders, process_parsed_directories, replace_text_in_trainconfig
+from modules.util.replacement_util import parse_directory_for_folders, process_parsed_directories
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState
 

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -28,7 +28,7 @@ from modules.util.enum.DataType import DataType
 from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.TrainingMethod import TrainingMethod
-from modules.util.replacement_util import parse_directory_for_folders, process_parsed_directories, replace_text, replace_text_in_trainconfig
+from modules.util.replacement_util import parse_directory_for_folders, process_parsed_directories
 from modules.util.torch_util import torch_gc
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from modules.util.ModelNames import ModelNames, EmbeddingName
 from modules.util.ModelWeightDtypes import ModelWeightDtypes
-from modules.util.config.BaseConfig import BaseConfig
+from modules.util.config.BaseConfig import BaseConfig 
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.SampleConfig import SampleConfig
 from modules.util.enum.AlignPropLoss import AlignPropLoss
@@ -338,6 +338,10 @@ class TrainConfig(BaseConfig):
     save_after: float
     save_after_unit: TimeUnit
     save_filename_prefix: str
+    
+    # automation
+    automation_directory_enabled: bool
+    automation_queued_dir: str
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super(TrainConfig, self).__init__(
@@ -726,5 +730,9 @@ class TrainConfig(BaseConfig):
         data.append(("save_after", 0, int, False))
         data.append(("save_after_unit", TimeUnit.NEVER, TimeUnit, False))
         data.append(("save_filename_prefix", "", str, False))
+        
+        # automation settings
+        data.append(("automation_directory_enabled", "", str, False))
+        data.append(("automation_queued_dir", "", str, False))
 
         return TrainConfig(data)

--- a/modules/util/replacement_util.py
+++ b/modules/util/replacement_util.py
@@ -1,0 +1,149 @@
+import os
+
+from copy import deepcopy
+from pathlib import Path
+import random
+from typing import Any
+from unittest import result
+from uuid import uuid1
+import chevron
+from modules.util.config.SampleConfig import SampleConfig
+
+from modules.util.config.TrainConfig import TrainConfig
+
+def replace_text_in_trainconfig(original: TrainConfig, test_only: bool)  -> TrainConfig:
+    new_train_config = deepcopy(original)
+    new_train_config.workspace_dir = replace_text(new_train_config.workspace_dir, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+    new_train_config.cache_dir = replace_text(new_train_config.cache_dir, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+    new_train_config.output_model_destination = replace_text(new_train_config.output_model_destination, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+    instanceguid = str(uuid1())
+    
+    if new_train_config.concepts is not None:
+        for c in new_train_config.concepts:
+            c.name = replace_text(c.name, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+            c.path = replace_text(c.path, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+    else:
+        concepts = read_file(original.concept_file_name)
+        concepts = replace_text(concepts, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+        tempfilename = "%s_concepts.json" % (instanceguid)
+        save_to_directory(concepts, new_train_config.workspace_dir, tempfilename)
+        tempconceptsfilepath = os.path.join(new_train_config.workspace_dir, tempfilename)
+        new_train_config.concept_file_name = tempconceptsfilepath
+        
+
+    if new_train_config.samples is not None:
+        for s in new_train_config.samples:
+            s.prompt = replace_text(c.name, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+    else:
+        samples = read_file(original.sample_definition_file_name)
+        samples = replace_text(samples, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
+        samplestempfilename = "%s_samples.json" % (instanceguid)
+        save_to_directory(samples, new_train_config.workspace_dir, samplestempfilename)
+        tempsamplesfilepath = os.path.join(new_train_config.workspace_dir, samplestempfilename)
+        new_train_config.sample_definition_file_name = tempsamplesfilepath
+    
+    return new_train_config
+
+def replace_text_in_sampleconfig(original: SampleConfig, keyword: str, replacement_text:str) -> SampleConfig:
+    new_sample_config = deepcopy(original)
+    new_sample_config.prompt = replace_text(c.name, keyword, replacement_text)
+    return new_sample_config
+        
+
+def replace_text(original: str, keyword: str, replacement_text: str):
+    return chevron.render(original, {keyword: replacement_text})
+
+def replace_text_from_dict(original: str, replacement_text_dict: dict[str, Any]):
+    return chevron.render(original, replacement_text_dict)
+
+def read_file(file_path) -> str:
+    try:
+        with open(file_path, 'r') as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"File not found at path: {file_path}")
+        return None
+
+def save_to_directory(content, output_dir, output_filename):
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, output_filename)
+        with open(output_path, 'w') as f:
+            f.write(content)
+        print(f"Saved modified content to: {output_path}")
+    except Exception as e:
+        print(f"Error while saving to directory: {e}")
+        
+
+def get_sub_directory_paths(start_directory):
+    sub_directories = []
+    for item in os.listdir(start_directory):
+        full_path = os.path.join(start_directory, item)
+        if os.path.isdir(full_path):
+            sub_directories.append(full_path)
+            # Recursive call to search through all subdirectories.
+            get_sub_directory_paths(full_path)
+    return sub_directories
+
+def split_directory_names(directory_list):
+    split_values = {}
+    for directory in directory_list:
+        folder_name = str(os.path.basename(directory))
+        split_values[folder_name] = folder_name.split("-")
+    return split_values
+
+def parse_directory_for_folders(path_to_search: str, original: TrainConfig)  -> TrainConfig:
+    all_directories = get_sub_directory_paths(path_to_search)
+    result_dict = split_directory_names(all_directories)
+    
+    return result_dict
+
+def process_parsed_directories(directories: dict[str, Any], original: TrainConfig, test_only: bool) -> list[TrainConfig]:
+    results = []
+    for directory, variablies in directories.items():
+        keywords = {}
+        counter = 1
+        for var in variablies:
+            var_str = f"V{counter}"
+            keywords[var_str] = var
+            counter += 1
+        new_train_config = deepcopy(original)
+        new_train_config = replace_text_in_trainconfig_from_dict(original, keywords, test_only)
+        results.append(new_train_config)
+    return results
+              
+def replace_text_in_trainconfig_from_dict(original: TrainConfig, keywords: dict[str, Any], test_only: bool)  -> TrainConfig:
+    new_train_config = deepcopy(original)
+    new_train_config.workspace_dir = replace_text_from_dict(new_train_config.workspace_dir, keywords)
+    new_train_config.cache_dir = replace_text_from_dict(new_train_config.cache_dir,  keywords)
+    new_train_config.output_model_destination = replace_text_from_dict(new_train_config.output_model_destination, keywords)
+    instanceguid = str(uuid1())
+    
+    if new_train_config.concepts is not None:
+        for c in new_train_config.concepts:
+            c.name = replace_text_from_dict(c.name, keywords)
+            c.path = replace_text_from_dict(c.path, keywords)
+    else:
+        concepts = read_file(original.concept_file_name)
+        concepts = replace_text_from_dict(concepts, keywords)
+        tempfilename = "concepts.json"
+        if not test_only:
+            save_to_directory(concepts, new_train_config.workspace_dir, tempfilename)
+        tempconceptsfilepath = os.path.join(new_train_config.workspace_dir, tempfilename)
+        new_train_config.concept_file_name = tempconceptsfilepath
+        
+
+    if new_train_config.samples is not None:
+        for s in new_train_config.samples:
+            s.prompt = replace_text_from_dict(c.name, keywords)
+    else:
+        samples = read_file(original.sample_definition_file_name)
+        samples = replace_text_from_dict(samples, keywords)
+        samplestempfilename = "samples.json"
+        if not test_only:
+            save_to_directory(samples, new_train_config.workspace_dir, samplestempfilename)
+        tempsamplesfilepath = os.path.join(new_train_config.workspace_dir, samplestempfilename)
+        new_train_config.sample_definition_file_name = tempsamplesfilepath
+    
+    return new_train_config
+    

--- a/modules/util/replacement_util.py
+++ b/modules/util/replacement_util.py
@@ -11,48 +11,6 @@ from modules.util.config.SampleConfig import SampleConfig
 
 from modules.util.config.TrainConfig import TrainConfig
 
-def replace_text_in_trainconfig(original: TrainConfig, test_only: bool)  -> TrainConfig:
-    new_train_config = deepcopy(original)
-    new_train_config.workspace_dir = replace_text(new_train_config.workspace_dir, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-    new_train_config.cache_dir = replace_text(new_train_config.cache_dir, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-    new_train_config.output_model_destination = replace_text(new_train_config.output_model_destination, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-    instanceguid = str(uuid1())
-    
-    if new_train_config.concepts is not None:
-        for c in new_train_config.concepts:
-            c.name = replace_text(c.name, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-            c.path = replace_text(c.path, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-    else:
-        concepts = read_file(original.concept_file_name)
-        concepts = replace_text(concepts, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-        tempfilename = "%s_concepts.json" % (instanceguid)
-        save_to_directory(concepts, new_train_config.workspace_dir, tempfilename)
-        tempconceptsfilepath = os.path.join(new_train_config.workspace_dir, tempfilename)
-        new_train_config.concept_file_name = tempconceptsfilepath
-        
-
-    if new_train_config.samples is not None:
-        for s in new_train_config.samples:
-            s.prompt = replace_text(c.name, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-    else:
-        samples = read_file(original.sample_definition_file_name)
-        samples = replace_text(samples, new_train_config.automation_replacement_keyword, new_train_config.automation_replacement_text)
-        samplestempfilename = "%s_samples.json" % (instanceguid)
-        save_to_directory(samples, new_train_config.workspace_dir, samplestempfilename)
-        tempsamplesfilepath = os.path.join(new_train_config.workspace_dir, samplestempfilename)
-        new_train_config.sample_definition_file_name = tempsamplesfilepath
-    
-    return new_train_config
-
-def replace_text_in_sampleconfig(original: SampleConfig, keyword: str, replacement_text:str) -> SampleConfig:
-    new_sample_config = deepcopy(original)
-    new_sample_config.prompt = replace_text(c.name, keyword, replacement_text)
-    return new_sample_config
-        
-
-def replace_text(original: str, keyword: str, replacement_text: str):
-    return chevron.render(original, {keyword: replacement_text})
-
 def replace_text_from_dict(original: str, replacement_text_dict: dict[str, Any]):
     return chevron.render(original, replacement_text_dict)
 

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -6,6 +6,7 @@ tqdm==4.66.1
 PyYAML==6.0.1
 huggingface-hub==0.20.3
 scipy==1.11.4; sys_platform != 'win32'
+chevron==0.14.0
 
 # pytorch
 accelerate==0.25.0


### PR DESCRIPTION
Found myself constantly going in and changing the same values over and over as i create a lot of lora's with the same settings.

The new tab support pointing at a folder and for each folder it will run to completion and then start the next one. Each folder get's it's only copy of the config, concepts and samples files with the values replaced if necessary.

You can name the folder with dashes to support multiple mustache replacements throughout the settings.

Specifically it supports the workspace / cache / modeloutput / concepts / samples folder replacements. 

An example would be /directory/{{V1}}{{V2}.safetensors in the model output and then name the folder "foo:bar" to get /directory/foobar.safetensors in the final config which is used as the "function_train_config". The original becomes a template. you can turn it off an on in the automation tab.