### PR TITLE
fix(ZLUDAInstaller.py): zluda using rocm 6.1

### DIFF
--- a/modules/zluda/ZLUDAInstaller.py
+++ b/modules/zluda/ZLUDAInstaller.py
@@ -7,7 +7,7 @@ import urllib.request
 from typing import Union
 
 
-RELEASE = f"rel.{os.environ.get('ZLUDA_HASH', '11cc5844514f93161e0e74387f04e2c537705a82')}"
+RELEASE = f"rel.{os.environ.get('ZLUDA_HASH', '86cdab3b14b556e95eafe370b8e8a1a80e8d093b')}"
 DLL_MAPPING = {
     'cublas.dll': 'cublas64_11.dll',
     'cusparse.dll': 'cusparse64_11.dll',

--- a/modules/zluda/ZLUDAInstaller.py
+++ b/modules/zluda/ZLUDAInstaller.py
@@ -13,8 +13,8 @@ DLL_MAPPING = {
     'cusparse.dll': 'cusparse64_11.dll',
     'nvrtc.dll': 'nvrtc64_112_0.dll',
 }
-HIP_TARGETS = ['rocblas.dll', 'rocsolver.dll', 'hiprtc0507.dll',]
-ZLUDA_TARGETS = ('nvcuda.dll', 'nvml.dll',)
+HIP_TARGETS = ['rocblas.dll', 'rocsolver.dll', 'hiprtc0507.dll', 'hiprtc0601.dll']
+ZLUDA_TARGETS = ('nvcuda.dll', 'nvml.dll')
 
 
 def get_path() -> str:


### PR DESCRIPTION
The installer only checks for the rocm 5.7 hiprtc dll, ideally that should be a wildcard like "hiprtc*.dll" so there is no need to hardcode the dll in there every time a new rocm version releases