### PR TITLE
update.bat: update pip before the requirements

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -23,7 +23,8 @@ set PYTHON="%VENV_DIR%\Scripts\python.exe"
 
 :install_dependencies
 echo installing dependencies
-%PYTHON% -m pip install -r requirements.txt --upgrade-strategy eager
+%PYTHON% -m pip install --upgrade --upgrade-strategy eager pip setuptools
+%PYTHON% -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
 
 :end_success
 echo.


### PR DESCRIPTION
Certain requirements can complain if pip or setuptools are outdated. Updating pip and setuptools first will avoid that risk.

I've personally seen a OneTrainer dependency fail to install when setuptools was outdated. It's used when installing dependencies that build themselves from source.

Having the latest pip also avoids some issues since they frequently fix bugs. I've seen dependencies that couldn't resolve until pip was updated.

Those tools (pip and setuptools) must be installed in a separate step before the requirements.txt, to take effect.

Added `--upgrade` flag too, which I am pretty sure needs to be there (since `--upgrade-strategy` is a modifier for the `--upgrade` mode).

This now matches the Linux commands:

https://github.com/Nerogar/OneTrainer/blob/b5699f51c070c15c9aac340d5967fd6fa8f855f5/lib.include.sh#L335-L336