### PR TITLE
Tensorboard on tweaks

### DIFF
--- a/modules/trainer/BaseTrainer.py
+++ b/modules/trainer/BaseTrainer.py
@@ -1,6 +1,4 @@
-import os
 import subprocess
-import sys
 from abc import ABCMeta, abstractmethod
 
 from modules.model.BaseModel import BaseModel
@@ -12,6 +10,7 @@ from modules.util import create
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.TrainConfig import TrainConfig
+from modules.util.tensorboard_util import start_filtered_tensorboard, stop_tensorboard
 from modules.util.TimedActionMixin import TimedActionMixin
 from modules.util.TrainProgress import TrainProgress
 
@@ -84,23 +83,10 @@ class BaseTrainer(
             self.config.model_type,
             self.config.training_method
         )
+
     def _start_tensorboard(self):
-        tensorboard_executable = os.path.join(os.path.dirname(sys.executable), "tensorboard")
-        tensorboard_log_dir = os.path.join(self.config.workspace_dir, "tensorboard")
-
-        tensorboard_args = [
-            tensorboard_executable,
-            "--logdir",
-            tensorboard_log_dir,
-            "--port",
-            str(self.config.tensorboard_port),
-            "--samples_per_plugin=images=100,scalars=10000",
-        ]
-
-        if self.config.tensorboard_expose:
-            tensorboard_args.append("--bind_all")
-
-        self.tensorboard_subprocess = subprocess.Popen(tensorboard_args)
+        self.tensorboard_subprocess = start_filtered_tensorboard(self.config)
 
     def _stop_tensorboard(self):
-        self.tensorboard_subprocess.kill()
+        stop_tensorboard(self.tensorboard_subprocess)
+        self.tensorboard_subprocess = None

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -23,6 +23,7 @@ from modules.util.dtype_util import create_grad_scaler, enable_grad_scaling
 from modules.util.enum.ConceptType import ConceptType
 from modules.util.enum.FileType import FileType
 from modules.util.enum.ModelFormat import ModelFormat
+from modules.util.enum.TensorboardMode import TensorboardMode
 from modules.util.enum.TimeUnit import TimeUnit
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.memory_util import TorchMemoryRecorder
@@ -66,7 +67,7 @@ class GenericTrainer(BaseTrainer):
         tensorboard_log_dir = os.path.join(config.workspace_dir, "tensorboard")
         os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
         self.tensorboard = SummaryWriter(os.path.join(tensorboard_log_dir, f"{config.save_filename_prefix}{get_string_timestamp()}"))
-        if config.tensorboard and not config.tensorboard_always_on:
+        if config.tensorboard_mode == TensorboardMode.TRAIN_ONLY:
             super()._start_tensorboard()
 
         self.model = None
@@ -799,7 +800,7 @@ class GenericTrainer(BaseTrainer):
 
         self.tensorboard.close()
 
-        if self.config.tensorboard and not self.config.tensorboard_always_on:
+        if self.config.tensorboard_mode == TensorboardMode.TRAIN_ONLY:
             super()._stop_tensorboard()
 
         for handle in self.grad_hook_handles:

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -211,20 +211,22 @@ class TrainUI(ctk.CTk):
         components.dir_entry(frame, 5, 1, self.ui_state, "debug_dir")
 
         # tensorboard
-        components.label(frame, 6, 0, "Tensorboard",
-                         tooltip="Starts the Tensorboard Web UI during training")
+        components.label(frame, 6, 0, "Tensorboard During Training",
+                         tooltip="Starts the Tensorboard Web UI during training only")
         components.switch(frame, 6, 1, self.ui_state, "tensorboard")
 
-        components.label(frame, 7, 0, "Expose Tensorboard",
-                         tooltip="Exposes Tensorboard Web UI to all network interfaces (makes it accessible from the network)")
-        components.switch(frame, 7, 1, self.ui_state, "tensorboard_expose")
-        components.label(frame, 7, 2, "Tensorboard Port",
-                         tooltip="Port to use for Tensorboard link")
-        components.entry(frame, 7, 3, self.ui_state, "tensorboard_port")
-
-        components.label(frame, 8, 0, "Always-On Tensorboard",
+        components.label(frame, 7, 0, "Always-On Tensorboard",
                          tooltip="Keep Tensorboard accessible even when not training. Useful for monitoring completed training sessions.")
-        components.switch(frame, 8, 1, self.ui_state, "tensorboard_always_on", command=self._on_always_on_tensorboard_toggle)
+        components.switch(frame, 7, 1, self.ui_state, "tensorboard_always_on", command=self._on_always_on_tensorboard_toggle)
+
+        components.label(frame, 8, 0, "Tensorboard Port",
+                         tooltip="Port to use for Tensorboard link")
+        components.entry(frame, 8, 1, self.ui_state, "tensorboard_port")
+
+        components.label(frame, 8, 2, "Expose Tensorboard",
+                         tooltip="Exposes Tensorboard Web UI to all network interfaces (makes it accessible from the network)")
+        components.switch(frame, 8, 3, self.ui_state, "tensorboard_expose")
+
 
         # validation
         components.label(frame, 9, 0, "Validation",

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -623,16 +623,16 @@ class TrainUI(ctk.CTk):
                 self.ui_state.get_var("secrets.cloud").update(self.train_config.secrets.cloud)
             error_caught = True
             traceback.print_exc()
+        finally:
+            trainer.end()
 
-        trainer.end()
+            # clear gpu memory
+            del trainer
 
-        # clear gpu memory
-        del trainer
-
-        self.training_thread = None
-        self.training_commands = None
-        torch.clear_autocast_cache()
-        torch_gc()
+            self.training_thread = None
+            self.training_commands = None
+            torch.clear_autocast_cache()
+            torch_gc()
 
         if error_caught:
             self.on_update_status("error: check the console for more information")

--- a/modules/util/config/BaseConfig.py
+++ b/modules/util/config/BaseConfig.py
@@ -108,11 +108,18 @@ class BaseConfig:
                     else:
                         setattr(self, name, str(data[name]))
                 elif issubclass_safe(self.types[name], Enum):
-                    if isinstance(data[name], str):
-                        if self.nullables[name]:
-                            setattr(self, name, None if data[name] is None else self.types[name][data[name]])
-                        else:
-                            setattr(self, name, self.types[name][data[name]])
+                    if data[name] is None and self.nullables[name]:
+                        setattr(self, name, None)
+                    elif isinstance(data[name], str):
+                        try:
+                            # Try to set by value first (for StrEnum)
+                            setattr(self, name, self.types[name](data[name]))
+                        except ValueError:
+                            try:
+                                # Fallback to setting by name for other Enum types
+                                setattr(self, name, self.types[name][data[name]])
+                            except KeyError:
+                                print(f"Could not set {name} as {str(data[name])}")
                     else:
                         setattr(self, name, data[name])
                 elif self.types[name] is bool:

--- a/modules/util/enum/TensorboardMode.py
+++ b/modules/util/enum/TensorboardMode.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class TensorboardMode(StrEnum):
+    OFF = "off"
+    TRAIN_ONLY = "train_only"
+    ALWAYS_ON = "always_on"

--- a/modules/util/tensorboard_util.py
+++ b/modules/util/tensorboard_util.py
@@ -1,0 +1,83 @@
+import contextlib
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from modules.util.config.TrainConfig import TrainConfig
+
+
+def get_tensorboard_args(config: TrainConfig) -> list[str]:
+    """Get Tensorboard command line arguments"""
+    tensorboard_executable = os.path.join(os.path.dirname(sys.executable), "tensorboard")
+    tensorboard_log_dir = os.path.join(config.workspace_dir, "tensorboard")
+
+    os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
+
+    args = [
+        tensorboard_executable,
+        "--logdir",
+        tensorboard_log_dir,
+        "--port",
+        str(config.tensorboard_port),
+        "--samples_per_plugin=images=100,scalars=10000",
+    ]
+
+    if config.tensorboard_expose:
+        args.append("--bind_all")
+
+    return args
+
+
+def start_filtered_tensorboard(config: TrainConfig) -> subprocess.Popen | None:
+    """Start Tensorboard with filtered output"""
+    try:
+        print("Starting Tensorboard please wait...")
+        env = os.environ.copy()
+        env['PYTHONWARNINGS'] = 'ignore::UserWarning:tensorboard.default'
+
+        process = subprocess.Popen(
+            get_tensorboard_args(config),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+
+        def filter_output():
+            for line in iter(process.stdout.readline, ''):
+                # https://github.com/tensorflow/tensorboard/issues/7003
+                line_lower = line.lower().strip()
+                if (
+                    "pkg_resources" in line_lower or
+                    "installation not found" in line_lower
+                ):
+                    continue  # Skip these lines
+
+                if line.strip():
+                    print(line, end='')
+
+        threading.Thread(target=filter_output, daemon=True).start()
+
+        return process
+
+    except Exception as e:
+        print(f"Failed to start Tensorboard: {e}")
+        return None
+
+
+def stop_tensorboard(process: subprocess.Popen | None):
+    """Gracefully stop the Tensorboard subprocess"""
+    if not process:
+        return
+
+    try:
+        print("Stopping Tensorboard...")
+        process.terminate()
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(Exception):
+            process.kill()
+    except Exception:
+        pass

--- a/modules/util/ui/UIState.py
+++ b/modules/util/ui/UIState.py
@@ -68,22 +68,27 @@ class UIState:
         return update
 
     def __set_enum_var(self, obj, is_dict, name, var, var_type, nullable):
-        if is_dict:
-            def update(_0, _1, _2):
-                string_var = var.get()
-                if (string_var == "" or string_var == "None") and nullable:
-                    obj[name] = None
-                else:
-                    obj[name] = var_type[string_var]
-                self.__call_var_traces(name)
-        else:
-            def update(_0, _1, _2):
-                string_var = var.get()
-                if (string_var == "" or string_var == "None") and nullable:
-                    setattr(obj, name, None)
-                else:
-                    setattr(obj, name, var_type[string_var])
-                self.__call_var_traces(name)
+        def update(_0, _1, _2):
+            string_var = var.get()
+            value_to_set = None
+
+            if not ((string_var == "" or string_var == "None") and nullable):
+                try:
+                    # Try to set by value first (for StrEnum)
+                    value_to_set = var_type(string_var)
+                except ValueError:
+                    try:
+                        # Fallback to setting by name for other Enum types
+                        value_to_set = var_type[string_var]
+                    except KeyError:
+                        print(f"Could not set {name} as {string_var}")
+
+            if is_dict:
+                obj[name] = value_to_set
+            else:
+                setattr(obj, name, value_to_set)
+
+            self.__call_var_traces(name)
 
         return update
 


### PR DESCRIPTION
The tensorboard logic needed some tweaking. Always-on shouldnt be terminated in training, it should persist + be a little more safe. New Tensorboard warnings (as of 1week ago) need filtering: https://github.com/tensorflow/tensorboard/issues/7003

## Commit - 84c9f89c2b47a78d184d557cb8fee07233ad2586

Keeps pretty much the same UI structure that Bitcrushed had


## Commit - 6c7a7bc25dc6335a6b7ada07a19c4c9ca39b9554

Moves to an `option_kv` dropdown instead. Much easier for users to understand and logic is simpler.

![image](https://github.com/user-attachments/assets/803c81d8-6092-413e-a97a-810e3e3a105a)
