### PR TITLE
deduplicate code for linux scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,67 +1,8 @@
 #!/bin/bash
 
-# Let user specify python and venv directly.
-if [[ -z "${python_cmd}" ]]; then
-    python_cmd="python"
-fi
-if [[ -z "${python_venv}" ]]; then
-    python_venv=venv
-fi
+source ./linux-env-vars.sh
 
-#change the environment name for conda to use
-conda_env=ot
-#change the environment name for python to use (only needed if Anaconda3 or miniconda is not installed)
+export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
+export linux_cmd_conda_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
 
-if [ -e /dev/kfd ]; then
-	PLATFORM_REQS=requirements-rocm.txt
-elif [ -x "$(command -v nvcc)" ]; then
-	PLATFORM_REQS=requirements-cuda.txt
-else
-	PLATFORM_REQS=requirements-default.txt
-fi
-
-if ! [ -x "$(command -v ${python_cmd})" ]; then
-	echo 'error: python not installed or found!'
-elif [ -x "$(command -v ${python_cmd})" ]; then
-	major=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
-	minor=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
-
-	#check major version of python
-	if [[ "$major" -eq "3" ]];
-		then
-			#check minor version of python
-			if [[ "$minor" -le "10" ]];
-				then
-					if ! [ -x "$(command -v conda)" ]; then
-						echo 'conda not found; python version correct; use native python'
-						if ! [ -d $python_venv ]; then
-							${python_cmd} -m venv $python_venv
-						fi
-						source $python_venv/bin/activate
-						if [[ -z "$VIRTUAL_ENV" ]]; then
-    							echo "warning: No VIRTUAL_ENV set. exiting."
-						else
-    							${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS
-						fi
-					elif [ -x "$(command -v conda)" ]; then
-						#check for venv
-						if conda info --envs | grep -q ${conda_env}; 
-							then
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS")
-							else 
-								conda create -y -n $conda_env python==3.10;
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS")
-						fi
-					fi
-				else
-					echo 'error: wrong python version installed:'$major'.'$minor
-					echo 'OneTrainer requires the use of python 3.10, please refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-			fi
-		else
-			echo 'error: wrong python version installed:'$major'.'$minor
-			echo 'OneTrainer requires the use of python 3.10, either install python3 on your system or refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-	fi
-fi
-
-#create workdirs
-#TODO
+/bin/bash ./linux-python-env.sh

--- a/install.sh
+++ b/install.sh
@@ -38,11 +38,11 @@ ask() {
     done
 }
 
-#clear linux-platform (used  to store the selected platform-requirements, so we don't have to confirm on every update)
+#clear linux-platform (used to store the selected platform-requirements, so we don't have to confirm on every update)
 > linux-platform
 
 echo ""
-echo "Platform requirements diverge slightly sepending on you GPU."Would you want to use the detected platform Requirements? (echo $PLATFORM_REQS)
+echo "Platform requirements diverge slightly depending on you GPU.Would you want to use the detected platform Requirements? (echo $PLATFORM_REQS)"
 if ask "Use $PLATFORM_REQS? default: Yes" Y; then
     echo "Using $PLATFORM_REQS"
     cat $PLATFORM_REQS > linux-platform

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,58 @@
 
 source ./linux-env-vars.sh
 
-export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
-export linux_cmd_conda_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
+ask() {
+    local prompt default reply
+
+    if [[ ${2:-} = 'Y' ]]; then
+        prompt='Y/n'
+        default='Y'
+    elif [[ ${2:-} = 'N' ]]; then
+        prompt='y/N'
+        default='N'
+    else
+        prompt='y/n'
+        default=''
+    fi
+
+    while true; do
+
+        # Ask the question (not using "read -p" as it uses stderr not stdout)
+        echo -n "$1 [$prompt] "
+
+        # Read the answer (use /dev/tty in case stdin is redirected from somewhere else)
+        read -r reply </dev/tty
+
+        # Default?
+        if [[ -z $reply ]]; then
+            reply=$default
+        fi
+
+        # Check if the reply is valid
+        case "$reply" in
+            Y*|y*) return 0 ;;
+            N*|n*) return 1 ;;
+        esac
+
+    done
+}
+
+#clear linux-platform (used  to store the selected platform-requirements, so we don't have to confirm on every update)
+> linux-platform
+
+echo ""
+echo "Platform requirements diverge slightly sepending on you GPU."Would you want to use the detected platform Requirements? (echo $PLATFORM_REQS)
+if ask "Use $PLATFORM_REQS? default: Yes" Y; then
+    echo "Using $PLATFORM_REQS"
+    cat $PLATFORM_REQS > linux-platform
+else
+    echo "Using default"
+    cat "requirements-default.txt" > linux-platform
+fi
+
+stored_platform_reqs=$(<linux-platform)
+
+export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
+export linux_cmd_conda_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
 
 /bin/bash ./linux-python-env.sh

--- a/install.sh
+++ b/install.sh
@@ -39,21 +39,19 @@ ask() {
 }
 
 #clear linux-platform (used to store the selected platform-requirements, so we don't have to confirm on every update)
-> linux-platform
+> linux-platform.txt
 
 echo ""
 echo "Platform requirements diverge slightly depending on you GPU.Would you want to use the detected platform Requirements? ($PLATFORM_REQS)"
 if ask "Use $PLATFORM_REQS? default: Yes" Y; then
     echo "Using $PLATFORM_REQS"
-    cat $PLATFORM_REQS > linux-platform
+    echo $PLATFORM_REQS > linux-platform.txt
 else
     echo "Using default"
-    cat "requirements-default.txt" > linux-platform
+    echo "requirements-default.txt" > linux-platform.txt
 fi
 
-stored_platform_reqs=$(<linux-platform)
-
-export linux_cmd_python_venv='${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
-export linux_cmd_conda_venv='${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
+export linux_cmd_python_venv='${python_cmd} -m pip install -r requirements-global.txt -r $(<linux-platform.txt)'
+export linux_cmd_conda_venv='${python_cmd} -m pip install -r requirements-global.txt -r $(<linux-platform.txt)'
 
 /bin/bash ./linux-python-env.sh

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ ask() {
 > linux-platform
 
 echo ""
-echo "Platform requirements diverge slightly depending on you GPU.Would you want to use the detected platform Requirements? (echo $PLATFORM_REQS)"
+echo "Platform requirements diverge slightly depending on you GPU.Would you want to use the detected platform Requirements? ($PLATFORM_REQS)"
 if ask "Use $PLATFORM_REQS? default: Yes" Y; then
     echo "Using $PLATFORM_REQS"
     cat $PLATFORM_REQS > linux-platform
@@ -53,7 +53,7 @@ fi
 
 stored_platform_reqs=$(<linux-platform)
 
-export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
-export linux_cmd_conda_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
+export linux_cmd_python_venv='${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
+export linux_cmd_conda_venv='${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs'
 
 /bin/bash ./linux-python-env.sh

--- a/linux-env-vars.sh
+++ b/linux-env-vars.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Let user specify python and venv directly, otherwise default to 'python', 'venv' and 'ot' respectively.
+
+# python command to call
+if [[ -z "${python_cmd}" ]]; then
+   export  python_cmd="python"
+fi
+# python virtual environment name
+if [[ -z "${python_venv}" ]]; then
+    export python_venv=venv
+fi
+# conda virtual environment name
+if [[ -z "${conda_venv}" ]]; then
+    export conda_env=ot
+fi
+
+if [ -e /dev/kfd ]; then
+	export PLATFORM_REQS=requirements-rocm.txt
+elif [ -x "$(command -v nvcc)" ]; then
+	export PLATFORM_REQS=requirements-cuda.txt
+else
+	export PLATFORM_REQS=requirements-default.txt
+fi

--- a/linux-env-vars.sh
+++ b/linux-env-vars.sh
@@ -15,10 +15,10 @@ if [[ -z "${conda_venv}" ]]; then
     export conda_env=ot
 fi
 
-if [ -e /dev/kfd ]; then
-	export PLATFORM_REQS=requirements-rocm.txt
-elif [ -x "$(command -v nvcc)" ]; then
+if [ -x "$(command -v nvcc)" ]; then
 	export PLATFORM_REQS=requirements-cuda.txt
+elif [ -e /dev/kfd ]; then
+	export PLATFORM_REQS=requirements-rocm.txt
 else
 	export PLATFORM_REQS=requirements-default.txt
 fi

--- a/linux-python-env.sh
+++ b/linux-python-env.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+source ./linux-env-vars.sh
+
+#additional arguments helpful if running into CUDA OOM error; default: false
+use_alloc_args=false
+
+if [ "$(uname)" = "Darwin" ]; then
+	export PYTORCH_ENABLE_MPS_FALLBACK=1
+fi
+
+if "$use_alloc_args"; then
+	export PYTORCH_CUDA_ALLOC_CONF=garbage_collection_threshold:0.6,max_split_size_mb:128
+fi
+
+if ! [ -x "$(command -v ${python_cmd})" ]; then
+	echo 'error: python not installed or found!'
+elif [ -x "$(command -v ${python_cmd})" ]; then
+	major=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
+	minor=$(${python_cmd} -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
+
+	#check major version of python
+	if [[ "$major" -eq "3" ]];
+		then
+			#check minor version of python
+			if [[ "$minor" -le "10" ]];
+				then
+					if ! [ -x "$(command -v conda)" ]; then
+						echo 'conda not found; python version correct; use native python'
+						if ! [ -d $python_venv ]; then
+							${python_cmd} -m venv $python_venv
+						fi
+						source $python_venv/bin/activate
+						if [[ -z "$VIRTUAL_ENV" ]]; then
+    							echo "warning: No VIRTUAL_ENV set. exiting."
+						else
+    							eval "$linux_cmd_python_venv"
+						fi
+					elif [ -x "$(command -v conda)" ]; then
+						#check for venv
+						if conda info --envs | grep -q ${conda_env}; 
+							then
+								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; $linux_cmd_conda_venv")
+							else 
+								conda create -y -n $conda_env python==3.10;
+								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; $linux_cmd_conda_venv")
+						fi
+					fi
+				else
+					echo 'error: wrong python version installed:'$major'.'$minor
+					echo 'OneTrainer requires the use of python 3.10, please refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
+					exit 1
+			fi
+		else
+			echo 'error: wrong python version installed:'$major'.'$minor
+			echo 'OneTrainer requires the use of python 3.10, either install python3 on your system or refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
+			exit 1
+	fi
+fi

--- a/start-ui.sh
+++ b/start-ui.sh
@@ -1,62 +1,8 @@
 #!/bin/bash
 
-#change the environment name for conda to use
-conda_env=ot
-#change the environment name for python to use (only needed if Anaconda3 or miniconda is not installed)
-python_venv=venv
-#additional arguments helpful if running into CUDA OOM error; default: false
-use_alloc_args=false
+source ./linux-env-vars.sh
 
-if [ "$(uname)" = "Darwin" ]; then
-	export PYTORCH_ENABLE_MPS_FALLBACK=1
-fi
+export linux_cmd_python_venv='${python_cmd} scripts/train_ui.py'
+export linux_cmd_conda_venv='${python_cmd} scripts/train_ui.py'
 
-if "$use_alloc_args"; then
-	export PYTORCH_CUDA_ALLOC_CONF=garbage_collection_threshold:0.6,max_split_size_mb:128
-fi
-
-if ! [ -x "$(command -v python)" ]; then
-	echo 'error: python not installed or found!'
-	break
-elif [ -x "$(command -v python)" ]; then
-	major=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
-	minor=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
-
-	#check major version of python
-	if [[ "$major" -eq "3" ]];
-		then
-			#check minor version of python
-			if [[ "$minor" -le "10" || "$minor" -le "11" ]];
-				then
-					if ! [ -x "$(command -v conda)" ]; then
-						echo 'conda not found; python version correct; use native python'
-						if ! [ -d $python_venv ]; then
-							python -m venv $python_venv
-						fi
-						source $python_venv/bin/activate
-						if [[ -z "$VIRTUAL_ENV" ]]; then
-    							echo "warning: No VIRTUAL_ENV set. exiting."
-						else
-							python scripts/train_ui.py
-						fi
-					elif [ -x "$(command -v conda)" ]; then
-						#check for venv
-						if conda info --envs | grep -q ${conda_env}; 
-							then
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; python scripts/train_ui.py")
-							else 
-								conda create -y -n $conda_env python==3.10;
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; python scripts/train_ui.py")
-						fi
-					fi
-				else
-					echo 'error: wrong python version installed:'$major'.'$minor
-					echo 'OneTrainer requires the use of python 3.10, please refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-					exit 1
-			fi
-		else
-			echo 'error: wrong python version installed:'$major'.'$minor
-			echo 'OneTrainer requires the use of python 3.10, either install python3 on your system or refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-			exit 1
-	fi
-fi
+/bin/bash ./linux-python-env.sh

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ source ./linux-env-vars.sh
 
 stored_platform_reqs=$(<linux-platform)
 
-export linux_cmd_python_venv = 'git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall'
-export linux_cmd_conda_venv = 'git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall)'
+export linux_cmd_python_venv='git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall'
+export linux_cmd_conda_venv='git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall)'
 
 /bin/bash ./linux-python-env.sh

--- a/update.sh
+++ b/update.sh
@@ -1,60 +1,8 @@
 #!/bin/bash
 
-#change the environment name for conda to use
-conda_env=ot
-#change the environment name for python to use (only needed if Anaconda3 or miniconda is not installed)
-python_venv=venv
+source ./linux-env-vars.sh
 
-if [ -e /dev/kfd ]; then
-	PLATFORM_REQS=requirements-rocm.txt
-elif [ -x "$(command -v nvcc)" ]; then
-	PLATFORM_REQS=requirements-cuda.txt
-else
-	PLATFORM_REQS=requirements-default.txt
-fi
+export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
+export linux_cmd_conda_venv = 'git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS" --force-reinstall)'
 
-if ! [ -x "$(command -v python)" ]; then
-	echo 'error: python not installed or found!'
-	break
-elif [ -x "$(command -v python)" ]; then
-	major=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major)')
-	minor=$(python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
-
-	#check major version of python
-	if [[ "$major" -eq "3" ]];
-		then
-			#check minor version of python
-			if [[ "$minor" -le "10" ]];
-				then
-					if ! [ -x "$(command -v conda)" ]; then
-						echo 'conda not found; python version correct; use native python'
-						git pull
-						if ! [ -d $python_venv ]; then
-							python -m venv $python_venv
-						fi
-						source $python_venv/bin/activate
-						if [[ -z "$VIRTUAL_ENV" ]]; then
-    							echo "warning: No VIRTUAL_ENV set. exiting."
-						else
-							pip install -r requirements-global.txt -r $PLATFORM_REQS
-						fi
-					elif [ -x "$(command -v conda)" ]; then
-						#check for venv
-						if conda info --envs | grep -q ${conda_env}; 
-							then
-								bash --init-file <(echo ". \"$HOME/.bashrc\"; conda activate $conda_env; git pull; python -m pip install -r requirements-global.txt -r $PLATFORM_REQS" --force-reinstall)
-							else 
-								echo 'run install.sh first'
-						fi
-					fi
-				else
-					echo 'error: wrong python version installed:'$major'.'$minor
-					echo 'OneTrainer requires the use of python 3.10, please refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-					break
-			fi
-		else
-			echo 'error: wrong python version installed:'$major'.'$minor
-			echo 'OneTrainer requires the use of python 3.10, either install python3 on your system or refer to the anaconda project to setup a virtual environment with that version. https://anaconda.org/anaconda/python'
-			break
-	fi
-fi
+/bin/bash ./linux-python-env.sh

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,9 @@
 
 source ./linux-env-vars.sh
 
-export linux_cmd_python_venv = 'git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS --force-reinstall'
-export linux_cmd_conda_venv = 'git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS" --force-reinstall)'
+stored_platform_reqs=$(<linux-platform)
+
+export linux_cmd_python_venv = 'git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall'
+export linux_cmd_conda_venv = 'git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall)'
 
 /bin/bash ./linux-python-env.sh

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 source ./linux-env-vars.sh
 
-export linux_cmd_python_venv = '${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS'
+export linux_cmd_python_venv = 'git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS --force-reinstall'
 export linux_cmd_conda_venv = 'git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $PLATFORM_REQS" --force-reinstall)'
 
 /bin/bash ./linux-python-env.sh

--- a/update.sh
+++ b/update.sh
@@ -2,9 +2,7 @@
 
 source ./linux-env-vars.sh
 
-stored_platform_reqs=$(<linux-platform)
-
-export linux_cmd_python_venv='git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall'
-export linux_cmd_conda_venv='git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $stored_platform_reqs --force-reinstall)'
+export linux_cmd_python_venv='git pull && ${python_cmd} -m pip install -r requirements-global.txt -r $(<linux-platform.txt) --force-reinstall'
+export linux_cmd_conda_venv='git pull; ${python_cmd} -m pip install -r requirements-global.txt -r $(<linux-platform.txt) --force-reinstall)'
 
 /bin/bash ./linux-python-env.sh


### PR DESCRIPTION
This commit aims to prevent code duplication. 

It  adds two new files, linux-env-vars.sh which houses the environment variables and linux-python-env which is the actual unified script. The existing scripts have been dumbed down to export the command which is exported & executed by  linux-python-env. (name may be misleading?)

There was the "issue" of someone patching one particular script but not the others, so the  scripts diverged in having said fixes or changes. 
I  tried to unify them as one script which basically uses export variables to then determine what command is to be used.

Aim is simplification of future modifications/enhancements/fixes which tunes in for each and every script (install/start-ui/update.

looking for feedback if this f.e. fragments  the scripts too much, or if it is a better readability in general. 

~~also it seems that apart from update.sh the commands for either python_venv or conda_venv are the same aswell, but the python version never issued a git pull, nor did a --force-reinstall - a possible bug.
If this is the case we can slim down the code further and simplify it.~~