### PR TITLE
Temperature scaling

### DIFF
--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,6 +236,9 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            temperature = 1.5
+            latent_noise *= temperature ** 0.5
+
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -304,7 +307,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise - scaled_latent_image
+            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,


### PR DESCRIPTION
- Might get rid of NF4 grid patterns
- Did get rid of similar patterns in one my trainings
- Might have other benefits as a hyperparameter: "Temperature scaling controls how noisy the starting points are, affecting how diverse or sharp the generated samples will be."
- Difference to perturbation noise: Perturbation noise adds noise to *both* the sample and the target. Temperature scaling *only* adds noise to the sample and expects the model to learn the same target

Temperature setting is currently in the code, no UI.
1.5 might be on the high side.

Draft PR:
- [ ] Is this useful?
- [ ] Port to other models
- [ ] Add UI