### PR TITLE
Validation timesteps

### DIFF
--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -67,8 +67,7 @@ class BaseModelSetup(
             batch: dict,
             config: TrainConfig,
             train_progress: TrainProgress,
-            *,
-            deterministic: bool = False,
+            seed: int,
     ) -> dict:
         pass
 
@@ -80,6 +79,16 @@ class BaseModelSetup(
             data: dict,
             config: TrainConfig,
     ) -> Tensor:
+        pass
+
+    @abstractmethod
+    def calculate_validation_losses(
+            self,
+            model: BaseModel,
+            batch: dict,
+            config: TrainConfig,
+            train_progress: TrainProgress,
+    ) -> dict:
         pass
 
     @abstractmethod

--- a/modules/modelSetup/mixin/ModelSetupText2ImageMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupText2ImageMixin.py
@@ -1,0 +1,53 @@
+from abc import ABCMeta, abstractmethod
+
+from modules.model.BaseModel import BaseModel
+from modules.util.config.TrainConfig import TrainConfig
+from modules.util.TrainProgress import TrainProgress
+
+import torch
+from torch import Tensor
+
+
+class ModelSetupText2ImageMixin(
+    metaclass=ABCMeta,
+):
+    @abstractmethod
+    def predict(
+            self,
+            model: BaseModel,
+            batch: dict,
+            config: TrainConfig,
+            train_progress: TrainProgress,
+            seed: int,
+            *,
+            #extend signature of BaseModelSetup.predict() by one parameter only known to image models:
+            timestep: Tensor = None,
+    ) -> dict:
+        pass
+
+    @abstractmethod
+    def calculate_loss(
+            self,
+            model: BaseModel,
+            batch: dict,
+            data: dict,
+            config: TrainConfig,
+    ) -> Tensor:
+        pass
+
+    @torch.no_grad()
+    def calculate_validation_losses(
+            self,
+            model: BaseModel,
+            batch: dict,
+            config: TrainConfig,
+            train_progress: TrainProgress,
+    ) -> dict:
+        losses = {}
+        tasks = [int(x) for x in config.validation_timesteps.split(',')]
+        for task in tasks:
+            timestep=torch.tensor([task], dtype=torch.long, device=config.train_device)
+            model_output_data = self.predict(model, batch, config, train_progress, seed=0, timestep=timestep)
+            loss = self.calculate_loss(model, batch, model_output_data, config)
+            losses[task] = loss.item()
+        return losses

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -214,6 +214,9 @@ class TrainUI(ctk.CTk):
         components.label(frame, 8, 0, "Validation",
                          tooltip="Enable validation steps and add new graph in tensorboard")
         components.switch(frame, 8, 1, self.ui_state, "validation")
+        components.label(frame, 8, 2, "Validation Timesteps",
+                         tooltip="Comma-separated list of timesteps that are used for validation, between 0 and 999. High values determine the image composition, low values the details.")
+        components.entry(frame, 8, 3, self.ui_state, "validation_timesteps")
 
         components.label(frame, 9, 0, "Validate after",
                          tooltip="The interval used when validate training")

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -273,6 +273,7 @@ class TrainConfig(BaseConfig):
     tensorboard_expose: bool
     tensorboard_port: str
     validation: bool
+    validation_timesteps: str
     validate_after: float
     validate_after_unit: TimeUnit
     continue_last_backup: bool
@@ -755,6 +756,7 @@ class TrainConfig(BaseConfig):
         data.append(("tensorboard_expose", False, bool, False))
         data.append(("tensorboard_port", 6006, int, False))
         data.append(("validation", False, bool, False))
+        data.append(("validation_timesteps", "500", str, False))
         data.append(("validate_after", 1, int, False))
         data.append(("validate_after_unit", TimeUnit.EPOCH, TimeUnit, False))
         data.append(("continue_last_backup", False, bool, False))


### PR DESCRIPTION
Implementing the conclusions of this thread: https://github.com/Nerogar/OneTrainer/issues/772

Summarized:

- Validation on timestep 500 is not ideal, but hardcoded currently
- Choosing validation timesteps from a distribution is not good either, especially for small validation sets
- [X] let the user choose
- There is no meaningful way to average the loss of different timesteps
 - [X] report separately to tensorboard

I find it helpful to validate on a high timestep that determines image composition, and something in between - but other best practices might evolve

![grafik](https://github.com/user-attachments/assets/8ce5a6f6-d4f7-47ac-8a4b-ff669a4c9dfc)

![grafik](https://github.com/user-attachments/assets/a1cb3513-ae14-4ea9-bdd2-81d388524e93)
