### PR TITLE
learning_rate_min_factor

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -609,6 +609,7 @@ class GenericTrainer(BaseTrainer):
                     learning_rate_scheduler=self.config.learning_rate_scheduler,
                     warmup_steps=self.config.learning_rate_warmup_steps,
                     num_cycles=self.config.learning_rate_cycles,
+                    min_factor=self.config.learning_rate_min_factor,
                     num_epochs=self.config.epochs,
                     approximate_epoch_length=self.data_loader.get_data_set().approximate_length(),
                     batch_size=self.config.batch_size,

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -205,36 +205,41 @@ class TrainingTab:
                          tooltip="The number of steps it takes to gradually increase the learning rate from 0 to the specified learning rate. Values >1 are interpeted as a fixed number of steps, values <=1 are intepreted as a percentage of the total training steps (ex. 0.2 = 20% of the total step count)")
         components.entry(frame, 3, 1, self.ui_state, "learning_rate_warmup_steps")
 
+        # learning rate min factor
+        components.label(frame, 4, 0, "Learning Rate Min Factor",
+                         tooltip="Unit = float. Method = percentage. For a factor of 0.1, the final LR will be 10% of the initial LR. If the initial LR is 1e-4, the final LR will be 1e-5.")
+        components.entry(frame, 4, 1, self.ui_state, "learning_rate_min_factor")
+
         # learning rate cycles
-        components.label(frame, 4, 0, "Learning Rate Cycles",
+        components.label(frame, 5, 0, "Learning Rate Cycles",
                          tooltip="The number of learning rate cycles. This is only applicable if the learning rate scheduler supports cycles")
-        components.entry(frame, 4, 1, self.ui_state, "learning_rate_cycles")
+        components.entry(frame, 5, 1, self.ui_state, "learning_rate_cycles")
 
         # epochs
-        components.label(frame, 5, 0, "Epochs",
+        components.label(frame, 6, 0, "Epochs",
                          tooltip="The number of epochs for a full training run")
-        components.entry(frame, 5, 1, self.ui_state, "epochs")
+        components.entry(frame, 6, 1, self.ui_state, "epochs")
 
         # batch size
-        components.label(frame, 6, 0, "Batch Size",
+        components.label(frame, 7, 0, "Batch Size",
                          tooltip="The batch size of one training step")
-        components.entry(frame, 6, 1, self.ui_state, "batch_size")
+        components.entry(frame, 7, 1, self.ui_state, "batch_size")
 
         # accumulation steps
-        components.label(frame, 7, 0, "Accumulation Steps",
+        components.label(frame, 8, 0, "Accumulation Steps",
                          tooltip="Number of accumulation steps. Increase this number to trade batch size for training speed")
-        components.entry(frame, 7, 1, self.ui_state, "gradient_accumulation_steps")
+        components.entry(frame, 8, 1, self.ui_state, "gradient_accumulation_steps")
 
         # Learning Rate Scaler
-        components.label(frame, 8, 0, "Learning Rate Scaler",
+        components.label(frame, 9, 0, "Learning Rate Scaler",
                          tooltip="Selects the type of learning rate scaling to use during training. Functionally equated as: LR * SQRT(selection)")
-        components.options(frame, 8, 1, [str(x) for x in list(LearningRateScaler)], self.ui_state,
+        components.options(frame, 9, 1, [str(x) for x in list(LearningRateScaler)], self.ui_state,
                            "learning_rate_scaler")
 
         # clip grad norm
-        components.label(frame, 9, 0, "Clip Grad Norm",
+        components.label(frame, 10, 0, "Clip Grad Norm",
                          tooltip="Clips the gradient norm. Leave empty to disable gradient clipping.")
-        components.entry(frame, 9, 1, self.ui_state, "clip_grad_norm")
+        components.entry(frame, 10, 1, self.ui_state, "clip_grad_norm")
 
     def __create_base2_frame(self, master, row):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -276,6 +276,7 @@ class TrainConfig(BaseConfig):
     learning_rate: float
     learning_rate_warmup_steps: float
     learning_rate_cycles: float
+    learning_rate_min_factor: float
     epochs: int
     batch_size: int
     gradient_accumulation_steps: int
@@ -734,6 +735,7 @@ class TrainConfig(BaseConfig):
         data.append(("scheduler_params", [], list[dict[str, str]], True))
         data.append(("learning_rate", 3e-6, float, False))
         data.append(("learning_rate_warmup_steps", 200.0, float, False))
+        data.append(("learning_rate_cycles", 1.0, float, False))
         data.append(("learning_rate_cycles", 1.0, float, False))
         data.append(("epochs", 100, int, False))
         data.append(("batch_size", 1, int, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -736,7 +736,7 @@ class TrainConfig(BaseConfig):
         data.append(("learning_rate", 3e-6, float, False))
         data.append(("learning_rate_warmup_steps", 200.0, float, False))
         data.append(("learning_rate_cycles", 1.0, float, False))
-        data.append(("learning_rate_cycles", 1.0, float, False))
+        data.append(("learning_rate_min_factor", 1.0, float, False))
         data.append(("epochs", 100, int, False))
         data.append(("batch_size", 1, int, False))
         data.append(("gradient_accumulation_steps", 1, int, False))

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -1031,6 +1031,7 @@ def create_lr_scheduler(
         learning_rate_scheduler: LearningRateScheduler,
         warmup_steps: int | float,
         num_cycles: float,
+        min_factor: float,
         num_epochs: int,
         batch_size: int,
         approximate_epoch_length: int,
@@ -1059,27 +1060,29 @@ def create_lr_scheduler(
 
         case LearningRateScheduler.LINEAR:
             lr_lambda = lr_lambda_linear(
-                scheduler_steps
+                scheduler_steps, min_factor
             )
 
         case LearningRateScheduler.COSINE:
             lr_lambda = lr_lambda_cosine(
-                scheduler_steps
+                scheduler_steps, min_factor
             )
 
         case LearningRateScheduler.COSINE_WITH_RESTARTS:
             lr_lambda = lr_lambda_cosine_with_restarts(
-                scheduler_steps, num_cycles
+                scheduler_steps, num_cycles, min_factor
             )
 
         case LearningRateScheduler.COSINE_WITH_HARD_RESTARTS:
             lr_lambda = lr_lambda_cosine_with_hard_restarts(
-                scheduler_steps, num_cycles
+                scheduler_steps, num_cycles, min_factor
             )
+
         case LearningRateScheduler.REX:
             lr_lambda = lr_lambda_rex(
-                scheduler_steps
+                scheduler_steps, min_factor
             )
+            
         case LearningRateScheduler.ADAFACTOR:
             from transformers.optimization import AdafactorSchedule
             return AdafactorSchedule(

--- a/modules/util/lr_scheduler_util.py
+++ b/modules/util/lr_scheduler_util.py
@@ -21,20 +21,27 @@ def lr_lambda_constant():
 
 def lr_lambda_linear(
         scheduler_steps: int,
+        min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
-        return max(0.0, float(scheduler_steps - current_step) / float(scheduler_steps))
+        lin_val = max(0.0, float(scheduler_steps - current_step) / float(scheduler_steps))
+        factor = apply_min_factor(lin_val, min_factor)
+        return factor
 
     return lr_lambda
 
 
+
 def lr_lambda_cosine(
         scheduler_steps: int,
+        min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
         progress = float(current_step) / float(scheduler_steps)
-        schedule = math.cos(progress * math.pi)
-        return max(0.0, 0.5 * (1.0 + schedule))
+        cos_val = 0.5 * (1.0 + math.cos(progress * math.pi))
+        factor = max(0.0, cos_val)
+        factor = apply_min_factor(factor, min_factor)
+        return factor
 
     return lr_lambda
 
@@ -42,41 +49,55 @@ def lr_lambda_cosine(
 def lr_lambda_cosine_with_restarts(
         scheduler_steps: int,
         num_cycles: float,
+        min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
         progress = float(min(current_step, scheduler_steps - 1)) / float(scheduler_steps)
-        schedule = math.cos(progress * 2.0 * math.pi * num_cycles)
-        return max(0.0, 0.5 * (1.0 + schedule))
+        cos_val = 0.5 * (1.0 + math.cos(progress * 2.0 * math.pi * num_cycles))
+        factor = max(0.0, cos_val)
+        factor = apply_min_factor(factor, min_factor)
+        return factor
 
     return lr_lambda
+
 
 
 def lr_lambda_cosine_with_hard_restarts(
         scheduler_steps: int,
         num_cycles: float,
+        min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
         progress = float(min(current_step, scheduler_steps - 1)) / float(scheduler_steps)
-        schedule = math.cos(((progress * num_cycles) % 1.0) * math.pi)
-        return max(0.0, 0.5 * (1.0 + schedule))
+        cos_val = 0.5 * (1.0 + math.cos(((progress * num_cycles) % 1.0) * math.pi))
+        factor = max(0.0, cos_val)
+        factor = apply_min_factor(factor, min_factor)
+        return factor
 
     return lr_lambda
+
 
 
 def lr_lambda_rex(
         scheduler_steps: int,
+        min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
-        # https://arxiv.org/abs/2107.04197
         max_lr = 1
         min_lr = 0
         d = 0.9
-
         if current_step < scheduler_steps:
             progress = (current_step / scheduler_steps)
             div = (1 - d) + (d * (1 - progress))
-            return min_lr + (max_lr - min_lr) * ((1 - progress) / div)
+            val = min_lr + (max_lr - min_lr) * ((1 - progress) / div)
         else:
-            return min_lr
+            val = min_lr
+        
+        factor = apply_min_factor(val, min_factor)
+        return factor
 
     return lr_lambda
+
+
+def apply_min_factor(value: float, min_factor: float) -> float:
+    return min_factor + (1.0 - min_factor) * value

--- a/modules/util/lr_scheduler_util.py
+++ b/modules/util/lr_scheduler_util.py
@@ -83,6 +83,7 @@ def lr_lambda_rex(
         min_factor: float = 1.0,
 ):
     def lr_lambda(current_step: int):
+        # https://arxiv.org/abs/2107.04197
         max_lr = 1
         min_lr = 0
         d = 0.9


### PR DESCRIPTION
I implemented a new training parameter for use with cosines, linear, and REX. 

The `learning_rate_min_factor` sets the lower limit of the LR. If the initial LR is `2e-4` and you set a `learning_rate_min_factor` of `0.5`, the final LR value will be `1e-4`. 

Basically, the final LR equals the initial LR multiplied by the factor.