### PR TITLE
Save config lists on Start Training

### DIFF
--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -110,7 +110,7 @@ class ConfigList(metaclass=ABCMeta):
                 self.__open_element_window,
                 self.__remove_element,
                 self.__clone_element,
-                self.__save_current_config
+                self.save_current_config
             )
             self.widgets.append(widget)
 
@@ -128,7 +128,7 @@ class ConfigList(metaclass=ABCMeta):
         if len(self.configs) == 0:
             name = self.default_config_name.removesuffix(".json")
             self.__create_config(name)
-            self.__save_current_config()
+            self.save_current_config()
 
     def __create_config(self, name: str):
         name = path_util.safe_filename(name)
@@ -149,13 +149,13 @@ class ConfigList(metaclass=ABCMeta):
             self.__open_element_window,
             self.__remove_element,
             self.__clone_element,
-            self.__save_current_config
+            self.save_current_config
         )
         self.widgets.append(widget)
 
         widget.place_in_list()
 
-        self.__save_current_config()
+        self.save_current_config()
 
     def __clone_element(self, clone_i, modify_element_fun=None):
         i = len(self.current_config)
@@ -170,13 +170,13 @@ class ConfigList(metaclass=ABCMeta):
             self.__open_element_window,
             self.__remove_element,
             self.__clone_element,
-            self.__save_current_config
+            self.save_current_config
         )
         self.widgets.append(widget)
 
         widget.place_in_list()
 
-        self.__save_current_config()
+        self.save_current_config()
 
     def __remove_element(self, remove_i):
         self.current_config.pop(remove_i)
@@ -186,7 +186,7 @@ class ConfigList(metaclass=ABCMeta):
             widget.i = i
             widget.place_in_list()
 
-        self.__save_current_config()
+        self.save_current_config()
 
     def __load_current_config(self, filename):
         try:
@@ -202,7 +202,7 @@ class ConfigList(metaclass=ABCMeta):
 
         self._create_element_list()
 
-    def __save_current_config(self):
+    def save_current_config(self):
         if self.from_external_file:
             with contextlib.suppress(Exception):
                 if not os.path.exists(self.config_dir):
@@ -217,4 +217,4 @@ class ConfigList(metaclass=ABCMeta):
         window = self.open_element_window(i, ui_state)
         self.master.wait_window(window)
         self.widgets[i].configure_element()
-        self.__save_current_config()
+        self.save_current_config()

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -150,9 +150,9 @@ class TrainUI(ctk.CTk):
         self.general_tab = self.create_general_tab(self.tabview.add("general"))
         self.model_tab = self.create_model_tab(self.tabview.add("model"))
         self.data_tab = self.create_data_tab(self.tabview.add("data"))
-        self.create_concepts_tab(self.tabview.add("concepts"))
+        self.concepts_tab = self.create_concepts_tab(self.tabview.add("concepts"))
         self.training_tab = self.create_training_tab(self.tabview.add("training"))
-        self.create_sampling_tab(self.tabview.add("sampling"))
+        self.sampling_tab = self.create_sampling_tab(self.tabview.add("sampling"))
         self.backup_tab = self.create_backup_tab(self.tabview.add("backup"))
         self.tools_tab = self.create_tools_tab(self.tabview.add("tools"))
         self.additional_embeddings_tab = self.create_additional_embeddings_tab(self.tabview.add("additional embeddings"))
@@ -265,7 +265,7 @@ class TrainUI(ctk.CTk):
         return frame
 
     def create_concepts_tab(self, master):
-        ConceptTab(master, self.train_config, self.ui_state)
+        return ConceptTab(master, self.train_config, self.ui_state)
 
     def create_training_tab(self, master) -> TrainingTab:
         return TrainingTab(master, self.train_config, self.ui_state)
@@ -315,7 +315,7 @@ class TrainUI(ctk.CTk):
         frame = ctk.CTkFrame(master=master, corner_radius=0)
         frame.grid(row=1, column=0, sticky="nsew")
 
-        SamplingTab(frame, self.train_config, self.ui_state)
+        return SamplingTab(frame, self.train_config, self.ui_state)
 
     def create_backup_tab(self, master):
         frame = ctk.CTkScrollableFrame(master, fg_color="transparent")
@@ -627,7 +627,7 @@ class TrainUI(ctk.CTk):
 
     def start_training(self):
         if self.training_thread is None:
-            self.top_bar_component.save_default()
+            self.save_default()
 
             self.training_button.configure(text="Stop Training", state="normal")
 
@@ -639,6 +639,12 @@ class TrainUI(ctk.CTk):
             self.training_button.configure(state="disabled")
             self.on_update_status("stopping")
             self.training_commands.stop()
+
+    def save_default(self):
+        self.top_bar_component.save_default()
+        self.concepts_tab.save_current_config()
+        self.sampling_tab.save_current_config()
+        self.additional_embeddings_tab.save_current_config()
 
     def export_training(self):
         file_path = filedialog.asksaveasfilename(filetypes=[


### PR DESCRIPTION
Now:
- config lists such as concepts and samples are basically saved "on each click" to the separate .json file
- when you press "Start Training", they are expected to already be saved to disk

When you have multiple OneTrainers started and change something, for example enable a concept, it gets saved to disk "on click" and then used for both OneTrainers when you "Start Training" - even though the other UI still displays the concept as disabled.

This PR:
- saves the current UI states for config lists to disk when you "Start Training", to make sure the current UI state is used for training
- doesn't change the on-click behaviour from above, this is just done in addition

Using multiple OTs at the same time might not be a use case that was planned or used by many people - but with cloud training it's easy to do because you have unlimited GPUs.
This is the only problem with it. And it's *very* annoying if you realize after an hours long training run that it used the wrong concepts.


