### PR TITLE
Add EXIF metadata handling

### DIFF
--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -11,16 +11,14 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
+from modules.util.image_util import load_image
 from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image, ImageOps
 from tqdm import tqdm
-
-from modules.util.image_util import load_image
 
 
 class FluxSampler(BaseModelSampler):

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -20,6 +20,8 @@ from torchvision.transforms import transforms
 from PIL import Image, ImageOps
 from tqdm import tqdm
 
+from modules.util.image_util import load_image
+
 
 class FluxSampler(BaseModelSampler):
     def __init__(
@@ -264,14 +266,13 @@ class FluxSampler(BaseModelSampler):
                     ),
                 ])
 
-                image = Image.open(base_image_path).convert("RGB")
-                image = ImageOps.exif_transpose(image)
+                image = load_image(base_image_path, convert_mode="RGB")
                 image = t(image).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,
                 )
 
-                mask = Image.open(mask_image_path).convert("L")
+                mask = load_image(mask_image_path, convert_mode='L')
                 mask = t(mask).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image
+from PIL import Image, ImageOps
 from tqdm import tqdm
 
 
@@ -265,6 +265,7 @@ class FluxSampler(BaseModelSampler):
                 ])
 
                 image = Image.open(base_image_path).convert("RGB")
+                image = ImageOps.exif_transpose(image)
                 image = t(image).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -12,6 +12,7 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
 from modules.util.torch_util import torch_gc
+from modules.util.image_util import load_image
 
 import torch
 from torch import nn
@@ -223,14 +224,13 @@ class StableDiffusionSampler(BaseModelSampler):
                     ),
                 ])
 
-                image = Image.open(base_image_path).convert("RGB")
-                image = ImageOps.exif_transpose(image)
+                image = load_image(base_image_path, convert_mode="RGB")
                 image = t(image).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,
                 )
 
-                mask = Image.open(mask_image_path).convert("L")
+                mask = load_image(mask_image_path, convert_mode='L')
                 mask = t(mask).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image
+from PIL import Image, ImageOps
 from tqdm import tqdm
 
 
@@ -224,6 +224,7 @@ class StableDiffusionSampler(BaseModelSampler):
                 ])
 
                 image = Image.open(base_image_path).convert("RGB")
+                image = ImageOps.exif_transpose(image)
                 image = t(image).to(
                     dtype=self.model.train_dtype.torch_dtype(),
                     device=self.train_device,

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -11,14 +11,13 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 from modules.util.image_util import load_image
+from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image, ImageOps
 from tqdm import tqdm
 
 

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image
+from PIL import Image, ImageOps
 from tqdm import tqdm
 
 
@@ -255,6 +255,8 @@ class StableDiffusionXLSampler(BaseModelSampler):
                     ])
 
                     image = Image.open(base_image_path).convert("RGB")
+                    # Apply EXIF orientation if present
+                    image = ImageOps.exif_transpose(image)
                     image = t(image).to(
                         dtype=self.model.vae_train_dtype.torch_dtype(),
                         device=self.train_device,

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -11,14 +11,13 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 from modules.util.image_util import load_image
+from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
 from torchvision.transforms import transforms
 
-from PIL import Image, ImageOps
 from tqdm import tqdm
 
 

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -12,6 +12,7 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
 from modules.util.torch_util import torch_gc
+from modules.util.image_util import load_image
 
 import torch
 from torch import nn
@@ -254,15 +255,13 @@ class StableDiffusionXLSampler(BaseModelSampler):
                         ),
                     ])
 
-                    image = Image.open(base_image_path).convert("RGB")
-                    # Apply EXIF orientation if present
-                    image = ImageOps.exif_transpose(image)
+                    image = load_image(base_image_path, convert_mode="RGB")
                     image = t(image).to(
                         dtype=self.model.vae_train_dtype.torch_dtype(),
                         device=self.train_device,
                     )
 
-                    mask = Image.open(mask_image_path).convert("L")
+                    mask = load_image(mask_image_path, convert_mode='L')
                     mask = t(mask).to(
                         dtype=self.model.train_dtype.torch_dtype(),
                         device=self.train_device,

--- a/modules/module/BaseImageCaptionModel.py
+++ b/modules/module/BaseImageCaptionModel.py
@@ -5,8 +5,9 @@ from collections.abc import Callable
 from pathlib import Path
 
 from modules.util import path_util
+from modules.util.image_util import load_image
 
-from PIL import Image, ImageOps
+from PIL import Image
 from tqdm import tqdm
 
 
@@ -23,8 +24,7 @@ class CaptionSample:
 
     def get_image(self) -> Image:
         if self.image is None:
-            self.image = Image.open(self.image_filename).convert('RGB')
-            self.image = ImageOps.exif_transpose(self.image)
+            self.image = load_image(self.image_filename, 'RGB')
             self.height = self.image.height
             self.width = self.image.width
 

--- a/modules/module/BaseImageCaptionModel.py
+++ b/modules/module/BaseImageCaptionModel.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from modules.util import path_util
 
-from PIL import Image
+from PIL import Image, ImageOps
 from tqdm import tqdm
 
 
@@ -24,6 +24,7 @@ class CaptionSample:
     def get_image(self) -> Image:
         if self.image is None:
             self.image = Image.open(self.image_filename).convert('RGB')
+            self.image = ImageOps.exif_transpose(self.image)
             self.height = self.image.height
             self.width = self.image.width
 

--- a/modules/module/BaseImageMaskModel.py
+++ b/modules/module/BaseImageMaskModel.py
@@ -9,7 +9,7 @@ import torch
 from torch import Tensor
 from torchvision.transforms import transforms
 
-from PIL import Image
+from PIL import Image, ImageOps
 from tqdm import tqdm
 
 
@@ -36,6 +36,7 @@ class MaskSample:
     def get_image(self) -> Image:
         if self.image is None:
             self.image = Image.open(self.image_filename).convert('RGB')
+            self.image = ImageOps.exif_transpose(self.image)
             self.height = self.image.height
             self.width = self.image.width
 

--- a/modules/module/BaseImageMaskModel.py
+++ b/modules/module/BaseImageMaskModel.py
@@ -4,12 +4,13 @@ from collections.abc import Callable
 from pathlib import Path
 
 from modules.util import path_util
+from modules.util.image_util import load_image
 
 import torch
 from torch import Tensor
 from torchvision.transforms import transforms
 
-from PIL import Image, ImageOps
+from PIL import Image
 from tqdm import tqdm
 
 
@@ -35,8 +36,7 @@ class MaskSample:
 
     def get_image(self) -> Image:
         if self.image is None:
-            self.image = Image.open(self.image_filename).convert('RGB')
-            self.image = ImageOps.exif_transpose(self.image)
+            self.image = load_image(self.image_filename, 'RGB')
             self.height = self.image.height
             self.width = self.image.width
 
@@ -44,7 +44,7 @@ class MaskSample:
 
     def get_mask_tensor(self) -> Tensor:
         if self.mask_tensor is None and os.path.exists(self.mask_filename):
-            mask = Image.open(self.mask_filename).convert('L')
+            mask = load_image(self.mask_filename, 'L')
             mask = self.image2Tensor(mask)
             mask = mask.to(self.device)
             self.mask_tensor = mask.unsqueeze(0)

--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -18,6 +18,7 @@ from modules.util.torch_util import default_device
 from modules.util.ui import components
 from modules.util.ui.ui_utils import bind_mousewheel, set_window_icon
 from modules.util.ui.UIState import UIState
+from modules.util.image_util import load_image
 
 import torch
 
@@ -253,8 +254,7 @@ class CaptionUI(ctk.CTkToplevel):
             image_name = os.path.join(self.dir, image_name)
 
         try:
-            img = Image.open(image_name).convert('RGB')
-            return ImageOps.exif_transpose(img)
+            return load_image(image_name, convert_mode="RGB")
         except Exception:
             print(f'Could not open image {image_name}')
 
@@ -265,7 +265,7 @@ class CaptionUI(ctk.CTkToplevel):
             mask_name = os.path.join(self.dir, mask_name)
 
             try:
-                return Image.open(mask_name).convert('RGB')
+                return load_image(mask_name, convert_mode='RGB')
             except Exception:
                 return None
         else:

--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -25,7 +25,7 @@ import customtkinter as ctk
 import cv2
 import numpy as np
 from customtkinter import ScalingTracker, ThemeManager
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageOps
 
 
 class CaptionUI(ctk.CTkToplevel):
@@ -253,7 +253,8 @@ class CaptionUI(ctk.CTkToplevel):
             image_name = os.path.join(self.dir, image_name)
 
         try:
-            return Image.open(image_name).convert('RGB')
+            img = Image.open(image_name).convert('RGB')
+            return ImageOps.exif_transpose(img)
         except Exception:
             print(f'Could not open image {image_name}')
 

--- a/modules/ui/CaptionUI.py
+++ b/modules/ui/CaptionUI.py
@@ -14,11 +14,11 @@ from modules.module.WDModel import WDModel
 from modules.ui.GenerateCaptionsWindow import GenerateCaptionsWindow
 from modules.ui.GenerateMasksWindow import GenerateMasksWindow
 from modules.util import path_util
+from modules.util.image_util import load_image
 from modules.util.torch_util import default_device
 from modules.util.ui import components
 from modules.util.ui.ui_utils import bind_mousewheel, set_window_icon
 from modules.util.ui.UIState import UIState
-from modules.util.image_util import load_image
 
 import torch
 
@@ -26,7 +26,7 @@ import customtkinter as ctk
 import cv2
 import numpy as np
 from customtkinter import ScalingTracker, ThemeManager
-from PIL import Image, ImageDraw, ImageOps
+from PIL import Image, ImageDraw
 
 
 class CaptionUI(ctk.CTkToplevel):

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -6,12 +6,12 @@ from modules.ui.ConfigList import ConfigList
 from modules.util import path_util
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.TrainConfig import TrainConfig
+from modules.util.image_util import load_image
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState
-from modules.util.image_util import load_image
 
 import customtkinter as ctk
-from PIL import Image, ImageOps
+from PIL import Image
 
 
 class ConceptTab(ConfigList):

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -8,6 +8,7 @@ from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState
+from modules.util.image_util import load_image
 
 import customtkinter as ctk
 from PIL import Image, ImageOps
@@ -131,8 +132,7 @@ class ConceptWidget(ctk.CTkFrame):
                     preview_path = path_util.canonical_join(self.concept.path, path)
                     break
 
-        image = Image.open(preview_path)
-        image = ImageOps.exif_transpose(image)
+        image = load_image(preview_path, convert_mode="RGB")
         size = min(image.width, image.height)
         image = image.crop((
             (image.width - size) // 2,

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -10,7 +10,7 @@ from modules.util.ui import components
 from modules.util.ui.UIState import UIState
 
 import customtkinter as ctk
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 class ConceptTab(ConfigList):
@@ -132,6 +132,7 @@ class ConceptWidget(ctk.CTkFrame):
                     break
 
         image = Image.open(preview_path)
+        image = ImageOps.exif_transpose(image)
         size = min(image.width, image.height)
         image = image.crop((
             (image.width - size) // 2,

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -8,6 +8,7 @@ import time
 from modules.util import concept_stats, path_util
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.enum.BalancingStrategy import BalancingStrategy
+from modules.util.image_util import load_image
 from modules.util.ui import components
 from modules.util.ui.ui_utils import set_window_icon
 from modules.util.ui.UIState import UIState
@@ -36,7 +37,7 @@ import customtkinter as ctk
 from customtkinter import AppearanceModeTracker, ThemeManager
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from PIL import Image, ImageOps
+from PIL import Image
 
 
 class InputPipelineModule(
@@ -550,8 +551,7 @@ class ConceptWindow(ctk.CTkToplevel):
                     if file_index == self.image_preview_file_index:
                         break
 
-        image = Image.open(preview_image_path).convert("RGB")
-        image = ImageOps.exif_transpose(image)
+        image = load_image(preview_image_path, 'RGB')
         image_tensor = functional.to_tensor(image)
 
         splitext = os.path.splitext(preview_image_path)

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -36,7 +36,7 @@ import customtkinter as ctk
 from customtkinter import AppearanceModeTracker, ThemeManager
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 class InputPipelineModule(
@@ -551,6 +551,7 @@ class ConceptWindow(ctk.CTkToplevel):
                         break
 
         image = Image.open(preview_image_path).convert("RGB")
+        image = ImageOps.exif_transpose(image)
         image_tensor = functional.to_tensor(image)
 
         splitext = os.path.splitext(preview_image_path)

--- a/modules/util/concept_stats.py
+++ b/modules/util/concept_stats.py
@@ -7,7 +7,7 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 
 import cv2
 import imagesize
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 def init_concept_stats(conceptconfig : ConceptConfig, advanced_checks : bool):
@@ -122,6 +122,7 @@ def folder_scan(dir, stats_dict : dict, advanced_checks : bool, conceptconfig : 
                         raise ValueError
                 except ValueError:     #use PIL if not supported by imagesize
                     img = Image.open(path)
+                    img = ImageOps.exif_transpose(img)
                     width, height = img.size
                     img.close()
                 pixels = width*height

--- a/modules/util/concept_stats.py
+++ b/modules/util/concept_stats.py
@@ -2,14 +2,12 @@ import os
 
 from modules.util import path_util
 from modules.util.config.ConceptConfig import ConceptConfig
+from modules.util.image_util import load_image
 
 from mgds.pipelineModules.AspectBucketing import AspectBucketing
 
 import cv2
 import imagesize
-from PIL import Image, ImageOps
-
-from modules.util.image_util import load_image
 
 
 def init_concept_stats(conceptconfig : ConceptConfig, advanced_checks : bool):

--- a/modules/util/concept_stats.py
+++ b/modules/util/concept_stats.py
@@ -9,6 +9,8 @@ import cv2
 import imagesize
 from PIL import Image, ImageOps
 
+from modules.util.image_util import load_image
+
 
 def init_concept_stats(conceptconfig : ConceptConfig, advanced_checks : bool):
     stats_dict = {
@@ -121,8 +123,7 @@ def folder_scan(dir, stats_dict : dict, advanced_checks : bool, conceptconfig : 
                     if width == -1:     #if imagesize doesn't recognize format it returns (-1, -1)
                         raise ValueError
                 except ValueError:     #use PIL if not supported by imagesize
-                    img = Image.open(path)
-                    img = ImageOps.exif_transpose(img)
+                    img = load_image(path.path)
                     width, height = img.size
                     img.close()
                 pixels = width*height

--- a/modules/util/image_util.py
+++ b/modules/util/image_util.py
@@ -1,0 +1,9 @@
+from PIL import Image, ImageOps
+
+
+def load_image(path: str, convert_mode: str = 'RGB') -> Image.Image:
+    image = Image.open(path)
+    image = ImageOps.exif_transpose(image)
+    if convert_mode:
+        image = image.convert(convert_mode)
+    return image 

--- a/modules/util/image_util.py
+++ b/modules/util/image_util.py
@@ -6,4 +6,4 @@ def load_image(path: str, convert_mode: str = 'RGB') -> Image.Image:
     image = ImageOps.exif_transpose(image)
     if convert_mode:
         image = image.convert(convert_mode)
-    return image 
+    return image


### PR DESCRIPTION
When uploading photos with EXIF metadata (e.g. captured with iPhone), current OT implementation doesn't handle rotation flags, leading to photos being processed in wrong orientation (e.g. when creating masks):
![image](https://github.com/user-attachments/assets/88736e7b-78f9-40c3-a407-98eda4ef6b20)

This fix adds EXIF metadata handling in all the necessary places (I hope):
![image](https://github.com/user-attachments/assets/77cdf772-4768-4959-9fb2-53f3274841ec)
