### PR TITLE
Implement mouse-wheel support for Mac and Linux

### DIFF
--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -16,6 +16,7 @@ from modules.ui.GenerateMasksWindow import GenerateMasksWindow
 from modules.util import path_util
 from modules.util.torch_util import default_device
 from modules.util.ui import components
+from modules.util.ui.ui_utils import bind_mousewheel
 from modules.util.ui.UIState import UIState
 
 import torch
@@ -195,7 +196,7 @@ Mouse wheel: increase or decrease brush size"""
         self.image_label.bind("<Motion>", self.edit_mask)
         self.image_label.bind("<Button-1>", self.edit_mask)
         self.image_label.bind("<Button-3>", self.edit_mask)
-        self.image_label.bind("<MouseWheel>", self.draw_mask_radius)
+        bind_mousewheel(self.image_label, {self.image_label.children["!label"]}, self.draw_mask_radius)
 
         # prompt
         self.prompt_var = ctk.StringVar()
@@ -351,12 +352,10 @@ Mouse wheel: increase or decrease brush size"""
         else:
             self.image.configure(light_image=self.pil_image, size=self.pil_image.size)
 
-    def draw_mask_radius(self, event):
-        if event.widget != self.image_label.children["!label"]:
-            return
-
-        delta = 1.0 + (-np.sign(event.delta) * 0.05)
-        self.mask_draw_radius *= delta
+    def draw_mask_radius(self, delta, raw_event):
+        # Wheel up = Increase radius. Wheel down = Decrease radius.
+        multiplier = 1.0 + (delta * 0.05)
+        self.mask_draw_radius = max(0.01, self.mask_draw_radius * multiplier)
 
     def edit_mask(self, event):
         if not self.enable_mask_editing_var.get():

--- a/modules/util/ui/ui_utils.py
+++ b/modules/util/ui/ui_utils.py
@@ -1,0 +1,41 @@
+from collections.abc import Callable
+from tkinter import EventType
+from typing import Any, Optional
+import customtkinter as ctk
+import sys
+
+
+def bind_mousewheel(
+    widget: Any, whitelist: Optional[set[Any]], callback: Callable[[int, Any], None]
+) -> None:
+    assert whitelist is None or isinstance(whitelist, set)
+
+    is_mac = sys.platform == "darwin"
+
+    def process_mousewheel(raw_event):
+        # If whitelist was provided, only respond to events on allowed widgets.
+        if whitelist is not None and raw_event.widget not in whitelist:
+            return
+
+        # Cross-platform mouse scroll handler.
+        # SEE: Section "54.6" of https://tkdocs.com/shipman/tkinter.pdf, which
+        # describes the `.delta` and `.num` property behaviors on each platform.
+        if raw_event.type == EventType.MouseWheel:  # Windows and Mac.
+            # Positive sign means scroll up, negative sign means scroll down.
+            # Windows uses a multiple of 120. Macs use the raw number of steps.
+            delta = raw_event.delta if is_mac else int(raw_event.delta / 120)
+        elif raw_event.type == EventType.ButtonPress:  # Linux.
+            # Button 4 means scroll up. Button 5 means scroll down.
+            # NOTE: Tk only supports binding mouse buttons 1, 2 and 3. The 4/5
+            # values are ONLY used for indicating mousewheel scrolling.
+            delta = 1 if raw_event.num == 4 else -1
+        else:
+            raise Exception(f"unhandled event type: {raw_event.type.name}")
+
+        # We provide the raw event too, if they want to analyze it further.
+        callback(delta, raw_event)
+
+    widget.bind("<MouseWheel>", process_mousewheel)
+    if sys.platform == "linux":
+        widget.bind("<Button-4>", process_mousewheel)
+        widget.bind("<Button-5>", process_mousewheel)


### PR DESCRIPTION
- Adds a unified helper function which binds the mouse-wheel correctly on every platform, and processes their platform-specific deltas into a unified format; "steps". The value is positive when scrolling up, and negative when scrolling down. And it now supports larger steps/deltas whenever the OS sends larger mouse events.

- The dataset mask editor's mouse-wheel radius adjustment now works on all platforms.

- Improved the mask radius calculation to ensure that it can never become smaller than 0.01, and made it behave like standard photo editors where "wheel up = zoom in/enlarge something, wheel down = zoom out/shrink something".

---

Tested:

- [x] Windows
- [x] Linux
- [x] Mac