### PR TITLE
GenericTrainer: Fix inconsistent output

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -410,7 +410,7 @@ class GenericTrainer(BaseTrainer):
         if os.path.isfile(self.config.sample_definition_file_name):
             shutil.copy2(self.config.sample_definition_file_name, samples_path)
 
-    def backup(self, train_progress: TrainProgress):
+    def backup(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
         torch_gc()
 
         self.callbacks.on_update_status("creating backup")
@@ -424,7 +424,8 @@ class GenericTrainer(BaseTrainer):
             self.model.optimizer.eval()
 
         try:
-            print("Creating Backup " + backup_path)
+            if print_msg:
+                print_cb("Creating Backup " + backup_path)
 
             self.model_saver.save(
                 self.model,
@@ -456,7 +457,7 @@ class GenericTrainer(BaseTrainer):
 
         torch_gc()
 
-    def save(self, train_progress: TrainProgress):
+    def save(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
         torch_gc()
 
         self.callbacks.on_update_status("saving")
@@ -466,7 +467,8 @@ class GenericTrainer(BaseTrainer):
             "save",
             f"{self.config.save_filename_prefix}{get_string_timestamp()}-save-{train_progress.filename_string()}{self.config.output_model_format.file_extension()}"
         )
-        print("Saving " + save_path)
+        if print_msg:
+            print_cb("Saving " + save_path)
 
         try:
             if self.model.ema:
@@ -657,12 +659,12 @@ class GenericTrainer(BaseTrainer):
 
                     if self.commands.get_and_reset_backup_command():
                         self.model.to(self.temp_device)
-                        self.backup(train_progress)
+                        self.backup(train_progress, True, step_tqdm.write)
                         transferred_to_temp_device = True
 
                     if self.commands.get_and_reset_save_command():
                         self.model.to(self.temp_device)
-                        self.save(train_progress)
+                        self.save(train_progress, True, step_tqdm.write)
                         transferred_to_temp_device = True
 
                     if transferred_to_temp_device:


### PR DESCRIPTION
    * backup, save: Take a callback function to handle emitting output.
      This allows things like tqdm.write to be passed in. Previously
      with print being used it would emit output like "Creating backup"
      at the end of the tqdm bar and then continue to the next line,
      munging/overlapping output. Depending on how often one creates
      backups or saves, it can result in the epoch line being clobbered
      every single cycle and/or a portion of it being emitted into
      scrollback repeatedly.
