### PR TITLE
fix Dockerfile to specify which registry to pull from

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Inspiration for setup @ https://dev.to/ordigital/nvidia-525-cuda-118-python-310-pytorch-gpu-docker-image-1l4a
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+FROM docker.io/nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 ENV PYTHONUNBUFFERED=1 
 


### PR DESCRIPTION
If this isn't specific, it can pull from any random registry instead. For example, Fedora machines have at least 3 matching container registries by default.

---

Notes:

- I don't know if the rest of the Dockerfile is still up-to-date. I decided not to use it.
- I also think that the installation of `nvidia-driver-525` inside the docker image looks very strange, since the whole point of NVIDIA's CUDA container images is that they have everything necessary inside the image already. I have made many containers based on NVIDIA's and never installed any specific driver inside them. They come with CUDA toolkit which in turn communicates with the latest NVIDIA driver on the host. That's the point. But hey, maybe I am wrong here.
- It also doesn't seem necessary to install any CUDA toolkit in the container anyway, since OneTrainer installs PyTorch, which in turn always installs `nvidia-cu*-cu*` packages from PyPi and uses those instead of the system's own CUDA Toolkit. PyTorch always installs the exact CUDA version it needs that way. Those packages literally provide the exact same `.so` library binaries as what you would get on the host by installing CUDA system packages.
- Furthermore, it doesn't pull in `libgl1` which OneTrainer's README claims is necessary on Ubuntu.
- So the dockerfile looks like it could be improved @dougbtv (added in https://github.com/Nerogar/OneTrainer/commit/64b8323712259852112316a550f9099ce5961fa7).
- But this new tweak will at least get rid of the confusion about which registry to pull NVIDIA's container from.