### PR TITLE
Make validation deterministic

### DIFF
--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -260,11 +260,10 @@ class BaseFluxSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -260,11 +260,15 @@ class BaseFluxSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -257,11 +257,10 @@ class BaseHunyuanVideoSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -257,11 +257,15 @@ class BaseHunyuanVideoSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             vae_scaling_factor = model.vae.config['scaling_factor']
 

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -69,6 +69,7 @@ class BaseModelSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         pass
 

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -69,7 +69,6 @@ class BaseModelSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         pass
 

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -192,11 +192,15 @@ class BasePixArtAlphaSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -192,11 +192,10 @@ class BasePixArtAlphaSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -196,11 +196,10 @@ class BaseSanaSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -196,11 +196,15 @@ class BaseSanaSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -315,11 +315,10 @@ class BaseStableDiffusion3Setup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -315,11 +315,15 @@ class BaseStableDiffusion3Setup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -173,11 +173,15 @@ class BaseStableDiffusionSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -173,11 +173,10 @@ class BaseStableDiffusionSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -224,11 +224,10 @@ class BaseStableDiffusionXLSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -224,11 +224,15 @@ class BaseStableDiffusionXLSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             is_align_prop_step = config.align_prop and (rand.random() < config.align_prop_probability)
 

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -216,7 +216,6 @@ class BaseWuerstchenSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
-            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             latent_image = batch['latent_image']
@@ -226,7 +225,7 @@ class BaseWuerstchenSetup(
                 scaled_latent_image = latent_image
 
             batch_seed = train_progress.global_step
-            if is_validation:
+            if deterministic:
                 batch_seed = 0
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -216,6 +216,7 @@ class BaseWuerstchenSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            is_validation: bool = False,
     ) -> dict:
         with model.autocast_context:
             latent_image = batch['latent_image']
@@ -224,9 +225,12 @@ class BaseWuerstchenSetup(
             elif model.model_type.is_stable_cascade():
                 scaled_latent_image = latent_image
 
+            batch_seed = train_progress.global_step
+            if is_validation:
+                batch_seed = 0
             generator = torch.Generator(device=config.train_device)
-            generator.manual_seed(train_progress.global_step)
-            rand = Random(train_progress.global_step)
+            generator.manual_seed(batch_seed)
+            rand = Random(batch_seed)
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -341,7 +341,7 @@ class GenericTrainer(BaseTrainer):
 
                 with torch.no_grad():
                     model_output_data = self.model_setup.predict(
-                        self.model, validation_batch, self.config, train_progress, deterministic=True, is_validation=True)
+                        self.model, validation_batch, self.config, train_progress, deterministic=True)
                     loss_validation = self.model_setup.calculate_loss(
                         self.model, validation_batch, model_output_data, self.config)
 

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -341,7 +341,7 @@ class GenericTrainer(BaseTrainer):
 
                 with torch.no_grad():
                     model_output_data = self.model_setup.predict(
-                        self.model, validation_batch, self.config, train_progress)
+                        self.model, validation_batch, self.config, train_progress, deterministic=True, is_validation=True)
                     loss_validation = self.model_setup.calculate_loss(
                         self.model, validation_batch, model_output_data, self.config)
 


### PR DESCRIPTION
See https://github.com/spacepxl/demystifying-sd-finetuning for more context on why this is helpful. TL;DR, it takes the validation loss from this:

![image](https://github.com/user-attachments/assets/f69ab4ce-ddab-4cce-84c2-7aa69cc14037)

to this:

![image](https://github.com/user-attachments/assets/f04a2816-6fb3-4453-ae33-8874c304ed25)

by seeding the validation process the same way each time it's run, so the only changing variable is the trained model.

This pr is just a very basic version, using the existing deterministic timestep option to lock timestep to 500, and overriding the seed to 0, but a better implementation would just seed once at the start of validation, and use different timesteps and noise for each image sampled, to be more robust. Unfortunately I couldn't find a way to stop the validation dataloader from shuffling, but this version is already more useful than the previous fully random validation.