### PR TITLE
Multi-GPU support

### DIFF
--- a/modules/dataLoader/FluxBaseDataLoader.py
+++ b/modules/dataLoader/FluxBaseDataLoader.py
@@ -49,6 +49,7 @@ class FluxBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/HunyuanVideoBaseDataLoader.py
+++ b/modules/dataLoader/HunyuanVideoBaseDataLoader.py
@@ -52,6 +52,7 @@ class HunyuanVideoBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/PixArtAlphaBaseDataLoader.py
+++ b/modules/dataLoader/PixArtAlphaBaseDataLoader.py
@@ -47,6 +47,7 @@ class PixArtAlphaBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/SanaBaseDataLoader.py
+++ b/modules/dataLoader/SanaBaseDataLoader.py
@@ -46,6 +46,7 @@ class SanaBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/StableDiffusion3BaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusion3BaseDataLoader.py
@@ -48,6 +48,7 @@ class StableDiffusion3BaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/StableDiffusionBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionBaseDataLoader.py
@@ -47,6 +47,7 @@ class StableDiffusionBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -56,6 +56,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
@@ -47,6 +47,7 @@ class StableDiffusionXLBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/WuerstchenBaseDataLoader.py
+++ b/modules/dataLoader/WuerstchenBaseDataLoader.py
@@ -45,6 +45,7 @@ class WuerstchenBaseDataLoader(
         if is_validation:
             config = copy.copy(config)
             config.batch_size = 1
+            config.multi_gpu = False
 
         self.__ds = self.create_dataset(
             config=config,

--- a/modules/dataLoader/mixin/DataLoaderMgdsMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderMgdsMixin.py
@@ -42,7 +42,7 @@ class DataLoaderMgdsMixin(metaclass=ABCMeta):
             concepts,
             settings,
             definition,
-            batch_size=config.batch_size,
+            batch_size=config.batch_size, #local batch size
             state=PipelineState(config.dataloader_threads),
             initial_epoch=train_progress.epoch,
             initial_epoch_sample=train_progress.epoch_sample,

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -250,7 +250,7 @@ class DataLoaderText2ImageMixin:
         else:
             batch_sorting = InlineAspectBatchSorting(resolution_in_name='crop_resolution', names=sort_names, batch_size=config.batch_size * world_size)
 
-        distributed_sampler = DistributedSampler(names=sort_names, local_batch_size=config.batch_size, world_size=world_size, rank = multi.rank())
+        distributed_sampler = DistributedSampler(names=sort_names, world_size=world_size, rank=multi.rank())
         output = OutputPipelineModule(names=output_names)
 
         modules = []

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable
 
+import modules.util.multi_gpu_util as multi
 from modules.util import path_util
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.DataType import DataType
@@ -11,6 +12,7 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 from mgds.pipelineModules.CalcAspect import CalcAspect
 from mgds.pipelineModules.CapitalizeTags import CapitalizeTags
 from mgds.pipelineModules.CollectPaths import CollectPaths
+from mgds.pipelineModules.DistributedSampler import DistributedSampler
 from mgds.pipelineModules.DropTags import DropTags
 from mgds.pipelineModules.GenerateImageLike import GenerateImageLike
 from mgds.pipelineModules.GenerateMaskedConditioningImage import GenerateMaskedConditioningImage
@@ -242,11 +244,13 @@ class DataLoaderText2ImageMixin:
             before_cache_fun=before_cache_image_fun,
         )
 
+        world_size = multi.world_size() if config.multi_gpu else 1  #world_size can be 1 for validation dataloader, even if multi.world_size() returns > 1
         if config.latent_caching:
-            batch_sorting = AspectBatchSorting(resolution_in_name='crop_resolution', names=sort_names, batch_size=config.batch_size)
+            batch_sorting = AspectBatchSorting(resolution_in_name='crop_resolution', names=sort_names, batch_size=config.batch_size * world_size)
         else:
-            batch_sorting = InlineAspectBatchSorting(resolution_in_name='crop_resolution', names=sort_names, batch_size=config.batch_size)
+            batch_sorting = InlineAspectBatchSorting(resolution_in_name='crop_resolution', names=sort_names, batch_size=config.batch_size * world_size)
 
+        distributed_sampler = DistributedSampler(names=sort_names, local_batch_size=config.batch_size, world_size=world_size, rank = multi.rank())
         output = OutputPipelineModule(names=output_names)
 
         modules = []
@@ -255,6 +259,8 @@ class DataLoaderText2ImageMixin:
             modules.append(mask_remove)
 
         modules.append(batch_sorting)
+        if world_size > 1:
+            modules.append(distributed_sampler)
 
         modules.append(output)
 

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.FluxModel import FluxModel, FluxModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -200,7 +201,7 @@ class BaseFluxSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.HunyuanVideoModel import HunyuanVideoModel, HunyuanVideoModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -202,7 +203,7 @@ class BaseHunyuanVideoSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.PixArtAlphaModel import PixArtAlphaModel, PixArtAlphaModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -156,7 +157,7 @@ class BasePixArtAlphaSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.SanaModel import SanaModel, SanaModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -166,7 +167,7 @@ class BaseSanaSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.StableDiffusion3Model import StableDiffusion3Model, StableDiffusion3ModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -245,7 +246,7 @@ class BaseStableDiffusion3Setup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.StableDiffusionModel import StableDiffusionModel, StableDiffusionModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -142,7 +143,7 @@ class BaseStableDiffusionSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel, StableDiffusionXLModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -186,7 +187,7 @@ class BaseStableDiffusionXLSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 from random import Random
 
+import modules.util.multi_gpu_util as multi
 from modules.model.WuerstchenModel import WuerstchenModel, WuerstchenModelEmbedding
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.mixin.ModelSetupDebugMixin import ModelSetupDebugMixin
@@ -196,7 +197,7 @@ class BaseWuerstchenSetup(
             elif model.model_type.is_stable_cascade():
                 scaled_latent_image = latent_image
 
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.DiffusionScheduleCoefficients import DiffusionScheduleCoefficients
-from modules.util.enum.LossScaler import LossScaler
 from modules.util.enum.LossWeight import LossWeight
 from modules.util.loss.masked_loss import masked_losses
 from modules.util.loss.vb_loss import vb_losses
@@ -223,13 +222,6 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
             alphas_cumprod_fun: Callable[[Tensor, int], Tensor] | None = None,
     ) -> Tensor:
         loss_weight = batch['loss_weight']
-        batch_size_scale = \
-            1 if config.loss_scaler in [LossScaler.NONE, LossScaler.GRADIENT_ACCUMULATION] \
-                else config.batch_size
-        gradient_accumulation_steps_scale = \
-            1 if config.loss_scaler in [LossScaler.NONE, LossScaler.BATCH] \
-                else config.gradient_accumulation_steps
-
         if self.__coefficients is None and betas is not None:
             self.__coefficients = DiffusionScheduleCoefficients.from_betas(betas)
 
@@ -244,7 +236,7 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
                 losses = self.__unmasked_losses(batch, data, config)
 
         # Scale Losses by Batch and/or GA (if enabled)
-        losses = losses * batch_size_scale * gradient_accumulation_steps_scale
+        losses = losses * config.loss_scaler.get_scale(batch_size=config.batch_size, accumulation_steps=config.gradient_accumulation_steps)
 
         losses *= loss_weight.to(device=losses.device, dtype=losses.dtype)
 
@@ -270,13 +262,6 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
             sigmas: Tensor | None = None,
     ) -> Tensor:
         loss_weight = batch['loss_weight']
-        batch_size_scale = \
-            1 if config.loss_scaler in [LossScaler.NONE, LossScaler.GRADIENT_ACCUMULATION] \
-                else config.batch_size
-        gradient_accumulation_steps_scale = \
-            1 if config.loss_scaler in [LossScaler.NONE, LossScaler.BATCH] \
-                else config.gradient_accumulation_steps
-
         if self.__sigmas is None and sigmas is not None:
             num_timesteps = sigmas.shape[0]
             all_timesteps = torch.arange(start=1, end=num_timesteps + 1, step=1, dtype=torch.int32, device=sigmas.device)
@@ -291,7 +276,7 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
                 losses = self.__unmasked_losses(batch, data, config)
 
         # Scale Losses by Batch and/or GA (if enabled)
-        losses = losses * batch_size_scale * gradient_accumulation_steps_scale
+        losses = losses * config.loss_scaler.get_scale(config.batch_size, config.gradient_accumulation_steps)
 
         losses *= loss_weight.to(device=losses.device, dtype=losses.dtype)
 

--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -111,7 +111,7 @@ class PeftBase(nn.Module):
         return super().load_state_dict(state_dict, strict, assign)
 
     @abstractmethod
-    def initialize_weights(self):
+    def initialize_weights(self, device: torch.device, generator: torch.Generator):
         pass
 
     @abstractmethod
@@ -122,7 +122,7 @@ class PeftBase(nn.Module):
     def extract_from_module(self, base_module: nn.Module):
         pass
 
-    def create_layer(self) -> tuple[nn.Module, nn.Module]:
+    def create_layer(self, device: torch.device) -> tuple[nn.Module, nn.Module]:
         """Generic helper function for creating a PEFT layer, like LoRA.
 
         Creates down/up layer modules for the given layer type in the
@@ -131,7 +131,6 @@ class PeftBase(nn.Module):
         Does not perform initialization, as that usually depends on the PEFT
         method.
         """
-        device = self.orig_module.weight.device
         match self.orig_module:
             case nn.Linear():
                 in_features = self.orig_module.in_features
@@ -188,7 +187,7 @@ class PeftBase(nn.Module):
                     raise RuntimeError("A state dict must be loaded before one can be returned.")
                 return self._state_dict
 
-            def initialize_weights(self):
+            def initialize_weights(self, device: torch.device, generator: torch.Generator):
                 raise NotImplementedError("Should never be called on a dummy module.")
 
             def hook_to_module(self):
@@ -221,35 +220,42 @@ class LoHaModule(PeftBase):
     hada_w2_a: Tensor | None
     hada_w2_b: Tensor | None
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, rank: int, alpha: float):
+    def __init__(
+            self,
+            prefix: str,
+            orig_module: nn.Module | None,
+            rank: int,
+            alpha: float,
+            device: torch.device,
+            generator: torch.Generator,
+    ):
         super().__init__(prefix, orig_module)
         self.rank = rank
         self.dropout = Dropout(0)
-        self.register_buffer("alpha", torch.tensor(alpha))
+        self.register_buffer("alpha", torch.tensor(alpha, device=device))
         self.hada_w1_a = None
         self.hada_w1_b = None
         self.hada_w2_a = None
         self.hada_w2_b = None
 
         if orig_module is not None:
-            self.initialize_weights()
-            self.alpha = self.alpha.to(orig_module.weight.device)
+            self.initialize_weights(device, generator)
         self.alpha.requires_grad_(False)
 
-    def initialize_weights(self):
+    def initialize_weights(self, device: torch.device, generator: torch.Generator):
         self._initialized = True
 
-        hada_w1_b, hada_w1_a = self.create_layer()
-        hada_w2_b, hada_w2_a = self.create_layer()
+        hada_w1_b, hada_w1_a = self.create_layer(device=device)
+        hada_w2_b, hada_w2_a = self.create_layer(device=device)
         self.hada_w1_a = hada_w1_a.weight
         self.hada_w1_b = hada_w1_b.weight
         self.hada_w2_a = hada_w2_a.weight
         self.hada_w2_b = hada_w2_b.weight
 
-        nn.init.normal_(self.hada_w1_a, std=0.1)
-        nn.init.normal_(self.hada_w1_b, std=1)
+        nn.init.normal_(self.hada_w1_a, std=0.1, generator=generator)
+        nn.init.normal_(self.hada_w1_b, std=1, generator=generator)
         nn.init.constant_(self.hada_w2_a, 0)
-        nn.init.normal_(self.hada_w2_b, std=1)
+        nn.init.normal_(self.hada_w2_b, std=1, generator=generator)
 
     def check_initialized(self):
         super().check_initialized()
@@ -291,24 +297,31 @@ class LoRAModule(PeftBase):
     # optional members. This is because these members might not exist at
     # construction, but definitely exist by the time those methods are called.
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, rank: int, alpha: float):
+    def __init__(
+            self,
+            prefix: str,
+            orig_module: nn.Module | None,
+            rank: int,
+            alpha: float,
+            device: torch.device,
+            generator: torch.Generator,
+    ):
         super().__init__(prefix, orig_module)
 
         self.rank = rank
         self.dropout = Dropout(0)
-        self.register_buffer("alpha", torch.tensor(alpha))
+        self.register_buffer("alpha", torch.tensor(alpha, device=device))
         self.lora_down = None
         self.lora_up = None
 
         if orig_module is not None:
-            self.initialize_weights()
-            self.alpha = self.alpha.to(orig_module.weight.device)
+            self.initialize_weights(device, generator)
         self.alpha.requires_grad_(False)
 
-    def initialize_weights(self):
+    def initialize_weights(self, device: torch.device, generator: torch.Generator):
         self._initialized = True
-        self.lora_down, self.lora_up = self.create_layer()
-        nn.init.kaiming_uniform_(self.lora_down.weight, a=math.sqrt(5))
+        self.lora_down, self.lora_up = self.create_layer(device=device)
+        nn.init.kaiming_uniform_(self.lora_down.weight, a=math.sqrt(5), generator=generator)
         nn.init.zeros_(self.lora_up.weight)
 
     def check_initialized(self):
@@ -344,13 +357,13 @@ class DoRAModule(LoRAModule):
     def __init__(self, *args, **kwargs):
         self.dora_scale = None
         self.norm_epsilon = kwargs.pop('norm_epsilon', False)
-        self.train_device = kwargs.pop('train_device')
+        self.train_device = kwargs.get('device')
         super().__init__(*args, **kwargs)
 
-    def initialize_weights(self):
-        super().initialize_weights()
+    def initialize_weights(self, device: torch.device, generator: torch.Generator):
+        super().initialize_weights(device, generator)
 
-        orig_weight = get_unquantized_weight(self.orig_module, torch.float, self.train_device)
+        orig_weight = get_unquantized_weight(self.orig_module, torch.float, device)
 
         # Thanks to KohakuBlueLeaf once again for figuring out the shape
         # wrangling that works for both Linear and Convolutional layers. If you
@@ -362,7 +375,7 @@ class DoRAModule(LoRAModule):
                 dim=1, keepdim=True)
             .reshape(orig_weight.shape[1], *[1] * self.dora_num_dims)
             .transpose(1, 0)
-            .to(device=self.orig_module.weight.device)
+            .to(device=device)
         )
 
         del orig_weight
@@ -434,7 +447,6 @@ class LoRAModuleWrapper:
                 self.additional_args = [self.rank, self.alpha]
                 self.additional_kwargs = {
                     'norm_epsilon': config.lora_decompose_norm_epsilon,
-                    'train_device': torch.device(config.train_device),
                 }
             else:
                 self.klass = LoRAModule
@@ -447,16 +459,20 @@ class LoRAModuleWrapper:
             self.additional_args = [self.rank, self.alpha]
             self.additional_kwargs = {}
 
-        self.lora_modules = self.__create_modules(orig_module)
+        self.lora_modules = self.__create_modules(orig_module, device=torch.device(config.train_device))
 
-    def __create_modules(self, orig_module: nn.Module | None) -> dict[str, PeftBase]:
+    def __create_modules(self, orig_module: nn.Module | None, device: torch.device) -> dict[str, PeftBase]:
         lora_modules = {}
+
+        generator = torch.Generator(device=device)
+        generator.manual_seed(0)
 
         if orig_module is not None:
             for name, child_module in orig_module.named_modules():
                 if len(self.module_filter) == 0 or any(x in name for x in self.module_filter):
                     if isinstance(child_module, Linear | Conv2d):
-                        lora_modules[name] = self.klass(self.prefix + "." + name, child_module, *self.additional_args, **self.additional_kwargs)
+                        lora_modules[name] = self.klass(self.prefix + "." + name, child_module, *self.additional_args,
+                                                        **self.additional_kwargs, device=device, generator=generator)
 
         return lora_modules
 

--- a/modules/trainer/BaseTrainer.py
+++ b/modules/trainer/BaseTrainer.py
@@ -45,10 +45,6 @@ class BaseTrainer(
     def end(self):
         pass
 
-    @abstractmethod
-    def backup(self, train_progress: TrainProgress):
-        pass
-
     def create_model_loader(self) -> BaseModelLoader:
         return create.create_model_loader(self.config.model_type, self.config.training_method)
 

--- a/modules/trainer/CloudTrainer.py
+++ b/modules/trainer/CloudTrainer.py
@@ -13,7 +13,6 @@ from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.CloudAction import CloudAction
 from modules.util.enum.CloudType import CloudType
-from modules.util.TrainProgress import TrainProgress
 
 
 class CloudTrainer(BaseTrainer):
@@ -195,10 +194,3 @@ class CloudTrainer(BaseTrainer):
             return (Path(remote_dir,"remote") / path).as_posix()
         else:
             return ""
-
-
-    def backup(self, train_progress: TrainProgress):
-        pass
-
-    def save(self, train_progress: TrainProgress):
-        pass

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -7,6 +7,7 @@ import traceback
 from collections.abc import Callable
 from pathlib import Path
 
+import modules.util.multi_gpu_util as multi
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
 from modules.model.BaseModel import BaseModel
 from modules.modelLoader.BaseModelLoader import BaseModelLoader
@@ -20,6 +21,7 @@ from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.SampleConfig import SampleConfig
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_grad_scaler, enable_grad_scaling
+from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.FileType import FileType
 from modules.util.enum.ModelFormat import ModelFormat
 from modules.util.enum.TimeUnit import TimeUnit
@@ -62,11 +64,12 @@ class GenericTrainer(BaseTrainer):
     def __init__(self, config: TrainConfig, callbacks: TrainCallbacks, commands: TrainCommands):
         super().__init__(config, callbacks, commands)
 
-        tensorboard_log_dir = os.path.join(config.workspace_dir, "tensorboard")
-        os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
-        self.tensorboard = SummaryWriter(os.path.join(tensorboard_log_dir, f"{config.save_filename_prefix}{get_string_timestamp()}"))
-        if config.tensorboard:
-            super()._start_tensorboard()
+        if multi.is_master():
+            tensorboard_log_dir = os.path.join(config.workspace_dir, "tensorboard")
+            os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
+            self.tensorboard = SummaryWriter(os.path.join(tensorboard_log_dir, f"{config.save_filename_prefix}{get_string_timestamp()}"))
+            if config.tensorboard:
+                super()._start_tensorboard()
 
         self.model = None
         self.one_step_trained = False
@@ -74,10 +77,11 @@ class GenericTrainer(BaseTrainer):
         self.grad_hook_handles = []
 
     def start(self):
-        self.__save_config_to_workspace()
+        if multi.is_master():
+            self.__save_config_to_workspace()
 
-        if self.config.clear_cache_before_training and self.config.latent_caching:
-            self.__clear_cache()
+            if self.config.clear_cache_before_training and self.config.latent_caching:
+                self.__clear_cache()
 
         if self.config.train_dtype.enable_tf():
             torch.backends.cuda.matmul.allow_tf32 = True
@@ -197,10 +201,11 @@ class GenericTrainer(BaseTrainer):
             train_progress: TrainProgress,
             train_device: torch.device,
             sample_config_list: list[SampleConfig],
+            ema_applied: bool,
             folder_postfix: str = "",
             is_custom_sample: bool = False,
     ):
-        for i, sample_config in enumerate(sample_config_list):
+        for i, sample_config in multi.distributed_enumerate(sample_config_list, distribute=not self.config.samples_to_tensorboard and not ema_applied):
             if sample_config.enabled:
                 try:
                     safe_prompt = path_util.safe_filename(sample_config.prompt)
@@ -286,6 +291,9 @@ class GenericTrainer(BaseTrainer):
             is_custom_sample = True
 
         if self.model.ema:
+            #the EMA model only exists in the master process, so EMA sampling is done on one GPU only
+            #non-EMA sampling is done on all GPUs
+            assert multi.is_master() and self.config.ema != EMAMode.OFF
             self.model.ema.copy_ema_to(self.parameters, store_temp=True)
 
         self.__sample_loop(
@@ -293,18 +301,20 @@ class GenericTrainer(BaseTrainer):
             train_device=train_device,
             sample_config_list=sample_params_list,
             is_custom_sample=is_custom_sample,
+            ema_applied = self.config.ema != EMAMode.OFF
         )
 
         if self.model.ema:
             self.model.ema.copy_temp_to(self.parameters)
 
-        # ema-less sampling, if an ema model exists
-        if self.model.ema and not is_custom_sample and self.config.non_ema_sampling:
+        # ema-less sampling, if ema is enabled:
+        if self.config.ema != EMAMode.OFF and not is_custom_sample and self.config.non_ema_sampling:
             self.__sample_loop(
                 train_progress=train_progress,
                 train_device=train_device,
                 sample_config_list=sample_params_list,
                 folder_postfix=" - no-ema",
+                ema_applied = False,
             )
 
         self.model_setup.setup_train_device(self.model, self.config)
@@ -402,7 +412,7 @@ class GenericTrainer(BaseTrainer):
         if os.path.isfile(self.config.sample_definition_file_name):
             shutil.copy2(self.config.sample_definition_file_name, samples_path)
 
-    def backup(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
+    def __backup(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
         torch_gc()
 
         self.callbacks.on_update_status("creating backup")
@@ -449,7 +459,7 @@ class GenericTrainer(BaseTrainer):
 
         torch_gc()
 
-    def save(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
+    def __save(self, train_progress: TrainProgress, print_msg: bool = True, print_cb: Callable[[str], None] = print):
         torch_gc()
 
         self.callbacks.on_update_status("saving")
@@ -528,33 +538,50 @@ class GenericTrainer(BaseTrainer):
         )
 
     def __apply_fused_back_pass(self, scaler):
-        if self.config.optimizer.optimizer.supports_fused_back_pass() and self.config.optimizer.fused_back_pass:
+        fused_optimizer_step = self.config.optimizer.optimizer.supports_fused_back_pass() and self.config.optimizer.fused_back_pass
+        fused_reduce = self.config.multi_gpu and self.config.fused_gradient_reduce
+        if fused_optimizer_step:
             if self.config.gradient_accumulation_steps > 1:
-                print("Warning: activating fused_back_pass with gradient_accumulation_steps > 1 does not reduce VRAM usage.")
+                print("Warning: activating Fused Back Pass with Accumulation Steps > 1 does not reduce VRAM usage.")
+            if self.config.multi_gpu and not fused_reduce:
+                raise ValueError("if Fused Back Pass and Multi-GPU is enabled, Fused Reduce must also be enabled")
+        elif not fused_reduce:
+            return
 
-            for param_group in self.model.optimizer.param_groups:
-                for i, parameter in enumerate(param_group["params"]):
-                    # TODO: Find a better check instead of "parameter.requires_grad".
-                    #       This will break if the some parameters don't require grad during the first training step.
-                    if parameter.requires_grad:
-                        if scaler:
-                            def __grad_hook(tensor: Tensor, param_group=param_group, i=i):
-                                if self.__is_update_step(self.model.train_progress):
-                                    scaler.unscale_parameter_(tensor, self.model.optimizer)
-                                    if self.config.clip_grad_norm is not None:
-                                        nn.utils.clip_grad_norm_(tensor, self.config.clip_grad_norm)
-                                    scaler.maybe_opt_step_parameter(tensor, param_group, i, self.model.optimizer)
-                                    tensor.grad = None
-                        else:
-                            def __grad_hook(tensor: Tensor, param_group=param_group, i=i):
-                                if self.__is_update_step(self.model.train_progress):
-                                    if self.config.clip_grad_norm is not None:
-                                        nn.utils.clip_grad_norm_(tensor, self.config.clip_grad_norm)
-                                    self.model.optimizer.step_parameter(tensor, param_group, i)
-                                    tensor.grad = None
+        for param_group in self.model.optimizer.param_groups:
+            for i, parameter in enumerate(param_group["params"]):
+                # TODO: Find a better check instead of "parameter.requires_grad".
+                #       This will break if the some parameters don't require grad during the first training step.
+                if parameter.requires_grad:
+                    if scaler:
+                        def __optimizer_step(tensor: Tensor, param_group=param_group, i=i):
+                            scaler.unscale_parameter_(tensor, self.model.optimizer)
+                            if self.config.clip_grad_norm is not None:
+                                nn.utils.clip_grad_norm_(tensor, self.config.clip_grad_norm)
+                            scaler.maybe_opt_step_parameter(tensor, param_group, i, self.model.optimizer)
+                            tensor.grad = None
+                    else:
+                        def __optimizer_step(tensor: Tensor, param_group=param_group, i=i):
+                            if self.config.clip_grad_norm is not None:
+                                nn.utils.clip_grad_norm_(tensor, self.config.clip_grad_norm)
+                            self.model.optimizer.step_parameter(tensor, param_group, i)
+                            tensor.grad = None
 
-                        handle = parameter.register_post_accumulate_grad_hook(__grad_hook)
-                        self.grad_hook_handles.append(handle)
+                    def __grad_hook(tensor: Tensor, param_group=param_group, i=i):
+                        if self.__is_update_step(self.model.train_progress):
+                            if fused_reduce:
+                                multi.reduce_grads_mean(
+                                    [tensor],
+                                    after_reduce=__optimizer_step if fused_optimizer_step else None,
+                                    async_op=self.config.async_gradient_reduce,
+                                    max_buffer=self.config.async_gradient_reduce_buffer * 1024 * 1024,
+                                )
+                            elif fused_optimizer_step:
+                                __optimizer_step(tensor)
+
+                    handle = parameter.register_post_accumulate_grad_hook(__grad_hook)
+                    self.grad_hook_handles.append(handle)
+
 
     def __before_eval(self):
         # Special case for schedule-free optimizers, which need eval()
@@ -570,9 +597,10 @@ class GenericTrainer(BaseTrainer):
         train_progress = self.model.train_progress
 
         if self.config.only_cache:
-            self.callbacks.on_update_status("caching")
-            for _epoch in tqdm(range(train_progress.epoch, self.config.epochs, 1), desc="epoch"):
-                self.data_loader.get_data_set().start_next_epoch()
+            if multi.is_master():
+                self.callbacks.on_update_status("caching")
+                for _epoch in tqdm(range(train_progress.epoch, self.config.epochs, 1), desc="epoch"):
+                    self.data_loader.get_data_set().start_next_epoch()
             return
 
         scaler = create_grad_scaler() if enable_grad_scaling(self.config.train_dtype, self.parameters) else None
@@ -587,15 +615,25 @@ class GenericTrainer(BaseTrainer):
         accumulated_loss = 0.0
         ema_loss = None
         ema_loss_steps = 0
-        for _epoch in tqdm(range(train_progress.epoch, self.config.epochs, 1), desc="epoch"):
+        epochs = range(train_progress.epoch, self.config.epochs, 1)
+        for _epoch in tqdm(epochs, desc="epoch") if multi.is_master() else epochs:
             self.callbacks.on_update_status("starting epoch/caching")
 
-            if self.config.latent_caching:
-                self.data_loader.get_data_set().start_next_epoch()
-                self.model_setup.setup_train_device(self.model, self.config)
-            else:
-                self.model_setup.setup_train_device(self.model, self.config)
-                self.data_loader.get_data_set().start_next_epoch()
+            #call start_next_epoch with only one process at first, because it might write to the cache. All subsequent processes can read in parallel:
+            for _ in multi.master_first():
+                if self.config.latent_caching:
+                    self.data_loader.get_data_set().start_next_epoch()
+                    self.model_setup.setup_train_device(self.model, self.config)
+                else:
+                    self.model_setup.setup_train_device(self.model, self.config)
+                    self.data_loader.get_data_set().start_next_epoch()
+
+            #TODO either remove (if we are reasonably sure this doesn't happen), or add an interval to TrainConfig:
+            #divergence = multi.parameter_divergence(self.model.parameters.parameters())
+            #if multi.is_enabled() and multi.is_master():
+            #    self.tensorboard.add_scalar("parameter divergence", divergence, train_progress.global_step)
+            #    if divergence > 0:
+            #        print(f"\n\nWARNING: Parameter divergence between GPUs of {divergence}\n\n")
 
             # Special case for schedule-free optimizers, which need train()
             # called before training. Can and should move this to a callback
@@ -622,14 +660,18 @@ class GenericTrainer(BaseTrainer):
                 )
 
             current_epoch_length = self.data_loader.get_data_set().approximate_length()
-            step_tqdm = tqdm(self.data_loader.get_data_loader(), desc="step", total=current_epoch_length,
-                             initial=train_progress.epoch_step)
-            for batch in step_tqdm:
+
+            if multi.is_master():
+                batches = step_tqdm = tqdm(self.data_loader.get_data_loader(), desc="step", total=current_epoch_length,
+                                 initial=train_progress.epoch_step)
+            else:
+                batches = self.data_loader.get_data_loader()
+            for batch in batches:
+                multi.sync_commands(self.commands)
                 if self.__needs_sample(train_progress) or self.commands.get_and_reset_sample_default_command():
                     self.__enqueue_sample_during_training(
                         lambda: self.__sample_during_training(train_progress, train_device)
                     )
-
                 if self.__needs_backup(train_progress):
                     self.commands.backup()
 
@@ -651,19 +693,14 @@ class GenericTrainer(BaseTrainer):
 
                 if not has_gradient:
                     self.__execute_sample_during_training()
-                    transferred_to_temp_device = False
-
-                    if self.commands.get_and_reset_backup_command():
+                    backup = self.commands.get_and_reset_backup_command()
+                    save = self.commands.get_and_reset_save_command()
+                    if multi.is_master() and (backup or save):
                         self.model.to(self.temp_device)
-                        self.backup(train_progress, True, step_tqdm.write)
-                        transferred_to_temp_device = True
-
-                    if self.commands.get_and_reset_save_command():
-                        self.model.to(self.temp_device)
-                        self.save(train_progress, True, step_tqdm.write)
-                        transferred_to_temp_device = True
-
-                    if transferred_to_temp_device:
+                        if backup:
+                            self.__backup(train_progress, True, step_tqdm.write)
+                        if save:
+                            self.__save(train_progress, True, step_tqdm.write)
                         self.model_setup.setup_train_device(self.model, self.config)
 
                 self.callbacks.on_update_status("training")
@@ -680,9 +717,16 @@ class GenericTrainer(BaseTrainer):
                         loss.backward()
 
                     has_gradient = True
-                    accumulated_loss += loss.item()
+                    detached_loss = loss.detach()
+                    multi.reduce_tensor_mean(detached_loss)
+                    accumulated_loss += detached_loss.item()
 
                     if self.__is_update_step(train_progress):
+                        if self.config.fused_gradient_reduce:
+                            multi.finish_async()
+                        else:
+                            multi.reduce_grads_mean(self.model.parameters.parameters())
+
                         if scaler and self.config.optimizer.optimizer.supports_fused_back_pass() and self.config.optimizer.fused_back_pass:
                             scaler.step_after_unscale_parameter_(self.model.optimizer)
                             scaler.update()
@@ -701,24 +745,27 @@ class GenericTrainer(BaseTrainer):
                         self.model.optimizer.zero_grad(set_to_none=True)
                         has_gradient = False
 
-                        self.model_setup.report_to_tensorboard(
-                            self.model, self.config, lr_scheduler, self.tensorboard
-                        )
+                        if multi.is_master():
+                            self.model_setup.report_to_tensorboard(
+                                self.model, self.config, lr_scheduler, self.tensorboard
+                            )
 
-                        self.tensorboard.add_scalar("loss/train_step", accumulated_loss, train_progress.global_step)
-                        ema_loss = ema_loss or accumulated_loss
-                        ema_loss_steps += 1
-                        ema_loss_decay = min(0.99, 1 - (1 / ema_loss_steps))
-                        ema_loss = (ema_loss * ema_loss_decay) + (accumulated_loss * (1 - ema_loss_decay))
-                        step_tqdm.set_postfix({
-                            'loss': accumulated_loss,
-                            'smooth loss': ema_loss,
-                        })
-                        self.tensorboard.add_scalar("smooth_loss/train_step", ema_loss, train_progress.global_step)
+                            self.tensorboard.add_scalar("loss/train_step", accumulated_loss, train_progress.global_step)
+                            ema_loss = ema_loss or accumulated_loss
+                            ema_loss_steps += 1
+                            ema_loss_decay = min(0.99, 1 - (1 / ema_loss_steps))
+                            ema_loss = (ema_loss * ema_loss_decay) + (accumulated_loss * (1 - ema_loss_decay))
+                            step_tqdm.set_postfix({
+                                'loss': accumulated_loss,
+                                'smooth loss': ema_loss,
+                            })
+                            self.tensorboard.add_scalar("smooth_loss/train_step", ema_loss, train_progress.global_step)
+
                         accumulated_loss = 0.0
-
                         self.model_setup.after_optimizer_step(self.model, self.config, train_progress)
+
                         if self.model.ema:
+                            assert multi.is_master()
                             update_step = train_progress.global_step // self.config.gradient_accumulation_steps
                             self.tensorboard.add_scalar(
                                 "ema_decay",
@@ -732,7 +779,7 @@ class GenericTrainer(BaseTrainer):
 
                         self.one_step_trained = True
 
-                if self.config.validation:
+                if self.config.validation and multi.is_master():
                     self.__validate(train_progress)
 
                 train_progress.next_step(self.config.batch_size)
@@ -751,40 +798,43 @@ class GenericTrainer(BaseTrainer):
         if self.one_step_trained:
             self.model.to(self.temp_device)
 
-            if self.config.backup_before_save:
-                self.backup(self.model.train_progress)
+            if self.config.backup_before_save and multi.is_master():
+                self.__backup(self.model.train_progress)
+
             # Special case for schedule-free optimizers.
             if self.config.optimizer.optimizer.is_schedule_free:
                 torch.clear_autocast_cache()
                 self.model.optimizer.eval()
 
-            self.callbacks.on_update_status("saving the final model")
+            if multi.is_master():
+                self.callbacks.on_update_status("saving the final model")
 
-            if self.model.ema:
-                self.model.ema.copy_ema_to(self.parameters, store_temp=False)
-            if os.path.isdir(self.config.output_model_destination) and self.config.output_model_format.is_single_file():
-                save_path = os.path.join(
-                    self.config.output_model_destination,
-                    f"{self.config.save_filename_prefix}{get_string_timestamp()}{self.config.output_model_format.file_extension()}"
+                if self.model.ema:
+                    self.model.ema.copy_ema_to(self.parameters, store_temp=False)
+                if os.path.isdir(self.config.output_model_destination) and self.config.output_model_format.is_single_file():
+                    save_path = os.path.join(
+                        self.config.output_model_destination,
+                        f"{self.config.save_filename_prefix}{get_string_timestamp()}{self.config.output_model_format.file_extension()}"
+                    )
+                else:
+                    save_path = self.config.output_model_destination
+                print("Saving " + save_path)
+
+                self.model_saver.save(
+                    model=self.model,
+                    model_type=self.config.model_type,
+                    output_model_format=self.config.output_model_format,
+                    output_model_destination=save_path,
+                    dtype=self.config.output_dtype.torch_dtype()
                 )
-            else:
-                save_path = self.config.output_model_destination
-            print("Saving " + save_path)
-
-            self.model_saver.save(
-                model=self.model,
-                model_type=self.config.model_type,
-                output_model_format=self.config.output_model_format,
-                output_model_destination=save_path,
-                dtype=self.config.output_dtype.torch_dtype()
-            )
         elif self.model is not None:
             self.model.to(self.temp_device)
 
-        self.tensorboard.close()
+        if multi.is_master():
+            self.tensorboard.close()
 
-        if self.config.tensorboard:
-            super()._stop_tensorboard()
+            if self.config.tensorboard:
+                super()._stop_tensorboard()
 
         for handle in self.grad_hook_handles:
             handle.remove()

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -6,8 +6,6 @@ from collections.abc import Callable
 from pathlib import Path
 from tkinter import filedialog
 
-from modules.trainer.CloudTrainer import CloudTrainer
-from modules.trainer.GenericTrainer import GenericTrainer
 from modules.ui.AdditionalEmbeddingsTab import AdditionalEmbeddingsTab
 from modules.ui.CaptionUI import CaptionUI
 from modules.ui.CloudTab import CloudTab
@@ -21,6 +19,7 @@ from modules.ui.SamplingTab import SamplingTab
 from modules.ui.TopBar import TopBar
 from modules.ui.TrainingTab import TrainingTab
 from modules.ui.VideoToolUI import VideoToolUI
+from modules.util import create
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.TrainConfig import TrainConfig
@@ -33,7 +32,6 @@ from modules.util.TrainProgress import TrainProgress
 from modules.util.ui import components
 from modules.util.ui.ui_utils import set_window_icon
 from modules.util.ui.UIState import UIState
-from modules.zluda import ZLUDA
 
 import torch
 
@@ -175,9 +173,9 @@ class TrainUI(ctk.CTk):
         components.dir_entry(frame, 0, 1, self.ui_state, "workspace_dir")
 
         # cache dir
-        components.label(frame, 1, 0, "Cache Directory",
+        components.label(frame, 0, 2, "Cache Directory",
                          tooltip="The directory where cached data is saved")
-        components.dir_entry(frame, 1, 1, self.ui_state, "cache_dir")
+        components.dir_entry(frame, 0, 3, self.ui_state, "cache_dir")
 
         # continue from previous backup
         components.label(frame, 2, 0, "Continue from last backup",
@@ -185,18 +183,18 @@ class TrainUI(ctk.CTk):
         components.switch(frame, 2, 1, self.ui_state, "continue_last_backup")
 
         # only cache
-        components.label(frame, 3, 0, "Only Cache",
+        components.label(frame, 2, 2, "Only Cache",
                          tooltip="Only populate the cache, without any training")
-        components.switch(frame, 3, 1, self.ui_state, "only_cache")
+        components.switch(frame, 2, 3, self.ui_state, "only_cache")
 
         # debug
         components.label(frame, 4, 0, "Debug mode",
                          tooltip="Save debug information during the training into the debug directory")
         components.switch(frame, 4, 1, self.ui_state, "debug_mode")
 
-        components.label(frame, 5, 0, "Debug Directory",
+        components.label(frame, 4, 2, "Debug Directory",
                          tooltip="The directory where debug data is saved")
-        components.dir_entry(frame, 5, 1, self.ui_state, "debug_dir")
+        components.dir_entry(frame, 4, 3, self.ui_state, "debug_dir")
 
         # tensorboard
         components.label(frame, 6, 0, "Tensorboard",
@@ -215,9 +213,9 @@ class TrainUI(ctk.CTk):
                          tooltip="Enable validation steps and add new graph in tensorboard")
         components.switch(frame, 8, 1, self.ui_state, "validation")
 
-        components.label(frame, 9, 0, "Validate after",
+        components.label(frame, 8, 2, "Validate after",
                          tooltip="The interval used when validate training")
-        components.time_entry(frame, 9, 1, self.ui_state, "validate_after", "validate_after_unit")
+        components.time_entry(frame, 8, 3, self.ui_state, "validate_after", "validate_after_unit")
 
         # device
         components.label(frame, 10, 0, "Dataloader Threads",
@@ -225,12 +223,33 @@ class TrainUI(ctk.CTk):
         components.entry(frame, 10, 1, self.ui_state, "dataloader_threads")
 
         components.label(frame, 11, 0, "Train Device",
-                         tooltip="The device used for training. Can be \"cuda\", \"cuda:0\", \"cuda:1\" etc. Default:\"cuda\"")
+                         tooltip="The device used for training. Can be \"cuda\", \"cuda:0\", \"cuda:1\" etc. Default:\"cuda\". Must be \"cuda\" for multi-GPU training.")
         components.entry(frame, 11, 1, self.ui_state, "train_device")
 
-        components.label(frame, 12, 0, "Temp Device",
+        components.label(frame, 12, 0, "Multi-GPU",
+                         tooltip="Enable multi-GPU training")
+        components.switch(frame, 12, 1, self.ui_state, "multi_gpu")
+        components.label(frame, 12, 2, "Device Indexes",
+                         tooltip="Multi-GPU: A comma-separated list of device indexes. If empty, all your GPUs are used. With a list such as \"0,1,3,4\" you can omit a GPU, for example an on-board graphics GPU.")
+        components.entry(frame, 12, 3, self.ui_state, "device_indexes")
+
+        components.label(frame, 13, 0, "Sequential model setup",
+                         tooltip="Multi-GPU: If enabled, loading and setting up the model is done for each GPU one after the other. This is slower, but can reduce peak RAM usage.")
+        components.switch(frame, 13, 1, self.ui_state, "sequential_model_setup")
+        components.label(frame, 13, 2, "Fused Gradient Reduce",
+                         tooltip="Multi-GPU: Gradient synchronisation during the backward pass. Can be more efficient, especially with Async Gradient Reduce")
+        components.switch(frame, 13, 3, self.ui_state, "fused_gradient_reduce")
+
+        components.label(frame, 14, 0, "Async Gradient Reduce",
+                         tooltip="Multi-GPU: Asynchroniously start the gradient reduce operations during the backward pass. Can be more efficient, but requires some VRAM.")
+        components.switch(frame, 14, 1, self.ui_state, "async_gradient_reduce")
+        components.label(frame, 14, 2, "Buffer size (MB)",
+                         tooltip="Multi-GPU: Maximum VRAM for \"Async Gradient Reduce\", in megabytes. A multiple of this value can be needed if combined with \"Fused Back Pass\" and/or \"Layer offload fraction\"")
+        components.entry(frame, 14, 3, self.ui_state, "async_gradient_reduce_buffer")
+
+        components.label(frame, 15, 0, "Temp Device",
                          tooltip="The device used to temporarily offload models while they are not used. Default:\"cpu\"")
-        components.entry(frame, 12, 1, self.ui_state, "temp_device")
+        components.entry(frame, 15, 1, self.ui_state, "temp_device")
 
         frame.pack(fill="both", expand=1)
         return frame
@@ -591,12 +610,7 @@ class TrainUI(ctk.CTk):
             on_update_status=self.on_update_status,
         )
 
-        if self.train_config.cloud.enabled:
-            trainer = CloudTrainer(self.train_config, self.training_callbacks, self.training_commands, reattach=self.cloud_tab.reattach)
-        else:
-            ZLUDA.initialize_devices(self.train_config)
-            trainer = GenericTrainer(self.train_config, self.training_callbacks, self.training_commands)
-
+        trainer = create.create_trainer(self.train_config, self.training_callbacks, self.training_commands, reattach=self.cloud_tab.reattach)
         try:
             trainer.start()
             if self.train_config.cloud.enabled:

--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -558,6 +558,8 @@ class LayerOffloadConductor:
 
     __is_active: bool
 
+    __deferred_layers: list[int]
+
     def __init__(
             self,
             module: nn.Module,
@@ -605,6 +607,8 @@ class LayerOffloadConductor:
         self.__keep_graph = False
 
         self.__is_active = False
+
+        self.__deferred_layers = []
 
     def offload_activated(self) -> bool:
         return self.__offload_activations or self.__offload_layers
@@ -740,6 +744,7 @@ class LayerOffloadConductor:
         if self.__offload_layers:
             self.__wait_layer_transfer(layer_index)
 
+            self.__schedule_deferred_layers_to_temp(except_layer=layer_index)
             for i in self.__offload_strategy.get_layers_to_offload(
                     layer_index=layer_index,
                     is_forward=self.__is_forward_pass,
@@ -853,6 +858,14 @@ class LayerOffloadConductor:
 
         allocator_fn = allocator.allocate_like if allocator is not None else None
 
+        if not is_forward and device_equals(device, self.__temp_device):
+            layer = self.__layers[layer_index]
+            for module in layer.modules():
+                for parameter in module.parameters():
+                    if parameter.grad is not None:
+                        self.__deferred_layers.append(layer_index)
+                        return
+
         with create_stream_context(self.__layer_transfer_stream):
             self.__wait_layer_train(layer_index)
             layer = self.__layers[layer_index]
@@ -869,6 +882,18 @@ class LayerOffloadConductor:
                 log(f"schedule layer {layer_index} to {str(device)}")
 
             self.__layer_device_map[layer_index] = device
+
+    def __schedule_deferred_layers_to_temp(
+            self,
+            except_layer: int,
+    ):
+        layers = self.__deferred_layers
+        self.__deferred_layers = []
+        for layer_index in layers:
+            if layer_index == except_layer:
+                #don't offload this layer, because it is needed now #TODO can this even happen?
+                continue
+            self.__schedule_layer_to(layer_index, device=self.__temp_device, is_forward=False)
 
     def __schedule_activations_to_device(
             self,

--- a/modules/util/NamedParameterGroup.py
+++ b/modules/util/NamedParameterGroup.py
@@ -2,7 +2,6 @@ from collections.abc import Iterable
 from functools import cached_property
 
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.enum.LearningRateScaler import LearningRateScaler
 
 from torch.nn import Parameter
 
@@ -37,19 +36,9 @@ class NamedParameterGroupCollection:
         parameters = []
 
         for group in self.__groups:
-            batch_size_scale = 1 if config.learning_rate_scaler in [
-                LearningRateScaler.NONE,
-                LearningRateScaler.GRADIENT_ACCUMULATION,
-            ] else config.batch_size
-
-            gradient_accumulation_steps_scale = 1 if config.learning_rate_scaler in [
-                LearningRateScaler.NONE,
-                LearningRateScaler.BATCH,
-            ] else config.gradient_accumulation_steps
-
             # Determine the learning rate
             lr = group.learning_rate if group.learning_rate is not None else config.learning_rate
-            lr = lr * ((batch_size_scale * gradient_accumulation_steps_scale) ** 0.5)
+            lr = lr * ((config.learning_rate_scaler.get_scale(config.batch_size, config.gradient_accumulation_steps)) ** 0.5)
 
             # Create a parameter group for the text encoder
             parameters.append({

--- a/modules/util/bf16_stochastic_rounding.py
+++ b/modules/util/bf16_stochastic_rounding.py
@@ -1,6 +1,11 @@
 import torch
 from torch import Tensor
 
+generator = None
+
+def init_stochastic_rounding():
+    global generator
+    generator = None
 
 def copy_stochastic_(target: Tensor, source: Tensor):
     """
@@ -10,12 +15,20 @@ def copy_stochastic_(target: Tensor, source: Tensor):
         target: the target tensor with dtype=bfloat16
         source: the target tensor with dtype=float32
     """
+
+    global generator
+    if generator is None:
+        generator = torch.Generator(device = source.device)
+        generator.manual_seed(0)
+
     # create a random 16 bit integer
-    result = torch.randint_like(
-        source,
+    result = torch.randint(
+        size=source.shape,
+        device=source.device,
         dtype=torch.int32,
         low=0,
         high=(1 << 16),
+        generator=generator,
     )
 
     # add the random number to the lower 16 bit of the mantissa

--- a/modules/util/commands/TrainCommands.py
+++ b/modules/util/commands/TrainCommands.py
@@ -76,3 +76,15 @@ class TrainCommands:
         save_command = self.__save_command
         self.__save_command = False
         return save_command
+
+    def merge(self, other):
+        if other.get_stop_command():
+            self.stop()
+        for entry in other.get_and_reset_sample_custom_commands():
+            self.sample_custom(entry)
+        if other.get_and_reset_sample_default_command():
+            self.sample_default()
+        if other.get_and_reset_backup_command():
+            self.backup()
+        if other.get_and_reset_save_command():
+            self.save()

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -278,6 +278,14 @@ class TrainConfig(BaseConfig):
     continue_last_backup: bool
     include_train_config: ConfigPart
 
+    # multi-GPU
+    multi_gpu: bool
+    device_indexes: str
+    sequential_model_setup: bool
+    fused_gradient_reduce: bool
+    async_gradient_reduce: bool
+    async_gradient_reduce_buffer: int
+
     # model settings
     base_model_name: str
     weight_dtype: DataType
@@ -758,6 +766,14 @@ class TrainConfig(BaseConfig):
         data.append(("validate_after_unit", TimeUnit.EPOCH, TimeUnit, False))
         data.append(("continue_last_backup", False, bool, False))
         data.append(("include_train_config", ConfigPart.NONE, ConfigPart, False))
+
+        #multi-GPU
+        data.append(("multi_gpu", False, bool, False))
+        data.append(("device_indexes", "", str, False))
+        data.append(("sequential_model_setup", False, bool, False))
+        data.append(("fused_gradient_reduce", True, bool, False))
+        data.append(("async_gradient_reduce", True, bool, False))
+        data.append(("async_gradient_reduce_buffer", 100, int, False))
 
         # model settings
         data.append(("base_model_name", "stable-diffusion-v1-5/stable-diffusion-v1-5", str, False))

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -100,6 +100,7 @@ from modules.modelSetup.WuerstchenEmbeddingSetup import WuerstchenEmbeddingSetup
 from modules.modelSetup.WuerstchenFineTuneSetup import WuerstchenFineTuneSetup
 from modules.modelSetup.WuerstchenLoRASetup import WuerstchenLoRASetup
 from modules.module.EMAModule import EMAModuleWrapper
+from modules.util.bf16_stochastic_rounding import init_stochastic_rounding
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.LearningRateScheduler import LearningRateScheduler
@@ -418,6 +419,9 @@ def create_optimizer(
             raise RuntimeError('layer offloading can only be used for fine tuning when using an optimizer that supports "fused_back_pass"')
 
     parameters = parameter_group_collection.parameters_for_optimizer(config)
+
+    if optimizer_config.stochastic_rounding:
+        init_stochastic_rounding()
 
     match config.optimizer.optimizer:
 

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -101,6 +101,8 @@ from modules.modelSetup.WuerstchenFineTuneSetup import WuerstchenFineTuneSetup
 from modules.modelSetup.WuerstchenLoRASetup import WuerstchenLoRASetup
 from modules.module.EMAModule import EMAModuleWrapper
 from modules.util.bf16_stochastic_rounding import init_stochastic_rounding
+from modules.util.callbacks.TrainCallbacks import TrainCallbacks
+from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.LearningRateScheduler import LearningRateScheduler
@@ -122,6 +124,7 @@ from modules.util.optimizer.adafactor_extensions import patch_adafactor
 from modules.util.optimizer.adam_extensions import patch_adam
 from modules.util.optimizer.adamw_extensions import patch_adamw
 from modules.util.TrainProgress import TrainProgress
+from modules.zluda import ZLUDA
 
 import torch
 from torch.nn import Parameter
@@ -1345,3 +1348,21 @@ def create_noise_scheduler(
         scheduler.set_timesteps(num_inference_timesteps)
 
     return scheduler
+
+def create_trainer(
+        config: TrainConfig,
+        callbacks: TrainCallbacks,
+        commands: TrainCommands,
+        reattach: bool = False,
+):
+    if config.cloud.enabled:
+        from modules.trainer.CloudTrainer import CloudTrainer
+        trainer = CloudTrainer(config, callbacks, commands, reattach=reattach)
+    elif config.multi_gpu:
+        from modules.trainer.MultiTrainer import MultiTrainer
+        trainer = MultiTrainer(config, callbacks, commands)
+    else:
+        ZLUDA.initialize_devices(config)
+        from modules.trainer.GenericTrainer import GenericTrainer
+        trainer = GenericTrainer(config, callbacks, commands)
+    return trainer

--- a/modules/util/enum/LearningRateScaler.py
+++ b/modules/util/enum/LearningRateScaler.py
@@ -1,11 +1,32 @@
 from enum import Enum
 
+import modules.util.multi_gpu_util as multi
+
 
 class LearningRateScaler(Enum):
     NONE = 'NONE'
     BATCH = 'BATCH'
+    GLOBAL_BATCH = 'GLOBAL_BATCH'
     GRADIENT_ACCUMULATION = 'GRADIENT_ACCUMULATION'
     BOTH = 'BOTH'
+    GLOBAL_BOTH = 'GLOBAL_BOTH'
 
     def __str__(self):
         return self.value
+
+    def get_scale(self, batch_size: int, accumulation_steps: int) -> int:
+        match self:
+            case LearningRateScaler.NONE:
+                return 1
+            case LearningRateScaler.BATCH:
+                return batch_size
+            case LearningRateScaler.GLOBAL_BATCH:
+                return batch_size * multi.world_size()
+            case LearningRateScaler.GRADIENT_ACCUMULATION:
+                return accumulation_steps
+            case LearningRateScaler.BOTH:
+                return accumulation_steps * batch_size
+            case LearningRateScaler.GLOBAL_BOTH:
+                return accumulation_steps * batch_size * multi.world_size()
+            case _:
+                raise ValueError

--- a/modules/util/enum/LossScaler.py
+++ b/modules/util/enum/LossScaler.py
@@ -1,11 +1,32 @@
 from enum import Enum
 
+import modules.util.multi_gpu_util as multi
+
 
 class LossScaler(Enum):
     NONE = 'NONE'
     BATCH = 'BATCH'
+    GLOBAL_BATCH = 'GLOBAL_BATCH'
     GRADIENT_ACCUMULATION = 'GRADIENT_ACCUMULATION'
     BOTH = 'BOTH'
+    GLOBAL_BOTH = 'GLOBAL_BOTH'
 
     def __str__(self):
         return self.value
+
+    def get_scale(self, batch_size: int, accumulation_steps: int) -> int:
+        match self:
+            case LossScaler.NONE:
+                return 1
+            case LossScaler.BATCH:
+                return batch_size
+            case LossScaler.GLOBAL_BATCH:
+                return batch_size * multi.world_size()
+            case LossScaler.GRADIENT_ACCUMULATION:
+                return accumulation_steps
+            case LossScaler.BOTH:
+                return accumulation_steps * batch_size
+            case LossScaler.GLOBAL_BOTH:
+                return accumulation_steps * batch_size * multi.world_size()
+            case _:
+                raise ValueError

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -1,3 +1,4 @@
+import modules.util.multi_gpu_util as multi
 from modules.model.BaseModel import BaseModel
 from modules.util import create
 from modules.util.config.TrainConfig import TrainConfig, TrainOptimizerConfig
@@ -59,7 +60,10 @@ def init_model_parameters(
         optimizer_to_device_(model.optimizer, train_device)
     model.optimizer_state_dict = None
 
-    model.ema = create.create_ema(parameters.parameters(), model.ema_state_dict, model.train_config)
+    if multi.is_master():
+        model.ema = create.create_ema(parameters.parameters(), model.ema_state_dict, model.train_config)
+    else:
+        model.ema = None
     model.ema_state_dict = None
 
     model.param_group_mapping = parameters.unique_name_mapping

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -30,7 +30,7 @@ pooch==1.8.2
 open-clip-torch==2.30.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@2c67a5a#egg=mgds
+-e git+https://github.com/dxqbYD/mgds.git@multi#egg=mgds
 
 # optimizers
 dadaptation==3.2 # dadaptation optimizers

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,7 +4,7 @@ script_imports()
 
 import json
 
-from modules.trainer.GenericTrainer import GenericTrainer
+from modules.util import create
 from modules.util.args.TrainArgs import TrainArgs
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
@@ -29,7 +29,7 @@ def main():
         if args.secrets_path is not None:
             raise
 
-    trainer = GenericTrainer(train_config, callbacks, commands)
+    trainer = create.create_trainer(train_config, callbacks, commands)
 
     trainer.start()
 


### PR DESCRIPTION
**Multi-GPU support for OneTrainer**

This is a draft, but it is intended to be feature-complete and work with all models, optimizations and other parameters OT has to offer.

Some basic tests have been done to ensure that multi-GPU training learns equally well as single GPU training, by comparing

- validation loss of training on 4 GPUs
- with training on 1 GPU, but with 4x the batch size
- and with training on 1 GPU, but 4x the gradient accumulation

More testing is necessary though.

Performance impact for LoRA training is negligable, meaning that 4 GPUs train as fast as 1 GPU but with 4x the batch size:
![grafik](https://github.com/user-attachments/assets/6a64da80-1c5f-4a94-8cc5-f3c89caa030e)

For full fine-tuning a model as large as Flux there is some performance impact. A minimum local batch size of 4 to 8 is required for it to make sense:
![grafik](https://github.com/user-attachments/assets/1276ea89-fa2b-4793-af3e-929f2a58b548)

Or better hardware: This test has been done on A5000s, which are older PCIe cards similar to 3090s, connected through PIX/PXB. If anyone has access to high-end hardware with NVLink connections it would be interesting to see the remaining performance impact on full finetuning.

Multi-GPU training *should* also work on Windows (even though less optimized, because NVIDIA nccl is not available for windows), but I have no way to test that. If anyone has a windows machine with 2 GPUs at home please confirm.

This PR includes https://github.com/Nerogar/OneTrainer/pull/803 and https://github.com/Nerogar/OneTrainer/pull/804
