### PR TITLE
VAE sampler fixes

### DIFF
--- a/modules/modelSampler/StableDiffusionVaeSampler.py
+++ b/modules/modelSampler/StableDiffusionVaeSampler.py
@@ -39,12 +39,12 @@ class StableDiffusionVaeSampler(BaseModelSampler):
         image = Image.open(sample_config.prompt)
         image = image.convert("RGB")
         # TODO: figure out better set of transformations for resize and/or implement way to configure them as per-sample toggle
-        
+
         if sample_config.width > sample_config.height:
             scale = sample_config.width
         else:
             scale = sample_config.height
-            
+
         t_in = transforms.Compose([
             transforms.Resize(scale),
             transforms.CenterCrop([sample_config.height, sample_config.width]),
@@ -65,9 +65,9 @@ class StableDiffusionVaeSampler(BaseModelSampler):
         image_tensor = image_tensor.clamp(0, 1)
 
         t_out = transforms.ToPILImage()
-        image = t_out(image_tensor)
+        image = t_out(image_tensor.float())
 
         os.makedirs(Path(destination).parent.absolute(), exist_ok=True)
         image.save(destination)
-        
+
         on_sample(image)


### PR DESCRIPTION
- `on_sample(image)` was missing so samples didn't render in gui in Sampling Tool
- resolution was not used so high resolution images used for sample where guaranteed OOM
- lines to match DecodeVAE implementation from MGDS (without it colors where off)

There are still some "burned" pixels on some of samples rendered in GUI using this code (example in attachment), I'll check tomorrow if they are visible after sampling to file while training.
![image](https://github.com/user-attachments/assets/d470de0b-cd8d-4cd5-bf21-cf3639c439aa)
