### PR TITLE
fix model config loading for sd and sdxl

### DIFF
--- a/modules/modelLoader/stableDiffusion/StableDiffusionModelLoader.py
+++ b/modules/modelLoader/stableDiffusion/StableDiffusionModelLoader.py
@@ -242,8 +242,8 @@ class StableDiffusionModelLoader(
     ):
         stacktraces = []
 
-        model.sd_config = self._load_sd_config(model_type)
-        model.sd_config_filename = self._get_sd_config_name(model_type)
+        model.sd_config = self._load_sd_config(model_type, model_names.base_model)
+        model.sd_config_filename = self._get_sd_config_name(model_type, model_names.base_model)
 
         try:
             self.__load_internal(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)

--- a/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
+++ b/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
@@ -209,8 +209,8 @@ class StableDiffusionXLModelLoader(
     ):
         stacktraces = []
 
-        model.sd_config = self._load_sd_config(model_type)
-        model.sd_config_filename = self._get_sd_config_name(model_type)
+        model.sd_config = self._load_sd_config(model_type, model_names.base_model)
+        model.sd_config_filename = self._get_sd_config_name(model_type, model_names.base_model)
 
         try:
             self.__load_internal(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)


### PR DESCRIPTION
Seems that model configs weren't loaded and always used default configs. Fixed by passing the model name to the function of the mixin.