### PR TITLE
added Skip Save interval before automatic saving starts

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -497,9 +497,9 @@ class GenericTrainer(BaseTrainer):
 
     def __needs_save(self, train_progress: TrainProgress):
         return self.single_action_elapsed(
-            "skip_save", self.config.skip_save, self.config.skip_save_unit, train_progress
+            "save_skip_first", self.config.save_skip_first, self.config.save_every_unit, train_progress
         ) and self.repeating_action_needed(
-            "save", self.config.save_after, self.config.save_after_unit, train_progress, start_at_zero=False
+            "save", self.config.save_every, self.config.save_every_unit, train_progress, start_at_zero=False
         )
 
     def __needs_gc(self, train_progress: TrainProgress):

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -496,7 +496,9 @@ class GenericTrainer(BaseTrainer):
         )
 
     def __needs_save(self, train_progress: TrainProgress):
-        return self.repeating_action_needed(
+        return self.single_action_elapsed(
+            "skip_save", self.config.skip_save, self.config.skip_save_unit, train_progress
+        ) and self.repeating_action_needed(
             "save", self.config.save_after, self.config.save_after_unit, train_progress, start_at_zero=False
         )
 

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -328,10 +328,15 @@ class TrainUI(ctk.CTk):
         # save now
         components.button(frame, 3, 3, "save now", self.save_now)
 
+        # skip save
+        components.label(frame, 4, 0, "Skip Save",
+                         tooltip="Start saving automatically after this interval has elapsed")
+        components.time_entry(frame, 4, 1, self.ui_state, "skip_save", "skip_save_unit")
+
         # save filename prefix
-        components.label(frame, 4, 0, "Save Filename Prefix",
+        components.label(frame, 5, 0, "Save Filename Prefix",
                          tooltip="The prefix for filenames used when saving the model during training")
-        components.entry(frame, 4, 1, self.ui_state, "save_filename_prefix")
+        components.entry(frame, 5, 1, self.ui_state, "save_filename_prefix")
 
         frame.pack(fill="both", expand=1)
         return frame

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -321,17 +321,17 @@ class TrainUI(ctk.CTk):
         components.switch(frame, 2, 1, self.ui_state, "backup_before_save")
 
         # save after
-        components.label(frame, 3, 0, "Save After",
+        components.label(frame, 3, 0, "Save Every",
                          tooltip="The interval used when automatically saving the model during training")
-        components.time_entry(frame, 3, 1, self.ui_state, "save_after", "save_after_unit")
+        components.time_entry(frame, 3, 1, self.ui_state, "save_every", "save_every_unit")
 
         # save now
         components.button(frame, 3, 3, "save now", self.save_now)
 
         # skip save
-        components.label(frame, 4, 0, "Skip Save",
+        components.label(frame, 4, 0, "Skip First",
                          tooltip="Start saving automatically after this interval has elapsed")
-        components.time_entry(frame, 4, 1, self.ui_state, "skip_save", "skip_save_unit")
+        components.entry(frame, 4, 1, self.ui_state, "save_skip_first", width=50, sticky="nw")
 
         # save filename prefix
         components.label(frame, 5, 0, "Save Filename Prefix",

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -388,6 +388,8 @@ class TrainConfig(BaseConfig):
     backup_before_save: bool
     save_after: float
     save_after_unit: TimeUnit
+    skip_save: float
+    skip_save_unit: TimeUnit
     save_filename_prefix: str
 
     def __init__(self, data: list[(str, Any, type, bool)]):
@@ -863,6 +865,8 @@ class TrainConfig(BaseConfig):
         data.append(("backup_before_save", True, bool, False))
         data.append(("save_after", 0, int, False))
         data.append(("save_after_unit", TimeUnit.NEVER, TimeUnit, False))
+        data.append(("skip_save", 0, int, False))
+        data.append(("skip_save_unit", TimeUnit.ALWAYS, TimeUnit, False))
         data.append(("save_filename_prefix", "", str, False))
 
         return TrainConfig(data)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -386,22 +386,22 @@ class TrainConfig(BaseConfig):
     rolling_backup: bool
     rolling_backup_count: int
     backup_before_save: bool
-    save_after: float
-    save_after_unit: TimeUnit
-    skip_save: float
-    skip_save_unit: TimeUnit
+    save_every: float
+    save_every_unit: TimeUnit
+    save_skip_first: float
     save_filename_prefix: str
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super(TrainConfig, self).__init__(
             data,
-            config_version=5,
+            config_version=6,
             config_migrations={
                 0: self.__migration_0,
                 1: self.__migration_1,
                 2: self.__migration_2,
                 3: self.__migration_3,
                 4: self.__migration_4,
+                5: self.__migration_5,
             }
         )
 
@@ -554,6 +554,14 @@ class TrainConfig(BaseConfig):
             migrated_data["gradient_checkpointing"] = GradientCheckpointingMethod.ON
         else:
             migrated_data["gradient_checkpointing"] = GradientCheckpointingMethod.OFF
+
+        return migrated_data
+
+    def __migration_5(self, data: dict) -> dict:
+        migrated_data = data.copy()
+
+        migrated_data["save_every"] = migrated_data.pop("save_after")
+        migrated_data["save_every_unit"] = migrated_data.pop("save_after_unit")
 
         return migrated_data
 
@@ -863,10 +871,9 @@ class TrainConfig(BaseConfig):
         data.append(("rolling_backup", False, bool, False))
         data.append(("rolling_backup_count", 3, int, False))
         data.append(("backup_before_save", True, bool, False))
-        data.append(("save_after", 0, int, False))
-        data.append(("save_after_unit", TimeUnit.NEVER, TimeUnit, False))
-        data.append(("skip_save", 0, int, False))
-        data.append(("skip_save_unit", TimeUnit.ALWAYS, TimeUnit, False))
+        data.append(("save_every", 0, int, False))
+        data.append(("save_every_unit", TimeUnit.NEVER, TimeUnit, False))
+        data.append(("save_skip_first", 0, int, False))
         data.append(("save_filename_prefix", "", str, False))
 
         return TrainConfig(data)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -386,9 +386,9 @@ class TrainConfig(BaseConfig):
     rolling_backup: bool
     rolling_backup_count: int
     backup_before_save: bool
-    save_every: float
+    save_every: int
     save_every_unit: TimeUnit
-    save_skip_first: float
+    save_skip_first: int
     save_filename_prefix: str
 
     def __init__(self, data: list[(str, Any, type, bool)]):

--- a/modules/util/ui/components.py
+++ b/modules/util/ui/components.py
@@ -44,14 +44,16 @@ def entry(
         var_name: str,
         command: Callable[[], None] = None,
         tooltip: str = "",
-        wide_tooltip: bool = False
+        wide_tooltip: bool = False,
+        width: int = 140,
+        sticky: str = "new",
 ):
     var = ui_state.get_var(var_name)
     if command:
         trace_id = ui_state.add_var_trace(var_name, command)
 
-    component = ctk.CTkEntry(master, textvariable=var)
-    component.grid(row=row, column=column, padx=PAD, pady=PAD, sticky="new")
+    component = ctk.CTkEntry(master, textvariable=var,width=width)
+    component.grid(row=row, column=column, padx=PAD, pady=PAD, sticky=sticky)
 
     def create_destroy(component):
         orig_destroy = component.destroy
@@ -91,8 +93,7 @@ def file_entry(
 
     frame.grid_columnconfigure(0, weight=1)
 
-    entry_component = ctk.CTkEntry(frame, textvariable=ui_state.get_var(var_name))
-    entry_component.grid(row=0, column=0, padx=(PAD, PAD), pady=PAD, sticky="new")
+    entry_component = entry(frame,row=0, column=0, ui_state=ui_state, var_name=var_name)
 
     def __open_dialog():
         filetypes = [
@@ -124,22 +125,6 @@ def file_entry(
             if command:
                 command(file_path)
 
-    # temporary fix until https://github.com/TomSchimansky/CustomTkinter/pull/2077 is merged
-    def create_destroy(component):
-        orig_destroy = component.destroy
-
-        def destroy(self):
-            if self._textvariable_callback_name:
-                self._textvariable.trace_remove("write", self._textvariable_callback_name)
-                self._textvariable_callback_name = ""
-
-            orig_destroy()
-
-        return destroy
-
-    destroy = create_destroy(entry_component)
-    entry_component.destroy = lambda: destroy(entry_component)
-
     button_component = ctk.CTkButton(frame, text="...", width=40, command=__open_dialog)
     button_component.grid(row=0, column=1, padx=(0, PAD), pady=PAD, sticky="nsew")
 
@@ -152,8 +137,7 @@ def dir_entry(master, row, column, ui_state: UIState, var_name: str, command: Ca
 
     frame.grid_columnconfigure(0, weight=1)
 
-    entry_component = ctk.CTkEntry(frame, textvariable=ui_state.get_var(var_name))
-    entry_component.grid(row=0, column=0, padx=(PAD, PAD), pady=PAD, sticky="new")
+    entry_component = entry(frame, row=0, column=0, ui_state=ui_state, var_name=var_name)
 
     def __open_dialog():
         dir_path = filedialog.askdirectory()
@@ -163,22 +147,6 @@ def dir_entry(master, row, column, ui_state: UIState, var_name: str, command: Ca
 
             if command:
                 command(dir_path)
-
-    # temporary fix until https://github.com/TomSchimansky/CustomTkinter/pull/2077 is merged
-    def create_destroy(component):
-        orig_destroy = component.destroy
-
-        def destroy(self):
-            if self._textvariable_callback_name:
-                self._textvariable.trace_remove("write", self._textvariable_callback_name)
-                self._textvariable_callback_name = ""
-
-            orig_destroy()
-
-        return destroy
-
-    destroy = create_destroy(entry_component)
-    entry_component.destroy = lambda: destroy(entry_component)
 
     button_component = ctk.CTkButton(frame, text="...", width=40, command=__open_dialog)
     button_component.grid(row=0, column=1, padx=(0, PAD), pady=PAD, sticky="nsew")
@@ -193,24 +161,7 @@ def time_entry(master, row, column, ui_state: UIState, var_name: str, unit_var_n
     frame.grid_columnconfigure(0, weight=0)
     frame.grid_columnconfigure(1, weight=1)
 
-    entry_component = ctk.CTkEntry(frame, textvariable=ui_state.get_var(var_name), width=50)
-    entry_component.grid(row=0, column=0, padx=PAD, pady=PAD, sticky="new")
-
-    # temporary fix until https://github.com/TomSchimansky/CustomTkinter/pull/2077 is merged
-    def create_destroy(component):
-        orig_destroy = component.destroy
-
-        def destroy(self):
-            if self._textvariable_callback_name:
-                self._textvariable.trace_remove("write", self._textvariable_callback_name)
-                self._textvariable_callback_name = ""
-
-            orig_destroy()
-
-        return destroy
-
-    destroy = create_destroy(entry_component)
-    entry_component.destroy = lambda: destroy(entry_component)
+    entry_component = entry(frame, row=0, column=0, ui_state=ui_state, var_name=var_name, width=50)
 
     values = [str(x) for x in list(TimeUnit)]
     if not supports_time_units:


### PR DESCRIPTION
Automatic saving is used to have multiple checkpoints after training, so you can choose the best one.
However, you know in advance that the first x000 steps will not be the best one.
This PR adds a function to skip saving in those first x000 steps.


This example saves every 500 steps, but not within the first 3000:

![grafik](https://github.com/user-attachments/assets/57167ff3-195b-4847-92d0-13a3664b9d97)

Especially useful for full finetunes with large file sizes. The first few checkpoints waste both disk space and the time it takes to save.