### PR TITLE
Support slice_p in Prodigy optimizer

### DIFF
--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -142,7 +142,7 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
             'r': {'title': 'R', 'tooltip': 'EMA factor.', 'type': 'float'},
             'adanorm': {'title': 'AdaNorm', 'tooltip': 'Whether to use the AdaNorm variant', 'type': 'bool'},
             'adam_debias': {'title': 'Adam Debias', 'tooltip': 'Only correct the denominator to avoid inflating step sizes early in training.', 'type': 'bool'},
-
+            'slice_p': {'title': 'Slice parameters', 'tooltip': 'Reduce memory usage by calculating LR adaptation statistics on only every pth entry of each tensor. For values greater than 1 this an an approximation to standard Prodigy. Values ~11 are reasonable.', 'type': 'int'},
         }
         # @formatter:on
 

--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -32,7 +32,7 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
         self.protocol("WM_DELETE_WINDOW", self.on_window_close)
 
         self.title("Optimizer Settings")
-        self.geometry("800x400")
+        self.geometry("800x500")
         self.resizable(True, True)
         self.wait_visibility()
         self.grab_set()

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -89,6 +89,7 @@ class TrainOptimizerConfig(BaseConfig):
     r: float
     adanorm: bool
     adam_debias: bool
+    slice_p: int
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
@@ -156,6 +157,7 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("r", None, float, True))
         data.append(("adanorm", False, bool, False))
         data.append(("adam_debias", False, bool, False))
+        data.append(("slice_p", None, int, True))
 
         return TrainOptimizerConfig(data)
 

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -829,6 +829,7 @@ def create_optimizer(
                 d_coef=optimizer_config.d_coef if optimizer_config.d_coef is not None else 1.0,
                 growth_rate=optimizer_config.growth_rate if optimizer_config.growth_rate is not None else float('inf'),
                 fsdp_in_use=optimizer_config.fsdp_in_use if optimizer_config.fsdp_in_use is not None else False,
+                slice_p=optimizer_config.slice_p if optimizer_config.slice_p is not None else 1,
             )
 
         # ADAFactor Optimizer

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -260,6 +260,7 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "d_coef": 1.0,
         "growth_rate": float('inf'),
         "fsdp_in_use": False,
+        "slice_p": 11,
     },
     Optimizer.DADAPT_ADA_GRAD: {
         "momentum": 0,

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -31,7 +31,7 @@ open-clip-torch==2.28.0
 # optimizers
 dadaptation==3.2 # dadaptation optimizers
 lion-pytorch==0.2.2 # lion optimizer
-prodigyopt==1.0 # prodigy optimizer
+prodigyopt==1.1.1 # prodigy optimizer
 schedulefree==1.3.0 # schedule-free optimizers
 pytorch_optimizer==3.3.0 # pytorch optimizers
 


### PR DESCRIPTION
Support new hyperparameter in Prodigy optimizer that reduces vram usage by about half.

Wait with merge until the prodigyopt package is updated in PyPi.

In this PR I've chosen to enable it by default, while the package maintainers have chosen to disable it by default in order to not change the behaviour.

This is debatable, but I think we can be a bit less careful: We haven't found a case yet in which Prodigy performs worse when this is enabled. In my own tests, in tests by a team of testers on Discord, and in original experiments of the Prodigy paper, repeated by the original authors. Details here: https://github.com/konstmish/prodigy/pull/22

I can disable it by default though if you prefer
