### PR TITLE
Don't create TE layers that won't be trained or used.

### DIFF
--- a/modules/modelSetup/StableDiffusionLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionLoRASetup.py
@@ -7,6 +7,7 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection, Name
 from modules.util.TrainProgress import TrainProgress
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.optimizer_util import init_model_parameters
+from modules.util.torch_util import state_dict_has_prefix
 
 
 class StableDiffusionLoRASetup(
@@ -93,26 +94,30 @@ class StableDiffusionLoRASetup(
         if config.train_any_embedding():
             model.text_encoder.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
 
+        create_te = config.text_encoder.train or state_dict_has_prefix(model.lora_state_dict, "lora_te")
         model.text_encoder_lora = LoRAModuleWrapper(
             model.text_encoder, config.lora_rank, "lora_te", config.lora_alpha
-        )
+        ) if create_te else None
 
         model.unet_lora = LoRAModuleWrapper(
             model.unet, config.lora_rank, "lora_unet", config.lora_alpha, ["attentions"]
         )
 
         if model.lora_state_dict:
-            model.text_encoder_lora.load_state_dict(model.lora_state_dict)
+            if create_te:
+                model.text_encoder_lora.load_state_dict(model.lora_state_dict)
             model.unet_lora.load_state_dict(model.lora_state_dict)
             model.lora_state_dict = None
 
-        model.text_encoder_lora.set_dropout(config.dropout_probability)
+
+        if config.text_encoder.train:
+            model.text_encoder_lora.set_dropout(config.dropout_probability)
+        if create_te:
+            model.text_encoder_lora.to(dtype=config.lora_weight_dtype.torch_dtype())
+            model.text_encoder_lora.hook_to_module()
+
         model.unet_lora.set_dropout(config.dropout_probability)
-
-        model.text_encoder_lora.to(dtype=config.lora_weight_dtype.torch_dtype())
         model.unet_lora.to(dtype=config.lora_weight_dtype.torch_dtype())
-
-        model.text_encoder_lora.hook_to_module()
         model.unet_lora.hook_to_module()
 
         if config.rescale_noise_scheduler_to_zero_terminal_snr:

--- a/modules/util/torch_util.py
+++ b/modules/util/torch_util.py
@@ -6,16 +6,23 @@ import accelerate
 accelerator = accelerate.Accelerator()
 default_device = accelerator.device
 
+
+def state_dict_has_prefix(state_dict: dict|None, prefix: str):
+    if not state_dict:
+        return False
+    return any(k.startswith(prefix) for k in state_dict.keys())
+
+
 def torch_gc():
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     if torch.backends.mps.is_available():
         torch.mps.synchronize()
-    
+
     gc.collect()
-    
+
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-    
+
     if torch.backends.mps.is_available():
         torch.mps.empty_cache()


### PR DESCRIPTION
Should work for any combination of:
* Train text encoder or not.
* Do not load a lora.
* Load a lora with a trained text encoder.
* Load a lora with an untrained text encoder.

Saves a (possibly significant) amount of output disk space.