### PR TITLE
use save prefix for samples

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -221,7 +221,7 @@ class GenericTrainer(BaseTrainer):
 
                     sample_path = os.path.join(
                         sample_dir,
-                        f"{get_string_timestamp()}-training-sample-{train_progress.filename_string()}"
+                        f"{self.config.save_filename_prefix}{get_string_timestamp()}-training-sample-{train_progress.filename_string()}"
                     )
 
                     def on_sample_default(sampler_output: ModelSamplerOutput):


### PR DESCRIPTION
for A/B tests I use the same workspace, to have all of them in tensorboard. 
I tend to mix up samples and don't remember to which run they belonged to, especially when running multiple OneTrainers at the same time on clouds. We already use the prefix for saves and for tensorboard. Can we use it for samples, too?
