### PR TITLE
Image preview from subdirectories, filename/caption preview

### DIFF
--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 from modules.ui.ConceptWindow import ConceptWindow
 from modules.ui.ConfigList import ConfigList
@@ -121,13 +122,23 @@ class ConceptWidget(ctk.CTkFrame):
     def __get_preview_image(self):
         preview_path = "resources/icons/icon.png"
 
-        if os.path.isdir(self.concept.path):
+        #check only top-level directory if subdirectories disabled
+        if os.path.isdir(self.concept.path) and not self.concept.include_subdirectories:
             for path in os.scandir(self.concept.path):
                 extension = os.path.splitext(path)[1]
                 if path.is_file() \
                         and path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_path = path_util.canonical_join(self.concept.path, path.name)
+                    break
+        #check all directories with glob if subdirectories enabled
+        elif os.path.isdir(self.concept.path) and self.concept.include_subdirectories:
+            for path in pathlib.Path(self.concept.path).rglob("*.*"):
+                extension = os.path.splitext(path)[1]
+                if path.is_file() \
+                        and path_util.is_supported_image_extension(extension) \
+                        and not path.name.endswith("-masklabel.png"):
+                    preview_path = path_util.canonical_join(self.concept.path, path)
                     break
 
         image = Image.open(preview_path)

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -122,21 +122,15 @@ class ConceptWidget(ctk.CTkFrame):
     def __get_preview_image(self):
         preview_path = "resources/icons/icon.png"
 
-        #check only top-level directory if subdirectories disabled
-        if os.path.isdir(self.concept.path) and not self.concept.include_subdirectories:
-            for path in os.scandir(self.concept.path):
+        if self.concept.include_subdirectories:
+            filelist = [file for file in pathlib.Path(self.concept.path).glob("**/*.*") if file.is_file()]
+        else:
+            filelist = [file for file in pathlib.Path(self.concept.path).glob("*.*")  if file.is_file()]
+
+        if os.path.isdir(self.concept.path):
+            for path in filelist:
                 extension = os.path.splitext(path)[1]
-                if path.is_file() \
-                        and path_util.is_supported_image_extension(extension) \
-                        and not path.name.endswith("-masklabel.png"):
-                    preview_path = path_util.canonical_join(self.concept.path, path.name)
-                    break
-        #check all directories with glob if subdirectories enabled
-        elif os.path.isdir(self.concept.path) and self.concept.include_subdirectories:
-            for path in pathlib.Path(self.concept.path).rglob("*.*"):
-                extension = os.path.splitext(path)[1]
-                if path.is_file() \
-                        and path_util.is_supported_image_extension(extension) \
+                if path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_path = path_util.canonical_join(self.concept.path, path)
                     break

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -121,16 +121,12 @@ class ConceptWidget(ctk.CTkFrame):
 
     def __get_preview_image(self):
         preview_path = "resources/icons/icon.png"
-
-        if self.concept.include_subdirectories:
-            filelist = [file for file in pathlib.Path(self.concept.path).glob("**/*.*") if file.is_file()]
-        else:
-            filelist = [file for file in pathlib.Path(self.concept.path).glob("*.*")  if file.is_file()]
+        glob_pattern = "**/*.*" if self.concept.include_subdirectories else "*.*"
 
         if os.path.isdir(self.concept.path):
-            for path in filelist:
+            for path in pathlib.Path(self.concept.path).glob(glob_pattern):
                 extension = os.path.splitext(path)[1]
-                if path_util.is_supported_image_extension(extension) \
+                if path.is_file() and path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_path = path_util.canonical_join(self.concept.path, path)
                     break

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -355,26 +355,17 @@ class ConceptWindow(ctk.CTkToplevel):
 
     def __get_preview_image(self):
         preview_image_path = "resources/icons/icon.png"
-
         file_index = -1
-        #check only top-level directory if subdirectories disabled
-        if os.path.isdir(self.concept.path) and not self.concept.include_subdirectories:
-            for path in os.scandir(self.concept.path):
-                extension = os.path.splitext(path)[1]
-                if path.is_file() \
-                        and path_util.is_supported_image_extension(extension) \
-                        and not path.name.endswith("-masklabel.png"):
-                    preview_image_path = path_util.canonical_join(self.concept.path, path.name)
 
-                    file_index += 1
-                    if file_index == self.image_preview_file_index:
-                        break
-        #check all directories with glob if subdirectories enabled
-        elif os.path.isdir(self.concept.path) and self.concept.include_subdirectories:
-            for path in pathlib.Path(self.concept.path).rglob("*.*"):
+        if self.concept.include_subdirectories:
+            filelist = [file for file in pathlib.Path(self.concept.path).glob("**/*.*") if file.is_file()]
+        else:
+            filelist = [file for file in pathlib.Path(self.concept.path).glob("*.*") if file.is_file()]
+
+        if os.path.isdir(self.concept.path):
+            for path in filelist:
                 extension = os.path.splitext(path)[1]
-                if path.is_file() \
-                        and path_util.is_supported_image_extension(extension) \
+                if path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_image_path = path_util.canonical_join(self.concept.path, path)
 

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -69,7 +69,6 @@ class ConceptWindow(ctk.CTkToplevel):
         self.image_preview_file_index = 0
 
         self.title("Concept")
-        self.geometry("800x630")
         self.geometry("800x700")
         self.resizable(True, True)
         self.wait_visibility()
@@ -261,8 +260,7 @@ class ConceptWindow(ctk.CTkToplevel):
         #caption and filename preview
         self.filename_preview = ctk.CTkLabel(master=frame, text=filename_preview, width=300, anchor="nw", justify="left", padx=10, wraplength=280)
         self.filename_preview.grid(row=7, column=4)
-        self.caption_preview = ctk.CTkTextbox(master=frame, width = 300, height = 150, wrap="word",
-                                              bg_color="white", border_width=3, corner_radius=3, border_color="#3B8ED0")
+        self.caption_preview = ctk.CTkTextbox(master=frame, width = 300, height = 150, wrap="word", border_width=2)
         self.caption_preview.insert(index="1.0", text=caption_preview)
         self.caption_preview.configure(state="disabled")
         self.caption_preview.grid(row=8, column=4, rowspan = 4)

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -70,6 +70,7 @@ class ConceptWindow(ctk.CTkToplevel):
 
         self.title("Concept")
         self.geometry("800x630")
+        self.geometry("800x700")
         self.resizable(True, True)
         self.wait_visibility()
         self.grab_set()
@@ -364,11 +365,9 @@ class ConceptWindow(ctk.CTkToplevel):
                 if path.is_file() and path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_image_path = path_util.canonical_join(self.concept.path, path)
-
                     file_index += 1
                     if file_index == self.image_preview_file_index:
                         break
-
 
         image = Image.open(preview_image_path).convert("RGB")
         image_tensor = functional.to_tensor(image)

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -356,16 +356,12 @@ class ConceptWindow(ctk.CTkToplevel):
     def __get_preview_image(self):
         preview_image_path = "resources/icons/icon.png"
         file_index = -1
-
-        if self.concept.include_subdirectories:
-            filelist = [file for file in pathlib.Path(self.concept.path).glob("**/*.*") if file.is_file()]
-        else:
-            filelist = [file for file in pathlib.Path(self.concept.path).glob("*.*") if file.is_file()]
+        glob_pattern = "**/*.*" if self.concept.include_subdirectories else "*.*"
 
         if os.path.isdir(self.concept.path):
-            for path in filelist:
+            for path in pathlib.Path(self.concept.path).glob(glob_pattern):
                 extension = os.path.splitext(path)[1]
-                if path_util.is_supported_image_extension(extension) \
+                if path.is_file() and path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png"):
                     preview_image_path = path_util.canonical_join(self.concept.path, path)
 


### PR DESCRIPTION
Image preview for concepts now looks in subdirectories if option is enabled, in both the concept tab and concept window. Tested with files in the top level and nested subdirectories and works as expected, no noticeable lag when previewing a concept folder with several thousand images.

Adds fields in concept window to display the name of the previewed file and the associated caption, depending on prompt source. Currently only displays the "unmodified" caption before shuffling/dropout, and only the first line if a file has multiple captions. Will try to change this to preview the "modified" caption in the future.