### PR TITLE
Extend Install.bat to work better with multiple versions of python

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -20,6 +20,7 @@ rem --- Helpers ---
   echo %RED%ERROR:%RESET% %~1&
   echo
   pause
+  popd
   exit /b 1
 
 :warn_store
@@ -112,4 +113,5 @@ echo.
 echo %GRN%**** Install successful! ****%RESET%
 echo.
 pause
+popd
 exit /b 0

--- a/install.bat
+++ b/install.bat
@@ -8,8 +8,8 @@ set "RED=[31m" & set "YEL=[33m" & set "GRN=[92m" & set "CYAN=[36m" & set "RE
 rem --- Constants ---
 pushd "%~dp0" || call :die "Cannot cd to script directory"
 set "SCRIPT_DIR=%CD%"
-set "VENV_DIR=%SCRIPT_DIR%\venv"
-set "VERSION_FILE=%SCRIPT_DIR%\scripts\util\version_check.py"
+set "VENV_DIR=%SCRIPT_DIR%\\venv"
+set "VERSION_FILE=%SCRIPT_DIR%\\scripts\\util\\version_check.py"
 set "MIN_PY=3.10" & set "MAX_PY=3.13"
 
 goto :main
@@ -18,99 +18,198 @@ rem --- Helpers ---
 :die
   echo.
   echo %RED%ERROR:%RESET% %~1&
-  echo
+  echo.
   pause
   popd
   exit /b 1
 
 :warn_store
   echo.
-  echo %YEL% ?? WARNING: Windows Store Python detected ?? %RESET%
+  echo %YEL% WARNING: Windows Store Python detected %RESET%
   echo Windows Store Python has a known history of causing insidious issues with virtual environments due to how
   echo Microsoft sandboxes it.
   echo.
-  echo We strongly recommend installing Python directly from[36m https://www.python.org[0m instead.
+  echo We strongly recommend installing Python directly from %CYAN%https://www.python.org%RESET% instead.
   echo.
   echo Support for Windows Store Python is provided AS IS.
-  set /p "ans=Proceed anyway? (y/n): "   >nul
+  set "ans="
+  set /p "ans=Proceed anyway? (y/n): "
   if /i "!ans!"=="y" exit /b 0
   exit /b 1
 
-:wrong_python_version
+:wrong_python_version_message
     echo.
-    echo Please install a supported Python version from:
-    echo https://www.python.org/downloads/windows/
+    echo %RED%No suitable Python version found or selected.%RESET%
+    echo Please install a supported Python version ^(%MIN_PY% - ^< %MAX_PY%^) from:
+    echo %CYAN%https://www.python.org/downloads/windows/%RESET%
     echo.
     echo Reminder: Do not rely on installation videos; they are often out of date.
     exit /b 1
 
 :run_or_die
-  echo %~1
-  cmd /c "%~1" || call :die "%~2"
+  echo Executing: %~1
+  cmd /c "%~1" || call :die "Command failed: %~2"
   exit /b 0
 
 rem --- Main ---
 :main
-rem 1) Check Python Launcher for available versions
-for /f "tokens=*" %%V in ('py --list ^| findstr /c:"-V:"') do (
-    rem parse version
-    py -%%V "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 && (
-    set "PYTHON=py -%%V"
+echo %CYAN%Searching for a suitable Python installation...%RESET%
+set "PYTHON="
+
+rem --- Python Detection ---
+echo %CYAN%Scanning Python installations reported by "py --list"...%RESET%
+
+if not exist "%VERSION_FILE%" (
+    call :die """%VERSION_FILE%\" not found"
+    rem The :die call should exit the script, failing that go to final
+    goto :final_python_failure_handling
+)
+
+set "PYTHON_VERSION_FROM_PY_LIST="
+for /f "tokens=2 delims=:" %%L in ('py --list 2^>nul ^| findstr /R /C:"-V:[0-9][.][0-9]"') do (
+    for /f "tokens=1" %%V in ("%%L") do (
+        set "CURRENT_PY_VER_TO_TEST=%%V"
+        echo   Testing Python !CURRENT_PY_VER_TO_TEST! via py.exe ...
+        py -!CURRENT_PY_VER_TO_TEST! "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1
+        if not errorlevel 1 (
+            echo   %GRN%SELECTED Python !CURRENT_PY_VER_TO_TEST! via py.exe%RESET%
+            set "PYTHON=py -!CURRENT_PY_VER_TO_TEST!"
+            set "PYTHON_VERSION_FROM_PY_LIST=!CURRENT_PY_VER_TO_TEST!"
+            goto :found_python_via_py_list
+        ) else (
+            echo   %YEL%Python !CURRENT_PY_VER_TO_TEST! via py.exe is not suitable or version_check.py failed.%RESET%
+        )
+    )
+    rem Check if we found Python and need to exit outer loop
+    if defined PYTHON_VERSION_FROM_PY_LIST goto :found_python_via_py_list
+)
+
+:found_python_via_py_list
+if not defined PYTHON_VERSION_FROM_PY_LIST (
+    echo %YEL%No suitable Python version found via "py --list" that satisfies %MIN_PY% ^<= v ^< %MAX_PY%.%RESET%
+    rem PYTHON remains unset, script will proceed to Step 3 or final failure handling
+)
+
+rem Check if PYTHON was set by the new logic. If so, go to :py_ok.
+rem Otherwise, continue to Step 3 (Windows Store Python check).
+if defined PYTHON (
     goto :py_ok
+)
+
+rem 3) Finally as a failsafe try to ask about Windows Store python, only if not found yet
+if not defined PYTHON (
+    echo.
+    echo %CYAN%Step 3: Checking for Windows Store Python installations in PATH...%RESET%
+    set "STORE_PYTHON_CHECKED="
+    for /f "delims=" %%P in ('where python 2^>nul ^| findstr /i "WindowsApps"') do (
+      if defined PYTHON ( goto :py_ok_check_step3 )
+      set "STORE_PYTHON_CHECKED=true"
+      echo Found potential Windows Store Python at "%%P".
+      call :warn_store
+      if errorlevel 1 (
+        echo %YEL%  ^> Skipping Store Python "%%P" due to user choice or warning issue.%RESET%
+      ) else (
+        REM User agreed to use this Store Python (warn_store returned 0)
+        echo Testing agreed-upon Store Python at "%%P"...
+        "%%P" "%VERSION_FILE%" %MIN_PY% %MAX_PY%
+        set "LAST_ERRORLEVEL=!errorlevel!"
+        echo   ^> Exit code from '"%%P" "%VERSION_FILE%"': !LAST_ERRORLEVEL!
+
+        if !LAST_ERRORLEVEL! == 0 (
+          echo %GRN%  ^> Using selected Store Python: "%%P"%RESET%
+          set "PYTHON=%%P"
+          goto :py_ok_check_step3
+        ) else (
+          echo %RED%  ^> Version check failed for this agreed-upon Store Python "%%P" ^(Code: !LAST_ERRORLEVEL!^).%RESET%
+          call :wrong_python_version_message
+          REM After calling wrong_python_version_message, which tries to exit, we must ensure this path also exits.
+          echo %RED%ERROR: The selected Windows Store Python version is not supported.%RESET%
+          pause
+          popd
+          exit /b 1
+        )
+      )
+    )
+    :py_ok_check_step3
+    if defined PYTHON ( goto :py_ok )
+
+    if not defined STORE_PYTHON_CHECKED (
+        echo %YEL%No Windows Store Python installations found in PATH to check in Step 3.%RESET%
     )
 )
 
-rem 2) Try non-Store python next
-for /f "delims=" %%P in ('where python 2^>nul ^| findstr /v /i "WindowsApps"') do (
-  %%P "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 && (
-    set "PYTHON=%%P"
-    goto :py_ok
-  )
+rem If we reach here and PYTHON is not set, no suitable Python was found at all
+if not defined PYTHON (
+  echo.
+  call :wrong_python_version_message
+  REM The above call prints details and sets errorlevel. Now, exit the main script.
+  echo.
+  echo %RED%ERROR: Failed to find a supported Python version after all checks.%RESET%
+  echo Please ensure a Python version between %MIN_PY% and %MAX_PY% is available.
+  pause
+  popd
+  exit /b 1
 )
 
-rem 3) Finally as a failsafe try to ask about Windows Store python
-for /f "delims=" %%P in ('where python 2^>nul ^| findstr /i "WindowsApps"') do (
-  call :warn_store
-  %%P "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 || (
-    call :wrong_python_version
-    call :die "Unsupported Python version %MIN_PY%-%MAX_PY% required"
-  )
-  set "PYTHON=%%P"
-  goto :py_ok
-)
-
-rem If we reach here, no Python was found at all
-echo %RED%ERROR: No Python installation found%RESET%
-call :wrong_python_version
-exit /b 1
+:final_python_failure_handling
+exit /b 0
 
 :py_ok
-echo %GRN%Using: %PYTHON% %RESET%
+if not defined PYTHON (
+    echo %RED%Internal error: Reached :py_ok without PYTHON being set. This should not happen.%RESET%
+    call :die "Script logic error at :py_ok."
+)
+echo.
+echo %GRN%Using Python: !PYTHON!%RESET%
 
 rem 4) Create & activate venv
-if not exist "%VENV_DIR%\Scripts\python.exe" (
-  echo Creating venv ...
-  %PYTHON% -m venv "%VENV_DIR%" || call :die "venv creation failed"
+echo.
+echo %CYAN%Managing virtual environment...%RESET%
+if not exist "%VENV_DIR%\\Scripts\\python.exe" (
+  echo Creating venv at "%VENV_DIR%"...
+  !PYTHON! -m venv "%VENV_DIR%" || call :die "venv creation failed using !PYTHON!"
+) else (
+  echo Virtual environment already exists at "%VENV_DIR%"
 )
-set "PYTHON=%VENV_DIR%\Scripts\python.exe"
+set "PYTHON_VENV=%VENV_DIR%\\Scripts\\python.exe"
+if not exist "%PYTHON_VENV%" (
+    call :die "Virtual environment Python executable not found at '%PYTHON_VENV%' after venv creation/check."
+)
+rem Set PYTHON to the venv python, though subsequent commands will use 'python' from activated PATH
+set "PYTHON=%PYTHON_VENV%"
+
+echo Activating virtual environment...
+call "%VENV_DIR%\Scripts\activate.bat"
+echo Virtual environment activated.
 
 rem 5) Upgrade pip & install
-call :run_or_die "%PYTHON% -m pip install --upgrade pip" "pip upgrade failed"
-call :run_or_die "%PYTHON% -m pip install -r requirements.txt" "Dependencies install failed"
+echo.
+echo %CYAN%Upgrading pip and installing dependencies from requirements.txt...%RESET%
+echo Executing: python -m pip install --upgrade pip
+python -m pip install --upgrade pip || call :die "pip upgrade failed"
+echo Executing: python -m pip install -r requirements.txt
+python -m pip install -r requirements.txt || call :die "Dependencies install failed"
 
 rem 6) Check CUDA
-%PYTHON% -c "import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)"
+echo.
+echo %CYAN%Checking CUDA availability...%RESET%
+python -c "import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)"
 if errorlevel 1 (
-  set /p "ans=CUDA not found. AMD GPU? (y/n): " >nul
-  if /i "!ans!"=="y" (
-    call :run_or_die "%PYTHON% scripts\install_zluda.py" "ZLUDA install failed"
+  echo %YEL%CUDA not found via torch.cuda.is_available.%RESET%
+  set "ans_amd="
+  set /p "ans_amd=AMD GPU? (y/n): "
+  if /i "!ans_amd!"=="y" (
+    echo Executing: python "%SCRIPT_DIR%\scripts\install_zluda.py"
+    python "%SCRIPT_DIR%\scripts\install_zluda.py" || call :die "ZLUDA install failed"
   ) else (
-    call :die "CUDA unavailable - aborting"
+    call :die "CUDA unavailable and not an AMD GPU setup - aborting. Please check PyTorch and NVIDIA driver compatibility."
   )
+) else (
+    echo %GRN%CUDA is available.%RESET%
 )
 
 echo.
-echo %GRN%**** Install successful! ****%RESET%
+echo %GRN%**** Install successful^^! ****%RESET%
 echo.
 pause
 popd

--- a/install.bat
+++ b/install.bat
@@ -1,169 +1,108 @@
-@echo off
-chcp 65001 >nul
-setlocal EnableDelayedExpansion
+@echo off & setlocal EnableDelayedExpansion
 
-REM Avoid footgun by explictly navigating to the directory containing the batch file
-cd /d "%~dp0"
+rem --- Color codes ---
+set "RED=[31m" & set "YEL=[33m" & set "GRN=[92m" & set "CYAN=[36m" & set "RESET=[0m"
 
-REM Verify that OneTrainer is our current working directory
-if not exist "scripts\train_ui.py" (
-    echo Error: train_ui.py does not exist, you have done something very wrong. Reclone the repository.
-    goto :end
-)
+rem --- Constants ---
+pushd "%~dp0" || call :die "Cannot cd to script directory"
+set "SCRIPT_DIR=%CD%"
+set "VENV_DIR=%SCRIPT_DIR%\venv"
+set "VERSION_FILE=%SCRIPT_DIR%\scripts\util\version_check.py"
+set "MIN_PY=3.10" & set "MAX_PY=3.13"
 
-if not defined PYTHON ( set "PYTHON=python" )
-:: %~dp0 expands to the full directory path of the script (with trailing backslash)
-if not defined VENV_DIR ( set "VENV_DIR=%~dp0venv" )
+goto :main
 
-:: ----------------------------------------------------------------------------
-:: 1. Check that a real Python version is available in PATH (ignoring the Windows Store alias)
-:: ----------------------------------------------------------------------------
-:check_python_exists
-set "REAL_PYTHON="
-for /f "delims=" %%p in ('where %PYTHON% 2^>nul ^| findstr /v /i "WindowsApps"') do (
-    set "REAL_PYTHON=%%p"
-    goto :found_valid_python
-)
+rem --- Helpers ---
+:die
+  echo.
+  echo %RED%ERROR:%RESET% %~1&
+  echo
+  pause
+  exit /b 1
 
-REM Fallback: Check specifically if Windows Store Python exists
-set "WINDOWS_STORE_PYTHON="
-for /f "delims=" %%p in ('where %PYTHON% 2^>nul ^| findstr /i "WindowsApps"') do (
-    set "WINDOWS_STORE_PYTHON=%%p"
-    goto :windows_store_warning
-)
-goto :no_python_found
-
-:windows_store_warning
-echo.
-echo ⚠️ [33m WINDOWS STORE PYTHON DETECTED[0m ⚠️
-echo.
-echo Windows Store Python has a known history of causing insidious issues with virtual environments due to how
-echo Microsoft sandboxes it.
-echo.
-echo We strongly recommend installing Python directly from[36m https://www.python.org[0m instead.
-echo.
-echo Support for Windows Store Python is provided AS IS.
-echo.
-echo -------------------------------------------------
-echo.
-set "USE_WINDOWS_STORE="
-set /p USE_WINDOWS_STORE=Do you want to continue with Windows Store Python anyway? (y/n):
-if /i "%USE_WINDOWS_STORE%"=="y" (
-    set "REAL_PYTHON=%WINDOWS_STORE_PYTHON%"
-    echo Using Windows Store Python: %WINDOWS_STORE_PYTHON%
-    goto :found_valid_python
-)
-echo You chose not to use Windows Store Python.
-goto :no_python_found
-
-:no_python_found
-echo Error: Python was not found in your PATH. It is likely that you have not installed Python yet.
-goto :wrong_python_version
-
-:found_valid_python
-if "%REAL_PYTHON%"=="" (
-    echo Error: Python was not found in your PATH. It is likely that you have not installed Python yet.
-    goto :wrong_python_version
-) else (
-    set "PYTHON=%REAL_PYTHON%"
-)
-
-:: ----------------------------------------------------------------------------
-:: 2. Check that Pythons version is supported by OT using version_check.py
-:: ----------------------------------------------------------------------------
-
-:check_python_version
-echo Checking Python version...
-"%PYTHON%" --version
-if errorlevel 1 (
-    echo Error: Failed to get Python version
-    goto :end_error
-)
-
-echo.
-"%PYTHON%" "%~dp0scripts\util\version_check.py" 3.10 3.13 2>&1
-if errorlevel 1 (
-    echo.
-    goto :wrong_python_version
-)
-
-:: ----------------------------------------------------------------------------
-:: 3. Continue with installation: create a virtual environment and install dependencies
-:: ----------------------------------------------------------------------------
-:check_venv
-dir "%VENV_DIR%" >NUL 2>&1
-if not errorlevel 1 goto :activate_venv
-echo Creating virtual environment in %VENV_DIR%
-"%PYTHON%" -m venv "%VENV_DIR%"
-if errorlevel 1 (
-    echo Error: Couldn't create virtual environment.
-    echo Checking if venv module is installed...
-    "%PYTHON%" -c "import venv" 2>nul
-    if errorlevel 1 (
-        echo Error: Python venv module not found. Please install it first:
-        echo %PYTHON% -m pip install --user virtualenv
-    )
-    goto :end_error
-)
-goto :activate_venv
-
-:activate_venv
-echo Activating virtual environment: %VENV_DIR%
-set "PYTHON=%VENV_DIR%\Scripts\python.exe"
-
-:install_dependencies
-echo Installing dependencies...
-echo This may take a while, please be patient...
-"%PYTHON%" -m pip install -r requirements.txt
-if errorlevel 1 (
-    echo Error: Failed to install dependencies
-    goto :end_error
-)
-echo Dependencies installed successfully
-
-:check_cuda
-echo Checking for CUDA support...
-for /f "tokens=*" %%i in ('CALL "%PYTHON%" -c "import torch; print(torch.cuda.is_available())"') do set "CUDA_AVAILABLE=%%i"
-if "%CUDA_AVAILABLE%"=="True" goto :end_success
-
-echo CUDA is not available.
-set "USE_ZLUDA="
-:ask_zluda
-set /p USE_ZLUDA=Are you using AMD GPUs on Windows? (y/n):
-if /i "%USE_ZLUDA%"=="y" goto :install_zluda
-if /i "%USE_ZLUDA%"=="n" goto :end_error
-echo Invalid input. Please enter 'y' or 'n'.
-goto :ask_zluda
-
-:install_zluda
-echo Continuing with ZLUDA installation...
-"%PYTHON%" scripts\install_zluda.py
-if errorlevel 1 (
-    echo Error: ZLUDA installation failed
-    goto :end_error
-)
-goto :end_success
+:warn_store
+  echo.& echo %YEL%WARNING: Windows Store Python detected ...%RESET%
+  >nul set /p "ans=Proceed anyway? (y/N): "
+  if /i "!ans!"=="y" exit /b 0
+  exit /b 1
 
 :wrong_python_version
-echo.
-echo Please install a supported Python version from:
-echo https://www.python.org/downloads/windows/
-echo.
-echo Reminder: Do not rely on installation videos; they are often out of date.
-goto :end_error
+    echo.
+    echo Please install a supported Python version from:
+    echo https://www.python.org/downloads/windows/
+    echo.
+    echo Reminder: Do not rely on installation videos; they are often out of date.
+    exit /b 1
 
-:end_success
+:run_or_die
+  echo %~1
+  cmd /c "%~1" || call :die "%~2"
+  exit /b 1
+
+rem --- Main ---
+:main
+rem 1) Check Python Launcher for available versions
+for /f "tokens=1,2 delims= " %%A in ('where py 2^>nul') do (
+  for /f "tokens=*" %%V in ('py --list ^| findstr /c:"-V:"') do (
+    rem parse version�
+    py -%%V "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 && (
+      set "PYTHON=py -%%V"
+      goto :py_ok
+    )
+  )
+)
+
+rem 2) Try non-Store python next
+for /f "delims=" %%P in ('where python 2^>nul ^| findstr /v /i "WindowsApps"') do (
+  %%P "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 && (
+    set "PYTHON=%%P"
+    goto :py_ok
+  )
+)
+
+rem 3) Finally as a failsafe try to ask about Windows Store python
+for /f "delims=" %%P in ('where python 2^>nul ^| findstr /i "WindowsApps"') do (
+  call :warn_store
+  %%P "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 || (
+    call :wrong_python_version
+    call :die "Unsupported Python version %MIN_PY%-%MAX_PY% required"
+  )
+  set "PYTHON=%%P"
+  goto :py_ok
+)
+
+rem If we reach here, no Python was found at all
+echo %RED%ERROR: No Python installation found%RESET%
+call :wrong_python_version
+exit /b 1
+
+:py_ok
+echo %GRN%Using: %PYTHON% %RESET%
+
+rem 4) Create & activate venv
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+  echo Creating venv ...
+  %PYTHON% -m venv "%VENV_DIR%" || call :die "venv creation failed"
+)
+set "PYTHON=%VENV_DIR%\Scripts\python.exe"
+
+rem 5) Upgrade pip & install
+call :run_or_die "%PYTHON% -m pip install --upgrade pip" "pip upgrade failed"
+call :run_or_die "%PYTHON% -m pip install -r requirements.txt" "Dependencies install failed"
+
+rem 6) Check CUDA
+%PYTHON% -c "import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)"
+if errorlevel 1 (
+  >nul set /p "ans=CUDA not found. AMD GPU? (y/N): "
+  if /i "!ans!"=="y" (
+    call :run_or_die "%PYTHON% scripts\install_zluda.py" "ZLUDA install failed"
+  ) else (
+    call :die "CUDA unavailable - aborting"
+  )
+)
+
 echo.
-echo ************
-echo Install done
-echo ************
+echo %GRN%**** Install successful! ****%RESET%
+echo.
 pause
 exit /b 0
-
-:end_error
-echo.
-echo ********************
-echo Error during install
-echo ********************
-pause
-exit /b 1

--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,6 @@
-@echo off & setlocal EnableDelayedExpansion
+@echo off
+chcp 65001 >nul
+setlocal EnableDelayedExpansion
 
 rem --- Color codes ---
 set "RED=[31m" & set "YEL=[33m" & set "GRN=[92m" & set "CYAN=[36m" & set "RESET=[0m"
@@ -21,7 +23,14 @@ rem --- Helpers ---
   exit /b 1
 
 :warn_store
-  echo.& echo %YEL%WARNING: Windows Store Python detected ...%RESET%
+  echo.
+  echo %YEL% ?? WARNING: Windows Store Python detected ?? RESET%
+  echo Windows Store Python has a known history of causing insidious issues with virtual environments due to how
+  echo Microsoft sandboxes it.
+  echo.
+  echo We strongly recommend installing Python directly from[36m https://www.python.org[0m instead.
+  echo.
+  echo Support for Windows Store Python is provided AS IS.
   >nul set /p "ans=Proceed anyway? (y/N): "
   if /i "!ans!"=="y" exit /b 0
   exit /b 1

--- a/install.bat
+++ b/install.bat
@@ -24,14 +24,14 @@ rem --- Helpers ---
 
 :warn_store
   echo.
-  echo %YEL% ?? WARNING: Windows Store Python detected ?? RESET%
+  echo %YEL% ?? WARNING: Windows Store Python detected ?? %RESET%
   echo Windows Store Python has a known history of causing insidious issues with virtual environments due to how
   echo Microsoft sandboxes it.
   echo.
   echo We strongly recommend installing Python directly from[36m https://www.python.org[0m instead.
   echo.
   echo Support for Windows Store Python is provided AS IS.
-  >nul set /p "ans=Proceed anyway? (y/N): "
+  set /p "ans=Proceed anyway? (y/n): "   >nul
   if /i "!ans!"=="y" exit /b 0
   exit /b 1
 
@@ -46,19 +46,17 @@ rem --- Helpers ---
 :run_or_die
   echo %~1
   cmd /c "%~1" || call :die "%~2"
-  exit /b 1
+  exit /b 0
 
 rem --- Main ---
 :main
 rem 1) Check Python Launcher for available versions
-for /f "tokens=1,2 delims= " %%A in ('where py 2^>nul') do (
-  for /f "tokens=*" %%V in ('py --list ^| findstr /c:"-V:"') do (
-    rem parse version…
+for /f "tokens=*" %%V in ('py --list ^| findstr /c:"-V:"') do (
+    rem parse version
     py -%%V "%VERSION_FILE%" %MIN_PY% %MAX_PY% >nul 2>&1 && (
-      set "PYTHON=py -%%V"
-      goto :py_ok
+    set "PYTHON=py -%%V"
+    goto :py_ok
     )
-  )
 )
 
 rem 2) Try non-Store python next
@@ -102,7 +100,7 @@ call :run_or_die "%PYTHON% -m pip install -r requirements.txt" "Dependencies ins
 rem 6) Check CUDA
 %PYTHON% -c "import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)"
 if errorlevel 1 (
-  >nul set /p "ans=CUDA not found. AMD GPU? (y/N): "
+  set /p "ans=CUDA not found. AMD GPU? (y/n): " >nul
   if /i "!ans!"=="y" (
     call :run_or_die "%PYTHON% scripts\install_zluda.py" "ZLUDA install failed"
   ) else (

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -6,7 +6,7 @@ imagesize==1.4.1 #for concept statistics
 tqdm==4.67.1
 PyYAML==6.0.2
 huggingface-hub==0.28.1
-scipy==1.15.1; sys_platform != 'win32'
+scipy==1.15.1
 matplotlib==3.10.0
 av==14.1.0 # using an older version. only update once torchvision has been updated as well.
 yt-dlp  #no pinned version, frequently updated for compatibility with sites


### PR DESCRIPTION
Tested locally on windows 10 and 11 with 3.13, 3.12 and 3.11 install. Shifted to using `py` first, and using `pushd`, `popd` and `call`, the previous approach was very annoying to extend.

The reason this came up is (stupidly) there is 'commercial' software supposedly (according to a user) requiring python 3.13. I wont name incase it was incorrect but regardless, we now check py launcher versions, loop through and check with version_check.py

![image](https://github.com/user-attachments/assets/9ba95fcd-4151-4894-bb96-25a4f11dc205)
