### PR TITLE
Implement source-aware updates to speed up dependency checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ debug*.py
 /training_samples
 /training_user_settings
 /external
+/update.var
 config.json
 secrets.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,35 @@
+# development
 .idea
-.python-version
-/.venv*
-/venv*
-/conda_env*
+*.bak
+*.pyc
+*.swp
+*~
+debug*.ipynb
+debug*.py
 /debug*
+
+# user data
 /workspace*
 /models*
 /training_concepts
 /training_samples
 /training_user_settings
 /external
-debug*.py
-debug*.ipynb
-train.bat
 config.json
-*.pyc
-*.bak
-/src
+secrets.json
+
+# environments
+/.venv*
+/venv*
+/conda_env*
+.python-version
+*.egg-info
+
 # pixi environments
 .pixi
 pixi.lock
 pixi.toml
-*.egg-info
-secrets.json
+
+# misc files
+/src
+train.bat

--- a/LAUNCH-SCRIPTS.md
+++ b/LAUNCH-SCRIPTS.md
@@ -23,6 +23,8 @@
 
 - `OT_PREFER_VENV`: If set to `true`, Conda will be ignored even if it exists on the system, and Python Venv will be used instead. This ensures that people who use `pyenv` (to choose which Python version to run on the host) can easily set up their desired Python Venv environments. Defaults to `false`.
 
+- `OT_LAZY_UPDATES`: If set to `true`, OneTrainer's self-update process will only update the Python environment's dependencies if the OneTrainer source code has been modified since the previous dependency update. This speeds up executions of `update.sh`, and is generally safe, but may miss some updates and important bugfixes for external third-party dependencies. If you use this option, you must set it permanently for *every* script (not just `update.sh`). Defaults to `false`.
+
 - `OT_CUDA_LOWMEM_MODE`: If set to `true`, it enables aggressive garbage collection in PyTorch to help with low-memory GPUs. Defaults to `false`.
 
 - `OT_PLATFORM_REQUIREMENTS`: Allows you to override which platform-specific "requirements" file you want to install. Defaults to `detect`, which automatically detects whether you have an AMD or NVIDIA GPU. But people with multi-GPU systems can use this setting to force a specific GPU acceleration framework's requirements. Valid values are `requirements-rocm.txt` for AMD, `requirements-cuda.txt` for NVIDIA, and `requirements-default.txt` for non-AMD/NVIDIA systems.


### PR DESCRIPTION
OneTrainer's self-update process now supports source-aware updates via an opt-in flag, which skips the update check if the OneTrainer source code hasn't changed.

This optimization significantly speeds up executions of `update.sh`.

While generally safe, this approach may miss some updates and critical bug fixes for third-party dependencies.

By default, this feature is disabled to ensure maximum safety.

Closes: #637 