### PR TITLE
Warmup steps allows values <1 as percentage of total

### DIFF
--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -186,7 +186,7 @@ class TrainingTab:
 
         # learning rate warmup steps
         components.label(frame, 3, 0, "Learning Rate Warmup Steps",
-                         tooltip="The number of steps it takes to gradually increase the learning rate from 0 to the specified learning rate")
+                         tooltip="The number of steps it takes to gradually increase the learning rate from 0 to the specified learning rate. Values >1 are interpeted as a fixed number of steps, values <=1 are intepreted as a percentage of the total training steps (ex. 0.2 = 20% of the total step count)")
         components.entry(frame, 3, 1, self.ui_state, "learning_rate_warmup_steps")
 
         # learning rate cycles

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -264,7 +264,7 @@ class TrainConfig(BaseConfig):
     # of restrictions with ConfigList.
     scheduler_params: list[dict[str, str]]
     learning_rate: float
-    learning_rate_warmup_steps: int
+    learning_rate_warmup_steps: float
     learning_rate_cycles: float
     epochs: int
     batch_size: int
@@ -711,7 +711,7 @@ class TrainConfig(BaseConfig):
         data.append(("custom_learning_rate_scheduler", None, str, True))
         data.append(("scheduler_params", [], list[dict[str, str]], True))
         data.append(("learning_rate", 3e-6, float, False))
-        data.append(("learning_rate_warmup_steps", 200, int, False))
+        data.append(("learning_rate_warmup_steps", 200, float, False))
         data.append(("learning_rate_cycles", 1, int, False))
         data.append(("epochs", 100, int, False))
         data.append(("batch_size", 1, int, False))

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -1003,7 +1003,7 @@ def create_lr_scheduler(
         config: TrainConfig,
         optimizer: torch.optim.Optimizer,
         learning_rate_scheduler: LearningRateScheduler,
-        warmup_steps: int,
+        warmup_steps: float,
         num_cycles: float,
         num_epochs: int,
         batch_size: int,
@@ -1013,7 +1013,14 @@ def create_lr_scheduler(
 ) -> LRScheduler:
     steps_per_epoch = approximate_epoch_length
     total_steps = int(steps_per_epoch * num_epochs / gradient_accumulation_steps)
-    warmup_steps = int(warmup_steps / gradient_accumulation_steps)
+
+    if warmup_steps > 1:   #values > 1 are literal step count
+        warmup_steps = int(warmup_steps / gradient_accumulation_steps)
+    elif 0 < warmup_steps <= 1:  #values between 0-1 are treated as percentage
+        warmup_steps = int(warmup_steps * total_steps)
+    else:   #catch any invalid inputs or negative values
+        warmup_steps = 0
+
     scheduler_steps = total_steps - warmup_steps
 
     # Force schedule-free algorithms to constant schedule.


### PR DESCRIPTION
Changes "warmup steps" parameter from int to float. For input values >1 it behaves the same way as it did previously, warmup steps / gradient steps. For values between 0-1, it changes to warmup steps * total steps (total steps already compensates for gradient accumulation). Any other values will be set to zero. Also modified mouseover text to reflect that change.

Some examples of behavior, tested with total steps 100. Also verified warmup behavior correctly works for different gradient accumulation values, though I did come across an issue related to changing that value while training is running (see issue #557):
- Warmup set to 50 = 50 steps of warmup, 50 steps of scheduler
- Warmup set to 0.4 = 40 steps of warmup, 60 steps of scheduler
- Warmup set to -0.3 = 0 steps of warmup, 100 steps of scheduler
- Warmup set to -20 = 0 steps of warmup, 100 steps of scheduler
- Warmup set to 1 = 100 steps of warmup, 0 steps of scheduler