### PR TITLE
Fix SDXL v-prediction training

### DIFF
--- a/modules/model/StableDiffusionXLModel.py
+++ b/modules/model/StableDiffusionXLModel.py
@@ -163,10 +163,12 @@ class StableDiffusionXLModel(BaseModel):
     def force_v_prediction(self):
         self.noise_scheduler.config.prediction_type = 'v_prediction'
         self.sd_config['model']['params']['parameterization'] = 'v'
+        self.model_spec.prediction_type = 'v'
 
     def force_epsilon_prediction(self):
         self.noise_scheduler.config.prediction_type = 'epsilon'
         self.sd_config['model']['params']['parameterization'] = 'epsilon'
+        self.model_spec.prediction_type = 'epsilon'
 
     def rescale_noise_scheduler_to_zero_terminal_snr(self):
         rescale_noise_scheduler_to_zero_terminal_snr(self.noise_scheduler)

--- a/modules/model/StableDiffusionXLModel.py
+++ b/modules/model/StableDiffusionXLModel.py
@@ -5,6 +5,9 @@ from modules.model.BaseModel import BaseModel, BaseModelEmbedding
 from modules.model.util.clip_util import encode_clip
 from modules.module.AdditionalEmbeddingWrapper import AdditionalEmbeddingWrapper
 from modules.module.LoRAModule import LoRAModuleWrapper
+from modules.util.convert.rescale_noise_scheduler_to_zero_terminal_snr import (
+    rescale_noise_scheduler_to_zero_terminal_snr,
+)
 from modules.util.enum.DataType import DataType
 from modules.util.enum.ModelType import ModelType
 
@@ -156,6 +159,17 @@ class StableDiffusionXLModel(BaseModel):
             unet=self.unet,
             scheduler=self.noise_scheduler,
         )
+
+    def force_v_prediction(self):
+        self.noise_scheduler.config.prediction_type = 'v_prediction'
+        self.sd_config['model']['params']['parameterization'] = 'v'
+
+    def force_epsilon_prediction(self):
+        self.noise_scheduler.config.prediction_type = 'epsilon'
+        self.sd_config['model']['params']['parameterization'] = 'epsilon'
+
+    def rescale_noise_scheduler_to_zero_terminal_snr(self):
+        rescale_noise_scheduler_to_zero_terminal_snr(self.noise_scheduler)
 
     def add_embeddings_to_prompt(self, prompt: str) -> str:
         return self._add_embeddings_to_prompt(self.additional_embeddings, self.embedding, prompt)

--- a/modules/modelSetup/StableDiffusionXLEmbeddingSetup.py
+++ b/modules/modelSetup/StableDiffusionXLEmbeddingSetup.py
@@ -78,6 +78,10 @@ class StableDiffusionXLEmbeddingSetup(
         model.text_encoder_1.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
         model.text_encoder_2.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
 
+        if config.rescale_noise_scheduler_to_zero_terminal_snr:
+            model.rescale_noise_scheduler_to_zero_terminal_snr()
+            model.force_v_prediction()
+
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_1)
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_2)
         self._setup_additional_embeddings(model, config)

--- a/modules/modelSetup/StableDiffusionXLFineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusionXLFineTuneSetup.py
@@ -110,6 +110,14 @@ class StableDiffusionXLFineTuneSetup(
             model.text_encoder_1.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
             model.text_encoder_2.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
 
+        if config.rescale_noise_scheduler_to_zero_terminal_snr:
+            model.rescale_noise_scheduler_to_zero_terminal_snr()
+            model.force_v_prediction()
+        elif config.force_v_prediction:
+            model.force_v_prediction()
+        elif config.force_epsilon_prediction:
+            model.force_epsilon_prediction()
+
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_1)
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_2)
         self._setup_additional_embeddings(model, config)

--- a/modules/modelSetup/StableDiffusionXLLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionXLLoRASetup.py
@@ -159,6 +159,10 @@ class StableDiffusionXLLoRASetup(
         model.unet_lora.to(dtype=config.lora_weight_dtype.torch_dtype())
         model.unet_lora.hook_to_module()
 
+        if config.rescale_noise_scheduler_to_zero_terminal_snr:
+            model.rescale_noise_scheduler_to_zero_terminal_snr()
+            model.force_v_prediction()
+
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_1)
         self._remove_added_embeddings_from_tokenizer(model.tokenizer_2)
         self._setup_additional_embeddings(model, config)

--- a/modules/util/convert/convert_sdxl_diffusers_to_ckpt.py
+++ b/modules/util/convert/convert_sdxl_diffusers_to_ckpt.py
@@ -136,6 +136,13 @@ def __map_text_encoder_2(in_states: dict, out_prefix: str, in_prefix: str) -> di
 
     return out_states
 
+def __map_vpred(noise_scheduler: DDIMScheduler) -> dict:
+    out_states = {}
+
+    if noise_scheduler.config.prediction_type == 'v_prediction':
+        out_states["v_pred"] = torch.tensor([])
+
+    return out_states
 
 def convert_sdxl_diffusers_to_ckpt(
         vae_state_dict: dict,
@@ -151,5 +158,6 @@ def convert_sdxl_diffusers_to_ckpt(
     state_dict |= __map_text_encoder_1(text_encoder_1_state_dict, "conditioner.embedders.0.transformer", "")
     state_dict |= __map_text_encoder_2(text_encoder_2_state_dict, "conditioner.embedders.1", "text_model")
     state_dict |= util.map_noise_scheduler(noise_scheduler)
+    state_dict |= __map_vpred(noise_scheduler)
 
     return state_dict


### PR DESCRIPTION
V prediction type is now recognized when training SDXL models.
Empty key from last commit is checked by comfyui and (re)forge to recognize the prediction type.