### PR TITLE
Stop training when smooth loss gets higher than specified thresold.

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -714,6 +714,11 @@ class GenericTrainer(BaseTrainer):
                             'loss': accumulated_loss,
                             'smooth loss': ema_loss,
                         })
+
+                        if self.config.stop_training_at_high_loss_thresold is not None and self.config.stop_training_at_high_loss_thresold > 0 and ema_loss > self.config.stop_training_at_high_loss_thresold:
+                            step_tqdm.write(f'Smooth loss is higher than specified thresold of {self.config.stop_training_at_high_loss_thresold}, stopping training.')
+                            self.commands.stop()
+
                         self.tensorboard.add_scalar("smooth_loss/train_step", ema_loss, train_progress.global_step)
                         accumulated_loss = 0.0
 

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -714,8 +714,8 @@ class GenericTrainer(BaseTrainer):
                             'loss': accumulated_loss,
                             'smooth loss': ema_loss,
                         })
-                        if self.config.stop_training_at_high_loss_thresold is not None and self.config.stop_training_at_high_loss_thresold > 0 and ema_loss > self.config.stop_training_at_high_loss_thresold:
-                            step_tqdm.write(f'Smooth loss is higher than specified thresold of {self.config.stop_training_at_high_loss_thresold}, stopping training.')
+                        if self.config.stop_training_at_high_loss_threshold is not None and self.config.stop_training_at_high_loss_threshold > 0 and ema_loss > self.config.stop_training_at_high_loss_threshold:
+                            step_tqdm.write(f'Smooth loss is higher than specified threshold of {self.config.stop_training_at_high_loss_threshold}, stopping training.')
                             self.commands.stop()
 
                         self.tensorboard.add_scalar("smooth_loss/train_step", ema_loss, train_progress.global_step)

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -258,7 +258,7 @@ class TrainingTab:
         # Stop training on high loss
         components.label(frame, 11, 0, "Stop training on high loss",
                          tooltip="Enter the value of smooth loss at which training should stop")
-        components.entry(frame, 11, 1, self.ui_state, "stop_training_at_high_loss_thresold")
+        components.entry(frame, 11, 1, self.ui_state, "stop_training_at_high_loss_threshold")
 
     def __create_base2_frame(self, master, row, video_training_enabled: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -255,6 +255,11 @@ class TrainingTab:
                          tooltip="Clips the gradient norm. Leave empty to disable gradient clipping.")
         components.entry(frame, 10, 1, self.ui_state, "clip_grad_norm")
 
+        # Stop training on high loss
+        components.label(frame, 11, 0, "Stop training on high loss",
+                         tooltip="Enter the value of smooth loss at which training should stop")
+        components.entry(frame, 11, 1, self.ui_state, "stop_training_at_high_loss_thresold")
+
     def __create_base2_frame(self, master, row, video_training_enabled: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)
         frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -314,7 +314,7 @@ class TrainConfig(BaseConfig):
     loss_scaler: LossScaler
     learning_rate_scaler: LearningRateScaler
     clip_grad_norm: float
-    stop_training_at_high_loss_thresold: float
+    stop_training_at_high_loss_threshold: float
 
     # noise
     offset_noise_weight: float
@@ -788,7 +788,7 @@ class TrainConfig(BaseConfig):
         data.append(("loss_scaler", LossScaler.NONE, LossScaler, False))
         data.append(("learning_rate_scaler", LearningRateScaler.NONE, LearningRateScaler, False))
         data.append(("clip_grad_norm", 1.0, float, True))
-        data.append(("stop_training_at_high_loss_thresold", 0.0, float, True))
+        data.append(("stop_training_at_high_loss_threshold", 0.0, float, True))
 
         # noise
         data.append(("offset_noise_weight", 0.0, float, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -314,6 +314,7 @@ class TrainConfig(BaseConfig):
     loss_scaler: LossScaler
     learning_rate_scaler: LearningRateScaler
     clip_grad_norm: float
+    stop_training_at_high_loss_thresold: float
 
     # noise
     offset_noise_weight: float
@@ -787,6 +788,7 @@ class TrainConfig(BaseConfig):
         data.append(("loss_scaler", LossScaler.NONE, LossScaler, False))
         data.append(("learning_rate_scaler", LearningRateScaler.NONE, LearningRateScaler, False))
         data.append(("clip_grad_norm", 1.0, float, True))
+        data.append(("stop_training_at_high_loss_thresold", 0.0, float, True))
 
         # noise
         data.append(("offset_noise_weight", 0.0, float, False))


### PR DESCRIPTION
Allow to stop training early when smooth loss gets higher than specified thresold.
Adds parameter 'Stop training on high loss' to training tab.
![image](https://github.com/user-attachments/assets/bdf8f48f-984d-43c4-9747-4438b8eb7cca)
I think that when smooth loss get to ~1.0 value it's unrecoverable and continued training is waste of resources.
This should be even more benefiting with rolling backups, where rolling backups may be overwritten if training continues.
![image](https://github.com/user-attachments/assets/253ddcc7-aaef-4ef5-8eac-d51cdb364e77)
