### PR TITLE
Update the default module filter for PixArt Sigma lora.

### DIFF
--- a/modules/modelSetup/PixArtAlphaLoRASetup.py
+++ b/modules/modelSetup/PixArtAlphaLoRASetup.py
@@ -99,7 +99,7 @@ class PixArtAlphaLoRASetup(
         )
 
         model.transformer_lora = LoRAModuleWrapper(
-            model.transformer, config.lora_rank, "lora_transformer", config.lora_alpha, ["attn1", "attn2"]
+            model.transformer, config.lora_rank, "lora_transformer", config.lora_alpha, ["attn1", "attn2", "ff.net"]
         )
 
         if model.lora_state_dict:


### PR DESCRIPTION
Folks were dissatisfied with lora training compared to finetunes. This will add the MLP layers to the training.

This is a stopgap measure until the lora refactor with presets comes online (this will be the "attention-mlp" preset, with the former being "attention-only").