### PR TITLE
add mps filter to ZLUDA check

### DIFF
--- a/modules/zluda/ZLUDA.py
+++ b/modules/zluda/ZLUDA.py
@@ -7,7 +7,7 @@ from torch._prims_common import DeviceLikeType
 
 def is_zluda(device: DeviceLikeType):
     device = torch.device(device)
-    if device.type == "cpu":
+    if device.type in ["cpu", "mps"]:
         return False
     return torch.cuda.get_device_name(device).endswith("[ZLUDA]")
 


### PR DESCRIPTION
Trying to dry run this on macos failed with the following error 
```bash
Exception in thread Thread-1 (__training_thread_function):
Traceback (most recent call last):
  File "${home}/.pyenv/versions/3.12.11/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "${home}/.pyenv/versions/3.12.11/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "${home}/code/OneTrainer/modules/ui/TrainUI.py", line 597, in __training_thread_function
    ZLUDA.initialize_devices(self.train_config)
  File "${home}/code/OneTrainer/modules/zluda/ZLUDA.py", line 37, in initialize_devices
    if not is_zluda(config.train_device) and not is_zluda(config.temp_device):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "${home}/code/OneTrainer/modules/zluda/ZLUDA.py", line 12, in is_zluda
    return torch.cuda.get_device_name(device).endswith("[ZLUDA]")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "${home}/code/OneTrainer/venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 544, in get_device_name
    return get_device_properties(device).name
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "${home}/code/OneTrainer/venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 576, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "${home}/code/OneTrainer/venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 363, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

adding mps to filter out ZLUDA solved it. Hope this helps someone else