### PR TITLE
Provide wrapper scripts to start tensorboard manually

### DIFF
--- a/start-tb.bat
+++ b/start-tb.bat
@@ -1,0 +1,22 @@
+@echo off
+
+if not defined PYTHON (set PYTHON=python)
+if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
+
+:check_venv
+dir "%VENV_DIR%" > NUL 2> NUL
+if %ERRORLEVEL% == 0 goto :activate_venv
+echo venv not found, please run install.bat first
+goto :end
+
+:activate_venv
+echo activating venv %VENV_DIR%
+set PYTHON="%VENV_DIR%\Scripts\python.exe"
+if defined PROFILE (set PYTHON=%PYTHON% -m scalene --off --cpu --gpu --profile-all --no-browser)
+echo Using Python %PYTHON%
+
+:launch
+%VENV_DIR%/Scripts/tensorboard --logdir=workspace/run/tensorboard --reload_interval=1
+
+:end
+pause

--- a/start-tb.sh
+++ b/start-tb.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "${BASH_SOURCE[0]%/*}/lib.include.sh"
+
+prepare_runtime_environment
+
+tensorboard --logdir=workspace/run/tensorboard --reload_interval=1 "$@"


### PR DESCRIPTION
* Provide a convenient way to run tensorboard independent of OneTrainer being active or not. The bat and shell scripts are just derivatives of start-ui.bat and start-ui.sh respectively.