### PR TITLE
Timestep shifting

### DIFF
--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -41,7 +41,7 @@ class FluxSampler(BaseModelSampler):
             base_seq_len: int = 256,
             max_seq_len: int = 4096,
             base_shift: float = 0.5,
-            max_shift: float = 1.16,
+            max_shift: float = 1.15,
     ):
         m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
         b = base_shift - m * base_seq_len

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -427,6 +427,8 @@ class BaseFluxSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                latent_height=scaled_latent_image.shape[-2],
+                latent_width=scaled_latent_image.shape[-1],
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -495,6 +495,8 @@ class BaseStableDiffusion3Setup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                latent_height=scaled_latent_image.shape[-2],
+                latent_width=scaled_latent_image.shape[-1],
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
@@ -70,65 +70,6 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
             max_timestep = int(num_train_timesteps * config.max_noising_strength)
             num_timestep = max_timestep - min_timestep
 
-            if config.timestep_distribution == TimestepDistribution.UNIFORM:
-                timestep = min_timestep + (max_timestep - min_timestep) * torch.rand(batch_size,generator=generator,device=generator.device)
-            elif config.timestep_distribution == TimestepDistribution.SIGMOID:
-                if self.__weights is None:
-                    bias = config.noising_bias + 0.5
-                    weight = config.noising_weight
-
-                    weights = torch.linspace(0, 1, num_timestep)
-                    weights = 1 / (1 + torch.exp(-weight * (weights - bias)))  # Sigmoid
-                    self.__weights = weights
-
-                samples = torch.multinomial(self.__weights, num_samples=batch_size, replacement=True) + min_timestep
-                timestep = samples.to(dtype=torch.long, device=generator.device)
-            # elif config.timestep_distribution == TimestepDistribution.LOGIT_NORMAL:  ## multinomial implementation
-            #     if self.__weights is None:
-            #         bias = config.noising_bias
-            #         scale = config.noising_weight + 1.0
-            #
-            #         weights = torch.linspace(0, 1, num_timestep)
-            #         weights = \
-            #             (1.0 / (scale * math.sqrt(2.0 * torch.pi))) \
-            #             * (1.0 / (weights * (1.0 - weights))) \
-            #             * torch.exp(
-            #                 -((torch.logit(weights) - bias) ** 2.0) / (2.0 * scale ** 2.0)
-            #             )
-            #         weights.nan_to_num_(0)
-            #         self.__weights = weights
-            #
-            #     samples = torch.multinomial(self.__weights, num_samples=batch_size, replacement=True) + min_timestep
-            #     return samples.to(dtype=torch.long, device=generator.device)
-            elif config.timestep_distribution == TimestepDistribution.LOGIT_NORMAL:
-                bias = config.noising_bias
-                scale = config.noising_weight + 1.0
-
-                normal = torch.normal(bias, scale, size=(batch_size,), generator=generator, device=generator.device)
-                logit_normal = normal.sigmoid()
-                timestep = logit_normal * num_timestep + min_timestep
-            elif config.timestep_distribution == TimestepDistribution.HEAVY_TAIL:
-                scale = config.noising_weight
-
-                u = torch.rand(
-                    size=(batch_size,),
-                    generator=generator,
-                    device=generator.device,
-                )
-                u = 1.0 - u - scale * (torch.cos(math.pi / 2.0 * u) ** 2.0 - 1.0 + u)
-                timestep = u * num_timestep + min_timestep
-            elif config.timestep_distribution == TimestepDistribution.COS_MAP:
-                if self.__weights is None:
-                    weights = torch.linspace(0, 1, num_timestep)
-                    weights = 2.0 / (math.pi - 2.0 * math.pi * weights + 2.0 * math.pi * weights ** 2.0)
-                    self.__weights = weights
-
-                samples = torch.multinomial(self.__weights, num_samples=batch_size, replacement=True) + min_timestep
-                timestep = samples.to(dtype=torch.long, device=generator.device)
-            else:
-                return None
-
-
             shift = config.timestep_shift
             if config.dynamic_timestep_shifting:
                 if not latent_width or not latent_height:
@@ -147,14 +88,69 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
 
                 shift = math.exp(mu)
 
-            if shift != 1.0 and (
-                config.timestep_distribution == TimestepDistribution.SIGMOID
-                or config.timestep_distribution == TimestepDistribution.COS_MAP
-            ):
-                raise NotImplementedError("Timestep shifting not implemented for SIGMOID and COS_MAP distributions")
+            if config.timestep_distribution in [
+                TimestepDistribution.UNIFORM,
+                TimestepDistribution.LOGIT_NORMAL,
+                TimestepDistribution.HEAVY_TAIL
+            ]:
+                # continuous implementations
+                if config.timestep_distribution == TimestepDistribution.UNIFORM:
+                    timestep = min_timestep + (max_timestep - min_timestep) \
+                               * torch.rand(batch_size, generator=generator, device=generator.device)
+                elif config.timestep_distribution == TimestepDistribution.LOGIT_NORMAL:
+                    bias = config.noising_bias
+                    scale = config.noising_weight + 1.0
 
-            timestep = num_train_timesteps * shift * timestep / ((shift-1) * timestep + num_train_timesteps)
+                    normal = torch.normal(bias, scale, size=(batch_size,), generator=generator, device=generator.device)
+                    logit_normal = normal.sigmoid()
+                    timestep = logit_normal * num_timestep + min_timestep
+                elif config.timestep_distribution == TimestepDistribution.HEAVY_TAIL:
+                    scale = config.noising_weight
 
+                    u = torch.rand(
+                        size=(batch_size,),
+                        generator=generator,
+                        device=generator.device,
+                    )
+                    u = 1.0 - u - scale * (torch.cos(math.pi / 2.0 * u) ** 2.0 - 1.0 + u)
+                    timestep = u * num_timestep + min_timestep
+
+                timestep = num_train_timesteps * shift * timestep / ((shift - 1) * timestep + num_train_timesteps)
+            else:
+                # Shifting a discrete distribution is done in two steps:
+                # 1. Apply the inverse shift to the linspace.
+                #    This moves the sample points of the function to their shifted place.
+                # 2. Multiply the result with the derivative of the inverse shift function.
+                #    The derivative is an approximation of the distance between sample points.
+                #    Or in other words, the size of a shifted bucket in the original function.
+                linspace = torch.linspace(0, 1, num_timestep)
+                linspace = linspace / (shift - shift * linspace + linspace)
+
+                linspace_derivative = torch.linspace(0, 1, num_timestep)
+                linspace_derivative = shift / (shift + linspace_derivative - (linspace_derivative * shift)).pow(2)
+
+                # continuous implementations
+                if config.timestep_distribution == TimestepDistribution.COS_MAP:
+                    if self.__weights is None:
+
+                        weights = 2.0 / (math.pi - 2.0 * math.pi * linspace + 2.0 * math.pi * linspace ** 2.0)
+                        weights *= linspace_derivative
+                        self.__weights = weights
+
+                    samples = torch.multinomial(self.__weights, num_samples=batch_size, replacement=True) + min_timestep
+                    timestep = samples.to(dtype=torch.long, device=generator.device)
+                elif config.timestep_distribution == TimestepDistribution.SIGMOID:
+                    if self.__weights is None:
+                        bias = config.noising_bias + 0.5
+                        weight = config.noising_weight
+
+                        weights = linspace / (shift - shift * linspace + linspace)
+                        weights = 1 / (1 + torch.exp(-weight * (weights - bias)))  # Sigmoid
+                        weights *= linspace_derivative
+                        self.__weights = weights
+
+                    samples = torch.multinomial(self.__weights, num_samples=batch_size, replacement=True) + min_timestep
+                    timestep = samples.to(dtype=torch.long, device=generator.device)
 
             return timestep.int()
 

--- a/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
@@ -154,7 +154,7 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
             timestep = num_train_timesteps*shift*timestep/((shift-1)*timestep + num_train_timesteps)
 
 
-            return timestep
+            return timestep.int()
 
     def _get_timestep_continuous(
             self,

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -683,6 +683,17 @@ class TrainingTab:
                          tooltip="Controls the bias parameter of the timestep distribution function. Use the preview to see more details.")
         components.entry(frame, 6, 1, self.ui_state, "noising_bias")
 
+        # timestep shift
+        components.label(frame, 7, 0, "Timestep Shift",
+                         tooltip="Shift the timestep distribution. Use the preview to see more details.")
+        components.entry(frame, 7, 1, self.ui_state, "timestep_shift")
+
+        # dynamic timestep shifting
+        components.label(frame, 8, 0, "Dynamic Timestep Shifting",
+                         tooltip="Dynamically shift the timestep distribution based on resolution. Use the preview to see more details.")
+        components.switch(frame, 8, 1, self.ui_state, "dynamic_timestep_shifting")
+
+
 
     def __create_masked_frame(self, master, row):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -325,6 +325,9 @@ class TrainConfig(BaseConfig):
     noising_weight: float
     noising_bias: float
 
+    timestep_shift: float
+    dynamic_timestep_shifting: bool
+
     # unet
     unet: TrainModelPartConfig
 
@@ -791,6 +794,9 @@ class TrainConfig(BaseConfig):
         data.append(("timestep_distribution", TimestepDistribution.UNIFORM, TimestepDistribution, False))
         data.append(("noising_weight", 0.0, float, False))
         data.append(("noising_bias", 0.0, float, False))
+        data.append(("timestep_shift", 1.0, float, False))
+        data.append(("dynamic_timestep_shifting", False, bool, False))
+
 
         # unet
         unet = TrainModelPartConfig.default_values()


### PR DESCRIPTION
This is an implementation of timestep shifting for training, as is done by `FlowMatchEulerDiscreteScheduler` during inference.
An explanation why I think this is correct you can find here: https://github.com/Nerogar/OneTrainer/issues/615

I am getting more and more convinved of this, because many of my own training experiments have failed or would have failed if I didn't manually mess with the timestep distribution first. The default timestep distribution often cannot change the image composition enough.

New training parameters:
![image](https://github.com/user-attachments/assets/845e283c-8429-48c3-abad-38faca07eedd)

This PR doesn't change any defaults, but I believe this should be the defaults for the presets:

SD3: timestep_shift = 3.0
Flux: dynamic_timestep_shifting = True

Here are some examples:
LOGIT_NORMAL distribution with timestep_shift == 1.8, which is what dynamic shifting calculates for 512x512 resolution:
![image](https://github.com/user-attachments/assets/bd42556d-b1f0-4926-8821-a4b2576d8ae4)

LOGIT_NORMAL with 3.15, which is what dynamic shifting calculates for 1024x1024:
![image](https://github.com/user-attachments/assets/2e4af7e7-ae31-405f-80e9-46e85f3d9b84)


This is a UNIFORM distribution with the same timestep shift of 1.8:
![image](https://github.com/user-attachments/assets/52fd0873-d485-49d5-b044-728761acc32e)


