### PR TITLE
Undo the a11y changes to the masks / caption UI.

### DIFF
--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -46,8 +46,7 @@ class CaptionUI(ctk.CTkToplevel):
 
         self.title("OneTrainer")
         self.geometry("1280x980")
-        self.resizable(True, True)
-        self.bind('<Configure>', self._resize)
+        self.resizable(False, False)
         self.wait_visibility()
         self.focus_set()
 
@@ -556,12 +555,3 @@ Mouse wheel: increase or decrease brush size"""
 
     def print_help(self):
         print(self.help_text)
-
-    def _resize(self, event):
-        if not event.widget == self:
-            return
-        new = min(event.width, event.height)
-        margin = 980 - 850
-        self.image_size = new - margin
-        if self.current_image_index >= 0:
-            self.switch_image(self.current_image_index)


### PR DESCRIPTION
It seems to have made things worse in a way that's difficult to understand, but is clearly causing regressions and problems for people. Making this zoomable etc. is going to be a larger and more difficult project.