### PR TITLE
Fix WD-Vit Initial Captions missing from output .txt

### DIFF
--- a/modules/module/WDModel.py
+++ b/modules/module/WDModel.py
@@ -71,6 +71,6 @@ class WDModel(BaseImageCaptionModel):
             for label
             in sorted_general_labels
         ])
-        predicted_caption = (caption_prefix + predicted_caption + caption_postfix).strip()
+        predicted_caption = (initial_caption + caption_prefix + predicted_caption + caption_postfix).strip()
 
         return predicted_caption


### PR DESCRIPTION
I'll open a discord bug for this shortly but figured may as well open a fix for something I noticed a long time ago but just tracked down finally.