### PR TITLE
Update dependencies only when necessary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,3 +5,5 @@ set -e
 source "${BASH_SOURCE[0]%/*}/lib.include.sh"
 
 prepare_runtime_environment
+
+git rev-parse HEAD > last-commit.sha

--- a/update.sh
+++ b/update.sh
@@ -12,5 +12,17 @@ git pull
 # Load the newest version of the function library.
 source "lib.include.sh"
 
+
+if [[ -f "last-commit.sha" ]]; then
+    last_commit=$(<"last-commit.sha")
+    current_commit=$(git rev-parse HEAD)
+    if [[ "$last_commit" == "$current_commit" && "$1" != "force" ]]; then
+        echo "Skipping dependency check. Run \"./update.sh force\" to check anyway."
+        exit 0
+    fi
+fi
+
 # Prepare runtime and upgrade all dependencies to latest compatible version.
 prepare_runtime_environment upgrade
+
+git rev-parse HEAD > last-commit.sha


### PR DESCRIPTION
https://github.com/Nerogar/OneTrainer/issues/632

Dependencies can only change when something new was pulled from github
This is useful for cloud training, so you can leave "Update OneTrainer" switched on without having to wait