### PR TITLE
Skip samples on training start

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -499,7 +499,7 @@ class GenericTrainer(BaseTrainer):
         return self.single_action_elapsed(
             "sample_skip_first", self.config.sample_skip_first, self.config.sample_after_unit, train_progress
         ) and self.repeating_action_needed(
-            "sample", self.config.sample_after, self.config.sample_after_unit, train_progress, start_at_zero=False
+            "sample", self.config.sample_after, self.config.sample_after_unit, train_progress
         )
 
     def __needs_backup(self, train_progress: TrainProgress):

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -496,8 +496,10 @@ class GenericTrainer(BaseTrainer):
         torch_gc()
 
     def __needs_sample(self, train_progress: TrainProgress):
-        return self.repeating_action_needed(
-            "sample", self.config.sample_after, self.config.sample_after_unit, train_progress
+        return self.single_action_elapsed(
+            "sample_skip_first", self.config.sample_skip_first, self.config.sample_after_unit, train_progress
+        ) and self.repeating_action_needed(
+            "sample", self.config.sample_after, self.config.sample_after_unit, train_progress, start_at_zero=False
         )
 
     def __needs_backup(self, train_progress: TrainProgress):

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -270,20 +270,25 @@ class TrainUI(ctk.CTk):
         top_frame.grid(row=0, column=0, sticky="nsew")
         sub_frame = ctk.CTkFrame(master=top_frame, corner_radius=0, fg_color="transparent")
         sub_frame.grid(row=1, column=0, sticky="nsew", columnspan=6)
+
         components.label(top_frame, 0, 0, "Sample After",
                          tooltip="The interval used when automatically sampling from the model during training")
         components.time_entry(top_frame, 0, 1, self.ui_state, "sample_after", "sample_after_unit")
 
-        components.label(top_frame, 0, 2, "Format",
+        components.label(top_frame, 0, 2, "Skip First",
+                         tooltip="Start sampling automatically after this interval has elapsed.")
+        components.entry(top_frame, 0, 3, self.ui_state, "sample_skip_first", width=50, sticky="nw")
+
+        components.label(top_frame, 0, 4, "Format",
                          tooltip="File Format used when saving samples")
-        components.options_kv(top_frame, 0, 3, [
+        components.options_kv(top_frame, 0, 5, [
             ("PNG", ImageFormat.PNG),
             ("JPG", ImageFormat.JPG),
         ], self.ui_state, "sample_image_format")
 
-        components.button(top_frame, 0, 4, "sample now", self.sample_now)
+        components.button(top_frame, 0, 6, "sample now", self.sample_now)
 
-        components.button(top_frame, 0, 5, "manual sample", self.open_sample_ui)
+        components.button(top_frame, 0, 7, "manual sample", self.open_sample_ui)
 
         components.label(sub_frame, 0, 0, "Non-EMA Sampling",
                          tooltip="Whether to include non-ema sampling when using ema.")

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -400,6 +400,7 @@ class TrainConfig(BaseConfig):
     sample_audio_format: AudioFormat
     samples_to_tensorboard: bool
     non_ema_sampling: bool
+    sample_skip_first: int
 
     # cloud settings
     cloud: CloudConfig
@@ -915,6 +916,7 @@ class TrainConfig(BaseConfig):
         data.append(("sample_audio_format", AudioFormat.MP3, AudioFormat, False))
         data.append(("samples_to_tensorboard", True, bool, False))
         data.append(("non_ema_sampling", True, bool, False))
+        data.append(("sample_skip_first", 0, int, False))
 
         # backup settings
         data.append(("backup_after", 30, int, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -395,12 +395,12 @@ class TrainConfig(BaseConfig):
     samples: list[SampleConfig]
     sample_after: float
     sample_after_unit: TimeUnit
+    sample_skip_first: int
     sample_image_format: ImageFormat
     sample_video_format: VideoFormat
     sample_audio_format: AudioFormat
     samples_to_tensorboard: bool
     non_ema_sampling: bool
-    sample_skip_first: int
 
     # cloud settings
     cloud: CloudConfig
@@ -911,12 +911,12 @@ class TrainConfig(BaseConfig):
         data.append(("samples", None, list[SampleConfig], True))
         data.append(("sample_after", 10, int, False))
         data.append(("sample_after_unit", TimeUnit.MINUTE, TimeUnit, False))
+        data.append(("sample_skip_first", 0, int, False))
         data.append(("sample_image_format", ImageFormat.JPG, ImageFormat, False))
         data.append(("sample_video_format", VideoFormat.MP4, VideoFormat, False))
         data.append(("sample_audio_format", AudioFormat.MP3, AudioFormat, False))
         data.append(("samples_to_tensorboard", True, bool, False))
         data.append(("non_ema_sampling", True, bool, False))
-        data.append(("sample_skip_first", 0, int, False))
 
         # backup settings
         data.append(("backup_after", 30, int, False))


### PR DESCRIPTION
Just a QoL option that makes OT skip sample generation when training starts.

I’ve been annoyed by this for a long time, always having to enable and disable samples at the start of each training session. 😉