### PR TITLE
Log `effective_lr` for `prodigy_plus_schedule_free` Optimizer

### DIFF
--- a/modules/util/enum/Optimizer.py
+++ b/modules/util/enum/Optimizer.py
@@ -100,9 +100,8 @@ class Optimizer(Enum):
         if self.is_adaptive:
             return {
                 # Return `effective_lr * d` if "effective_lr" key present, otherwise return `lr * d`
-                key: ((optimizer.param_groups[i]["effective_lr"] if "effective_lr" in optimizer.param_groups[i] else lr)
-                      * optimizer.param_groups[i].get("d", 1.0)
-                    if lr is not None else None)
+                key: (optimizer.param_groups[i].get("effective_lr", lr) * optimizer.param_groups[i].get("d", 1.0)
+                      if lr is not None else None)
                 for i, (key, lr) in enumerate(lrs.items())
             }
         return lrs


### PR DESCRIPTION
The newer (experimental) 2.0 version of the `prodigy_plus_schedule_free` added an `effective_lr` attribute for logging the `LR` when the Optimizer is running in `schedule_free` mode, which is forced-on in `OneTrainer`.  Without this change, the `LR` will be fixed at whatever value Prodigy decides on, and does not report the (effective) decay.

This value does not exist in the current version referenced by OneTrainer's requirements.txt, so this (safely) doesn't really do anything until OT updates to 2.0.  I'm posting this now in case anyone else is testing out the newest release of that Optimizer.