### PR TITLE
fix embedding setup to use vpred if configured

### DIFF
--- a/modules/modelSetup/StableDiffusionEmbeddingSetup.py
+++ b/modules/modelSetup/StableDiffusionEmbeddingSetup.py
@@ -67,6 +67,10 @@ class StableDiffusionEmbeddingSetup(
     ):
         model.text_encoder.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
 
+        if config.rescale_noise_scheduler_to_zero_terminal_snr:
+            model.rescale_noise_scheduler_to_zero_terminal_snr()
+            model.force_v_prediction()
+
         self._remove_added_embeddings_from_tokenizer(model.tokenizer)
         self._setup_additional_embeddings(model, config)
         self._setup_embedding(model, config)


### PR DESCRIPTION
A small fix for configuring vpred when training embeddings

I observed when training embeddings that the samples exhibited the behaviour of using a vpred model without having vpred enabled, even if Rescale Noise Schedule was enabled. So i investigated and found it was missing the lines present in the LoraSetup which setup vpred