### PR TITLE
Support very small brushes in the mask editor

### DIFF
--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -355,7 +355,7 @@ Mouse wheel: increase or decrease brush size"""
     def draw_mask_radius(self, delta, raw_event):
         # Wheel up = Increase radius. Wheel down = Decrease radius.
         multiplier = 1.0 + (delta * 0.05)
-        self.mask_draw_radius = max(0.01, self.mask_draw_radius * multiplier)
+        self.mask_draw_radius = max(0.0025, self.mask_draw_radius * multiplier)
 
     def edit_mask(self, event):
         if not self.enable_mask_editing_var.get():

--- a/modules/util/ui/ui_utils.py
+++ b/modules/util/ui/ui_utils.py
@@ -1,7 +1,7 @@
 import sys
 from collections.abc import Callable
 from tkinter import EventType
-from typing import Any, Optional
+from typing import Any
 
 
 def bind_mousewheel(


### PR DESCRIPTION
The recent refactor of mouse-wheel handling inadvertently made the lowest mask brush size a bit too big. This extends the lower range to allow very small brushes to be used.

Also fixes a small leftover import in related files.