### PR TITLE
improve Python version check backwards compatibility

### DIFF
--- a/scripts/util/version_check.py
+++ b/scripts/util/version_check.py
@@ -6,8 +6,9 @@ import sys
 
 
 def exit_err(msg):
-    print("Error: " + msg)
-    exit(1)
+    sys.stderr.write("Error: " + msg + "\n")
+    sys.stderr.flush()
+    sys.exit(1)
 
 
 def str_to_tuple(data):
@@ -20,9 +21,8 @@ def tuple_to_str(data):
 
 def exit_wrong_version(msg, min_ver, too_high_ver):
     exit_err(
-        "Your Python version is {}: {}. Must be >= {} and < {}.".format(
-            msg, sys.version, tuple_to_str(min_ver), tuple_to_str(too_high_ver)
-        )
+        "Your Python version is %s: %s. Must be >= %s and < %s."
+        % (msg, sys.version, tuple_to_str(min_ver), tuple_to_str(too_high_ver))
     )
 
 


### PR DESCRIPTION
- The `%` technique is Python's oldest format string syntax, so it's more backwards-compatible than `str.format()`.

- Using `sys.stderr.write()` allows us to output directly to stderr in a backwards-compatible way.

Verified on Python 2.5.6 from almost 20 years ago.

---

Example output:

```
Error: Your Python version is too low: 2.5.6 (r256:88840, Feb 22 2025, 23:16:06) 
[GCC 14.2.1 20250110 (Red Hat 14.2.1-7)]. Must be >= 3.10 and < 3.13.
```

---

Thanks to @O-J1 for suggesting `sys.stderr.write()`.