### PR TITLE
Attempt to fix alignprop temp device passing

### DIFF
--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -354,7 +354,7 @@ class BaseFluxSetup(
                 # negative_added_cond_kwargs = {"text_embeds": negative_pooled_text_encoder_2_output,
                 #                               "time_ids": add_time_ids}
 
-                # checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, self.temp_device)
+                # checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, ["temp_device"])
 
                 # for step in range(config.align_prop_steps):
                 #     timestep = model.noise_scheduler.timesteps[step] \

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -254,7 +254,7 @@ class BasePixArtAlphaSetup(
 
                 truncate_timestep_index = config.align_prop_steps - rand.randint(timestep_low, timestep_high)
 
-                checkpointed_transformer = create_checkpointed_forward(model.transformer, self.train_device, self.temp_device)
+                checkpointed_transformer = create_checkpointed_forward(model.transformer, self.train_device, ["temp_device"])
 
                 for step in range(config.align_prop_steps):
                     timestep = model.noise_scheduler.timesteps[step] \

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -415,7 +415,7 @@ class BaseStableDiffusion3Setup(
                 # negative_added_cond_kwargs = {"text_embeds": negative_pooled_text_encoder_2_output,
                 #                               "time_ids": add_time_ids}
 
-                # checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, self.temp_device)
+                # checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, ["temp_device"])
 
                 # for step in range(config.align_prop_steps):
                 #     timestep = model.noise_scheduler.timesteps[step] \

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -217,7 +217,7 @@ class BaseStableDiffusionSetup(
                             1.0 - config.align_prop_truncate_steps))
                 truncate_timestep_index = config.align_prop_steps - rand.randint(timestep_low, timestep_high)
 
-                checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, self.temp_device)
+                checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, ["temp_device"])
 
                 for step in range(config.align_prop_steps):
                     timestep = model.noise_scheduler.timesteps[step] \

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -309,7 +309,7 @@ class BaseStableDiffusionXLSetup(
                 negative_added_cond_kwargs = {"text_embeds": negative_pooled_text_encoder_2_output,
                                               "time_ids": add_time_ids}
 
-                checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, self.temp_device)
+                checkpointed_unet = create_checkpointed_forward(model.unet, self.train_device, ["temp_device"])
 
                 for step in range(config.align_prop_steps):
                     timestep = model.noise_scheduler.timesteps[step] \


### PR DESCRIPTION
I tried unsuccessfully to use AlignProp with SD15. `create_checkpointed_forward` expects  `include_from_offload_param_names: list[str]` as it's second argument, however the call points seem to be passing a raw Torch device there. It failed trying to index the Torch device as a list.

I'm not familiar with the code so I'm not sure if this is the correct fix, however it did appear to fix AlignProp for SD15 LoRA training. Only tested with SD15 and AlignProp but it looks like the code is about the same for other model types.