### PR TITLE
Increase default container size for RunPod

### DIFF
--- a/modules/cloud/RunpodCloud.py
+++ b/modules/cloud/RunpodCloud.py
@@ -74,7 +74,7 @@ class RunpodCloud(LinuxCloud):
             cloud_type=config.sub_type,
             support_public_ip=True,
             volume_in_gb=config.volume_size,
-            container_disk_in_gb=10,
+            container_disk_in_gb=20,
             volume_mount_path="/workspace",
             min_download=config.min_download,
             env={"JUPYTER_PASSWORD": pysecrets.token_urlsafe(16)},

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,9 +236,6 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
-            temperature = 1.5
-            latent_noise *= temperature ** 0.5
-
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -307,7 +304,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
+            flow = latent_noise - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,6 +236,9 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            temperature = 1.5
+            latent_noise *= temperature ** 0.5
+
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -304,7 +307,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise - scaled_latent_image
+            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,


### PR DESCRIPTION
Container size needs to be higher than 10 GB to allow for large updates such as pytorch.

Unfortunately, this default size, that is (only) used when a cloud instance is created through the API, had to be hardcoded because of a bug in the RunPod API: https://github.com/runpod/runpod-python/issues/386

That's why this is a code change, not only a change in the container template on RunPod