### PR TITLE
ConfigList - add 'enable/disable' and 'enable all/disable all' buttons

### DIFF
--- a/modules/ui/AdditionalEmbeddingsTab.py
+++ b/modules/ui/AdditionalEmbeddingsTab.py
@@ -20,7 +20,7 @@ class AdditionalEmbeddingsTab(ConfigList):
             from_external_file=False,
             add_button_text="add embedding",
             is_full_width=True,
-            show_toggle_buttons=True
+            show_toggle_button=True
         )
 
     def refresh_ui(self):

--- a/modules/ui/AdditionalEmbeddingsTab.py
+++ b/modules/ui/AdditionalEmbeddingsTab.py
@@ -16,9 +16,11 @@ class AdditionalEmbeddingsTab(ConfigList):
             train_config,
             ui_state,
             attr_name="additional_embeddings",
+            enabled_attr_name="train",
             from_external_file=False,
             add_button_text="add embedding",
             is_full_width=True,
+            can_disable_all=True
         )
 
     def refresh_ui(self):

--- a/modules/ui/AdditionalEmbeddingsTab.py
+++ b/modules/ui/AdditionalEmbeddingsTab.py
@@ -20,7 +20,7 @@ class AdditionalEmbeddingsTab(ConfigList):
             from_external_file=False,
             add_button_text="add embedding",
             is_full_width=True,
-            show_toggle_all_button=True
+            show_toggle_buttons=True
         )
 
     def refresh_ui(self):
@@ -103,7 +103,7 @@ class EmbeddingWidget(ctk.CTkFrame):
 
         # trainable
         components.label(bottom_frame, 0, 0, "train:")
-        trainable_switch = components.switch(bottom_frame, 0, 1, self.ui_state, "train")
+        trainable_switch = components.switch(bottom_frame, 0, 1, self.ui_state, "train", command=save_command)
         trainable_switch.configure(width=40)
 
         # output embedding

--- a/modules/ui/AdditionalEmbeddingsTab.py
+++ b/modules/ui/AdditionalEmbeddingsTab.py
@@ -16,11 +16,11 @@ class AdditionalEmbeddingsTab(ConfigList):
             train_config,
             ui_state,
             attr_name="additional_embeddings",
-            enabled_attr_name="train",
+            enable_key="train",
             from_external_file=False,
             add_button_text="add embedding",
             is_full_width=True,
-            can_disable_all=True
+            show_toggle_all_button=True
         )
 
     def refresh_ui(self):

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 
@@ -6,7 +7,6 @@ from modules.ui.ConfigList import ConfigList
 from modules.util import path_util
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.image_util import load_image
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState
 
@@ -27,6 +27,7 @@ class ConceptTab(ConfigList):
             default_config_name="concepts.json",
             add_button_text="add concept",
             is_full_width=False,
+            can_disable_all=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):
@@ -37,7 +38,6 @@ class ConceptTab(ConfigList):
 
     def open_element_window(self, i, ui_state) -> ctk.CTkToplevel:
         return ConceptWindow(self.master, self.current_config[i], ui_state[0], ui_state[1], ui_state[2])
-
 
 class ConceptWidget(ctk.CTkFrame):
     def __init__(self, master, concept, i, open_command, remove_command, clone_command, save_command):
@@ -128,11 +128,11 @@ class ConceptWidget(ctk.CTkFrame):
             for path in pathlib.Path(self.concept.path).glob(glob_pattern):
                 extension = os.path.splitext(path)[1]
                 if path.is_file() and path_util.is_supported_image_extension(extension) \
-                        and not path.name.endswith("-masklabel.png") and not path.name.endswith("-condlabel.png"):
+                        and not path.name.endswith("-masklabel.png"):
                     preview_path = path_util.canonical_join(self.concept.path, path)
                     break
 
-        image = load_image(preview_path, convert_mode="RGBA")
+        image = Image.open(preview_path)
         size = min(image.width, image.height)
         image = image.crop((
             (image.width - size) // 2,

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pathlib
 
@@ -7,6 +6,7 @@ from modules.ui.ConfigList import ConfigList
 from modules.util import path_util
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.TrainConfig import TrainConfig
+from modules.util.image_util import load_image
 from modules.util.ui import components
 from modules.util.ui.UIState import UIState
 
@@ -38,6 +38,7 @@ class ConceptTab(ConfigList):
 
     def open_element_window(self, i, ui_state) -> ctk.CTkToplevel:
         return ConceptWindow(self.master, self.current_config[i], ui_state[0], ui_state[1], ui_state[2])
+
 
 class ConceptWidget(ctk.CTkFrame):
     def __init__(self, master, concept, i, open_command, remove_command, clone_command, save_command):
@@ -128,11 +129,11 @@ class ConceptWidget(ctk.CTkFrame):
             for path in pathlib.Path(self.concept.path).glob(glob_pattern):
                 extension = os.path.splitext(path)[1]
                 if path.is_file() and path_util.is_supported_image_extension(extension) \
-                        and not path.name.endswith("-masklabel.png"):
+                        and not path.name.endswith("-masklabel.png") and not path.name.endswith("-condlabel.png"):
                     preview_path = path_util.canonical_join(self.concept.path, path)
                     break
 
-        image = Image.open(preview_path)
+        image = load_image(preview_path, convert_mode="RGBA")
         size = min(image.width, image.height)
         image = image.crop((
             (image.width - size) // 2,

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -25,9 +25,10 @@ class ConceptTab(ConfigList):
             attr_name="concept_file_name",
             config_dir="training_concepts",
             default_config_name="concepts.json",
-            add_button_text="add concept",
+            add_button_text="Add Concept",
+            add_button_tooltip="Adds a new concept to the current config.",
             is_full_width=False,
-            can_disable_all=True
+            show_toggle_all_button=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):
@@ -141,7 +142,7 @@ class ConceptWidget(ctk.CTkFrame):
             (image.width - size) // 2 + size,
             (image.height - size) // 2 + size,
         ))
-        image = image.resize((150, 150), Image.Resampling.LANCZOS)
+        image = image.resize((150, 150), Image.Resampling.BILINEAR)
         return image
 
     def place_in_list(self):

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -28,7 +28,7 @@ class ConceptTab(ConfigList):
             add_button_text="Add Concept",
             add_button_tooltip="Adds a new concept to the current config.",
             is_full_width=False,
-            show_toggle_buttons=True
+            show_toggle_button=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -28,7 +28,7 @@ class ConceptTab(ConfigList):
             add_button_text="Add Concept",
             add_button_tooltip="Adds a new concept to the current config.",
             is_full_width=False,
-            show_toggle_all_button=True
+            show_toggle_buttons=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -101,7 +101,7 @@ class ConfigList(metaclass=ABCMeta):
     def open_element_window(self, i, ui_state) -> ctk.CTkToplevel:
         pass
 
-    def _update_any_item_enabled_state(self) -> bool:
+    def _update_any_item_enabled_state(self):
         self._is_current_item_enabled = False
         self._is_any_item_enabled = False
         if self.from_external_file:
@@ -126,7 +126,6 @@ class ConfigList(metaclass=ABCMeta):
                 pass
             except Exception:
                 traceback.print_exc()
-                return False
         else:
             for widget in self.widgets:
                 if widget.ui_state.get_var(self.enable_key).get():

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -93,8 +93,8 @@ class ConfigList(metaclass=ABCMeta):
         if self.from_external_file:
             current_config = getattr(self.train_config, self.attr_name)
             try:
-                for config_file_name in self.configs:
-                    with open(config_file_name[1], "r+") as f:
+                for (name, file_path) in self.configs:
+                    with open(file_path, "r+") as f:
                         loaded_config = json.load(f)
                         for item in loaded_config:
                             if isinstance(item, dict):
@@ -102,7 +102,7 @@ class ConfigList(metaclass=ABCMeta):
                             else:
                                 setattr(item, self.enabled_attr_name, False)
                     write_json_atomic(
-                        config_file_name[1],
+                        file_path,
                         loaded_config
                     )
                 self.__load_current_config(current_config)

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -92,8 +92,8 @@ class ConfigList(metaclass=ABCMeta):
     def disable_all(self):
         if self.from_external_file:
             current_config = getattr(self.train_config, self.attr_name)
-            for config_file_name in self.configs:
-                try:
+            try:
+                for config_file_name in self.configs:
                     with open(config_file_name[1], "r+") as f:
                         loaded_config = json.load(f)
                         for item in loaded_config:
@@ -106,9 +106,9 @@ class ConfigList(metaclass=ABCMeta):
                         loaded_config
                     )
                     self.__load_current_config(current_config)
-                except Exception:
-                    traceback.print_exc()
-                    print("Failed to disable all items in all configs")
+            except Exception:
+                traceback.print_exc()
+                print("Failed to disable all items in all configs")
         else:
             for config in self.current_config:
                 setattr(config, self.enabled_attr_name, False)

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -170,7 +170,7 @@ class ConfigList(metaclass=ABCMeta):
                     )
             except Exception:
                 traceback.print_exc()
-                print(f"Failed to set all items to {enable_state} in {"all configs" if all_configs else "current config"}")
+                print(f"Failed to set all items to {enable_state} in {'all configs' if all_configs else 'current config'}")
                 # refresh from file if anything goes wrong to make sure UI state is accurate
                 self.__load_current_config(current_config_path)
             else:

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -90,14 +90,17 @@ class ConfigList(metaclass=ABCMeta):
         pass
 
     def disable_all(self):
-        if (self.from_external_file):
+        if self.from_external_file:
             current_config = getattr(self.train_config, self.attr_name)
             for config_file_name in self.configs:
                 try:
                     with open(config_file_name[1], "r+") as f:
                         loaded_config = json.load(f)
-                        for concept in loaded_config:
-                            concept["enabled"] = False
+                        for item in loaded_config:
+                            if isinstance(item, dict):
+                                item[self.enabled_attr_name] = False
+                            else:
+                                setattr(item, self.enabled_attr_name, False)
                     write_json_atomic(
                         config_file_name[1],
                         loaded_config

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -93,7 +93,7 @@ class ConfigList(metaclass=ABCMeta):
         if self.from_external_file:
             current_config = getattr(self.train_config, self.attr_name)
             try:
-                for (name, file_path) in self.configs:
+                for (_name, file_path) in self.configs:
                     with open(file_path, "r+") as f:
                         loaded_config = json.load(f)
                         for item in loaded_config:

--- a/modules/ui/ConfigList.py
+++ b/modules/ui/ConfigList.py
@@ -105,7 +105,7 @@ class ConfigList(metaclass=ABCMeta):
                         config_file_name[1],
                         loaded_config
                     )
-                    self.__load_current_config(current_config)
+                self.__load_current_config(current_config)
             except Exception:
                 traceback.print_exc()
                 print("Failed to disable all items in all configs")

--- a/modules/ui/SamplingTab.py
+++ b/modules/ui/SamplingTab.py
@@ -21,6 +21,7 @@ class SamplingTab(ConfigList):
             default_config_name="samples.json",
             add_button_text="add sample",
             is_full_width=True,
+            can_disable_all=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/SamplingTab.py
+++ b/modules/ui/SamplingTab.py
@@ -22,7 +22,7 @@ class SamplingTab(ConfigList):
             add_button_text="Add Sample",
             add_button_tooltip="Add a new sample configuration.",
             is_full_width=True,
-            show_toggle_all_button=True
+            show_toggle_buttons=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/SamplingTab.py
+++ b/modules/ui/SamplingTab.py
@@ -21,7 +21,7 @@ class SamplingTab(ConfigList):
             default_config_name="samples.json",
             add_button_text="add sample",
             is_full_width=True,
-            can_disable_all=True
+            show_toggle_all_button=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/SamplingTab.py
+++ b/modules/ui/SamplingTab.py
@@ -22,7 +22,7 @@ class SamplingTab(ConfigList):
             add_button_text="Add Sample",
             add_button_tooltip="Add a new sample configuration.",
             is_full_width=True,
-            show_toggle_buttons=True
+            show_toggle_button=True
         )
 
     def create_widget(self, master, element, i, open_command, remove_command, clone_command, save_command):

--- a/modules/ui/SamplingTab.py
+++ b/modules/ui/SamplingTab.py
@@ -19,7 +19,8 @@ class SamplingTab(ConfigList):
             attr_name="sample_definition_file_name",
             config_dir="training_samples",
             default_config_name="samples.json",
-            add_button_text="add sample",
+            add_button_text="Add Sample",
+            add_button_tooltip="Add a new sample configuration.",
             is_full_width=True,
             show_toggle_all_button=True
         )

--- a/modules/util/ui/components.py
+++ b/modules/util/ui/components.py
@@ -316,7 +316,7 @@ def switch(
     if command:
         trace_id = ui_state.add_var_trace(var_name, command)
 
-    component = ctk.CTkSwitch(master, variable=var, text=text)
+    component = ctk.CTkSwitch(master, variable=var, text=text, command=command)
     component.grid(row=row, column=column, padx=PAD, pady=(PAD, PAD), sticky="new")
 
     def create_destroy(component):

--- a/modules/util/ui/components.py
+++ b/modules/util/ui/components.py
@@ -185,9 +185,13 @@ def icon_button(master, row, column, text, command):
     return component
 
 
-def button(master, row, column, text, command, tooltip=None):
-    component = ctk.CTkButton(master, text=text, command=command)
-    component.grid(row=row, column=column, padx=PAD, pady=PAD, sticky="new")
+def button(master, row, column, text, command, tooltip=None, **kwargs):
+    # Pop grid-specific parameters from kwargs, using PAD as the default if not provided.
+    padx = kwargs.pop('padx', PAD)
+    pady = kwargs.pop('pady', PAD)
+
+    component = ctk.CTkButton(master, text=text, command=command, **kwargs)
+    component.grid(row=row, column=column, padx=padx, pady=pady, sticky="new")
     if tooltip:
         ToolTip(component, tooltip, x_position=25)
     return component


### PR DESCRIPTION
Saw a couple people talking about a 'disable all' button for the concept and sampling tabs and decided to update `ConfigList` to have a couple configurable attributes to allow this. Seemed minor so I opted not to create a discussion, but I can open one if needed.

Concepts tab:
![PjMCGkg9mA](https://github.com/user-attachments/assets/fc51021a-20b1-441f-b6b0-928f2e5ed0b3)

Sampling tab:
![CfLEhUUurP](https://github.com/user-attachments/assets/5e107527-874a-43e5-a214-c81827941a49)

Additional embeddings tab:
![u4KVyanwL1](https://github.com/user-attachments/assets/2a3ae7a6-4ba0-4cfa-a1ad-760e8eb8b5f0)

Scheduler params window (unchanged):
![python_2STQPvDRau](https://github.com/user-attachments/assets/56fa64bf-e511-44f5-9c12-3bf4ec530a0e)