### PR TITLE
Add wiki button to the Top Bar of the UI

### DIFF
--- a/modules/ui/TopBar.py
+++ b/modules/ui/TopBar.py
@@ -1,6 +1,7 @@
 import json
 import os
 import traceback
+import webbrowser
 from collections.abc import Callable
 
 from modules.util import path_util
@@ -59,18 +60,21 @@ class TopBar:
         # TODO
         # components.icon_button(self.frame, 0, 2, "-", self.__remove_config)
 
+        # Wiki button
+        components.button(self.frame, 0, 4, "Wiki", self.open_wiki)
+
         # save button
         components.button(self.frame, 0, 3, "save current config", self.__save_config,
                           tooltip="Save the current configuration in a custom preset")
 
         # padding
-        self.frame.grid_columnconfigure(4, weight=1)
+        self.frame.grid_columnconfigure(5, weight=1)
 
         # model type
         components.options_kv(
             master=self.frame,
             row=0,
-            column=5,
+            column=6,
             values=[
                 ("Stable Diffusion 1.5", ModelType.STABLE_DIFFUSION_15),
                 ("Stable Diffusion 1.5 Inpainting", ModelType.STABLE_DIFFUSION_15_INPAINTING),
@@ -86,7 +90,6 @@ class TopBar:
                 ("PixArt Alpha", ModelType.PIXART_ALPHA),
                 ("PixArt Sigma", ModelType.PIXART_SIGMA),
                 ("Flux Dev", ModelType.FLUX_DEV_1),
-                ("Flux Fill Dev", ModelType.FLUX_FILL_DEV_1),
             ],
             ui_state=self.ui_state,
             var_name="model_type",
@@ -121,7 +124,7 @@ class TopBar:
         self.training_method = components.options_kv(
             master=self.frame,
             row=0,
-            column=6,
+            column=7,
             values=values,
             ui_state=self.ui_state,
             var_name="training_method",
@@ -159,6 +162,9 @@ class TopBar:
 
         return path
 
+    def open_wiki(self):
+        webbrowser.open("https://github.com/Nerogar/OneTrainer/wiki", new=0, autoraise=False)
+        
     def __save_new_config(self, name):
         path = self.__save_to_file(name)
 

--- a/modules/ui/TopBar.py
+++ b/modules/ui/TopBar.py
@@ -90,6 +90,7 @@ class TopBar:
                 ("PixArt Alpha", ModelType.PIXART_ALPHA),
                 ("PixArt Sigma", ModelType.PIXART_SIGMA),
                 ("Flux Dev", ModelType.FLUX_DEV_1),
+                ("Flux Fill Dev", ModelType.FLUX_FILL_DEV_1),
             ],
             ui_state=self.ui_state,
             var_name="model_type",


### PR DESCRIPTION
Adds a button to be able to quickly go to the wiki of OneTrainer.
Adds webbrowser to topbay.py and moves the columns 1 to the right for the model and training type.