### PR TITLE
Fix the sample window (from additional tools) messing up after a11y fixes.

### DIFF
--- a/modules/ui/SampleFrame.py
+++ b/modules/ui/SampleFrame.py
@@ -33,8 +33,8 @@ class SampleFrame(ctk.CTkFrame):
             top_frame.grid_columnconfigure(1, weight=1)
 
         if include_settings:
-            bottom_frame = ctk.CTkFrame(self, fg_color="transparent")
-            bottom_frame.grid(row=1, column=0, padx=0, pady=0, sticky="nsew")
+            # Minimum width enforcement so the ScrollableFrame doesn't collapse.
+            bottom_frame = ctk.CTkScrollableFrame(self, fg_color="transparent", width=600)
 
             bottom_frame.grid_columnconfigure(0, weight=0)
             bottom_frame.grid_columnconfigure(1, weight=1)
@@ -110,3 +110,7 @@ class SampleFrame(ctk.CTkFrame):
                                   allow_model_files=False,
                                   allow_image_files=True,
                                   )
+
+            # Now that we're gridded out, switch to pack to expand it out.
+            # Grid and scrollbar don't play nicely together.
+            bottom_frame.pack(fill="both", expand=1)

--- a/modules/ui/SampleFrame.py
+++ b/modules/ui/SampleFrame.py
@@ -6,7 +6,7 @@ from modules.util.ui import components
 from modules.util.ui.UIState import UIState
 
 
-class SampleFrame(ctk.CTkScrollableFrame):
+class SampleFrame(ctk.CTkFrame):
     def __init__(
             self,
             parent,
@@ -15,7 +15,7 @@ class SampleFrame(ctk.CTkScrollableFrame):
             include_prompt: bool = True,
             include_settings: bool = True,
     ):
-        ctk.CTkScrollableFrame.__init__(self, parent, fg_color="transparent")
+        ctk.CTkFrame.__init__(self, parent, fg_color="transparent")
 
         self.sample = sample
         self.ui_state = ui_state


### PR DESCRIPTION
Oops. This fixes #352.

The additional scrollbars aren't particularly pretty, but a11y kinda trumps looking nice I think.