### PR TITLE
Sorted presets

### DIFF
--- a/modules/ui/TopBar.py
+++ b/modules/ui/TopBar.py
@@ -142,7 +142,7 @@ class TopBar:
 
     def __load_available_config_names(self):
         if os.path.isdir(self.dir):
-            for path in os.listdir(self.dir):
+            for path in sorted(os.listdir(self.dir)):
                 if path != "#.json":
                     path = path_util.canonical_join(self.dir, path)
                     if path.endswith(".json") and os.path.isfile(path):


### PR DESCRIPTION
As Python [os.listdir()](https://docs.python.org/3/library/os.html#os.listdir) returns the list in arbitrary order UI preset list is in random order (on Linux ext4).

See #437 for screenshots.
