### PR TITLE
Various Cloud improvements

### DIFF
--- a/modules/cloud/LinuxCloud.py
+++ b/modules/cloud/LinuxCloud.py
@@ -88,10 +88,12 @@ class LinuxCloud(BaseCloud):
             if update:
                 self.connection.run(f'cd {shlex.quote(config.onetrainer_dir)} \
                                       && export PATH=$PATH:/usr/local/cuda/bin \
+                                      && export OT_LAZY_UPDATES=true \
                                       && ./update.sh',in_stream=False)
         else:
             self.connection.run(f'cd {shlex.quote(config.onetrainer_dir)} \
                                   && export PATH=$PATH:/usr/local/cuda/bin \
+                                  && export OT_LAZY_UPDATES=true \
                                   && ./install.sh',in_stream=False)
 
     def _make_tensorboard_tunnel(self):

--- a/modules/trainer/CloudTrainer.py
+++ b/modules/trainer/CloudTrainer.py
@@ -177,6 +177,11 @@ class CloudTrainer(BaseTrainer):
             adjust(concept,"path")
             adjust(concept.text,"prompt_path")
 
+        if remote.train_device == "cpu":
+            #if there is no local GPU, "cpu" is the default, but not correct for cloud training
+            print("warning: replacing Train Device cpu with cuda")
+            remote.train_device = "cuda"
+
         return remote
 
     @staticmethod

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -568,11 +568,11 @@ class TrainUI(ctk.CTk):
         try:
             trainer.start()
             if self.train_config.cloud.enabled:
-                self.ui_state.get_var("cloud").update(self.train_config.cloud)
+                self.ui_state.get_var("secrets.cloud").update(self.train_config.secrets.cloud)
             trainer.train()
         except Exception:
             if self.train_config.cloud.enabled:
-                self.ui_state.get_var("cloud").update(self.train_config.cloud)
+                self.ui_state.get_var("secrets.cloud").update(self.train_config.secrets.cloud)
             error_caught = True
             traceback.print_exc()
 

--- a/scripts/train_remote.py
+++ b/scripts/train_remote.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import threading
+import traceback
 from contextlib import suppress
 
 from modules.trainer.GenericTrainer import GenericTrainer
@@ -17,12 +18,17 @@ from modules.util.config.TrainConfig import TrainConfig
 
 
 def write_request(filename,name, *params):
-    with suppress(FileNotFoundError):
-        os.rename(filename,filename+'.write')
-    with open(filename+'.write', 'ab') as f:
-        pickle.dump(name,f)
-        pickle.dump(params,f)
-    os.rename(filename+'.write',filename)
+    try:
+        with suppress(FileNotFoundError):
+            os.rename(filename,filename+'.write')
+        with open(filename+'.write', 'ab') as f:
+            pickle.dump(name,f)
+            pickle.dump(params,f)
+        os.rename(filename+'.write',filename)
+    except Exception:
+        #TrainCallbacks is suppressing all exceptions; at least print them:
+        traceback.print_exc()
+        raise
 
 def close_pipe(filename):
     with open(filename, 'wb'): #send EOF by closing


### PR DESCRIPTION
Various improvements for cloud:

 - bugfix: updating cloud id, host and port in the UI didnt work anymore since switch to SecretsConfig
- use OT_LAZY_UPDATES  see https://github.com/Nerogar/OneTrainer/pull/643
 - UI improvements
 - UI button to create RunPods on website
 - automatically replace train device `cpu` with `cuda`: cpu is the default if there is no GPU found on the client PC that runs OneTrainer. But using `cpu` on cloud is not intended
 - improve samples pickling

Collected over a while - submitting them now because the last point is a fix to a breaking change