### PR TITLE
Use project-local Conda environments for easier management and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .python-version
 /.venv*
 /venv*
+/conda_env*
 /debug*
 /workspace*
 /models*

--- a/LAUNCH-SCRIPTS.md
+++ b/LAUNCH-SCRIPTS.md
@@ -15,11 +15,11 @@
 
 - `OT_CONDA_CMD`: Sets a custom Conda command or an absolute path to the binary (useful when it isn't in the user's `PATH`). If nothing is provided, we detect and use `CONDA_EXE` if available, which is a variable that's set by Conda itself and always points at the user's installed Conda binary.
 
-- `OT_CONDA_ENV`: Sets the name of the Conda environment. Defaults to `onetrainer`.
+- `OT_CONDA_ENV`: Sets the directory name (or an absolute/relative path) of the Conda environment. If a name or relative path is used, it will be relative to the OneTrainer directory. Defaults to `conda_env`.
 
 - `OT_PYTHON_CMD`: Sets the Host's Python executable. It's used for creating the Python Venvs. This can be used to force the usage of a specific Python version's binary (such as `python3.10`) whenever the host has multiple versions installed. However, it's *always* recommended to use Conda or Pyenv instead, rather than relying on the host's unreliable system-wide Python binaries (which might change or be removed with system updates), so we don't recommend changing this option unless you *really* know what you're doing. Defaults to `python`.
 
-- `OT_PYTHON_VENV`: Sets the name (or an absolute/relative path) of the Python Venv. If a name or relative path is used, it will be relative to the OneTrainer directory. Defaults to `venv`.
+- `OT_PYTHON_VENV`: Sets the directory name (or an absolute/relative path) of the Python Venv. If a name or relative path is used, it will be relative to the OneTrainer directory. Defaults to `venv`.
 
 - `OT_PREFER_VENV`: If set to `true`, Conda will be ignored even if it exists on the system, and Python Venv will be used instead. This ensures that people who use `pyenv` (to choose which Python version to run on the host) can easily set up their desired Python Venv environments. Defaults to `false`.
 


### PR DESCRIPTION
- We now default to installing Conda's environment in `conda_env` as a sub-directory of OneTrainer's project directory. This mirrors the behavior of our Python Venvs, and makes it much easier for users to remove the environment if they are uninstalling OneTrainer, since most users wouldn't know how to uninstall a system-wide Conda environment. This change also ensures that the environment will now be stored on the exact same disk as OneTrainer.

- The same flexibility as Python Venvs has been implemented, where you can now specify the absolute or relative path to an alternative Conda environment location via `OT_CONDA_ENV`. Paths with spaces are of course supported.

- All cleanup commands during manual Conda environment upgrades are now instructing the user about how to erase the locally installed environment, which is necessary whenever the environment's installed Python version no longer satisfies OneTrainer's requirements. We use a path resolver to ensure that they always remove the local environment directory via its **absolute** path, to avoid any risk of users erasing another environment by accident.

- During each fresh Conda environment creation, we look for the existence of the deprecated "ot" Conda system-wide environment, and then instruct the user about how to remove it if they want to free up the disk space. This is only displayed during fresh Conda environment creation, to avoid slowing down regular startups.

- The automatic display of all executed commands in the launcher scripts has also been improved to display properly shell-escaped arguments whenever they contain spaces, to ensure that every displayed command can **always** be manually executed as-is by the user.