### PR TITLE
Add SSH keyfile support for Linux cloud training

### DIFF
--- a/modules/cloud/BaseSSHFileSync.py
+++ b/modules/cloud/BaseSSHFileSync.py
@@ -11,7 +11,7 @@ import fabric
 class BaseSSHFileSync(BaseFileSync):
     def __init__(self, config: CloudConfig, secrets: CloudSecretsConfig):
         super().__init__(config, secrets)
-        self.sync_connection=fabric.Connection(host=secrets.host,port=secrets.port,user=secrets.user)
+        self.sync_connection = secrets.create_connection()
 
     def close(self):
         if self.sync_connection:

--- a/modules/cloud/FabricFileSync.py
+++ b/modules/cloud/FabricFileSync.py
@@ -11,7 +11,7 @@ class FabricFileSync(BaseSSHFileSync):
         super().__init__(config,secrets)
 
     def __upload_batch(self,local_files,remote_dir : Path):
-        with fabric.Connection(host=self.secrets.host,port=self.secrets.port,user=self.secrets.user) as connection:
+        with self.secrets.create_connection() as connection:
             for local_file in local_files:
                 self.__put(connection,local_file=local_file,remote_file=remote_dir / local_file.name)
 
@@ -26,7 +26,7 @@ class FabricFileSync(BaseSSHFileSync):
                 max_batch_size=100)
 
     def __download_batch(self,local_dir : Path,remote_files):
-        with fabric.Connection(host=self.secrets.host,port=self.secrets.port,user=self.secrets.user) as connection:
+        with self.secrets.create_connection() as connection:
             for remote_file in remote_files:
                 self.__get(connection,local_file=local_dir / remote_file.name,remote_file=remote_file)
 

--- a/modules/cloud/LinuxCloud.py
+++ b/modules/cloud/LinuxCloud.py
@@ -44,13 +44,13 @@ class LinuxCloud(BaseCloud):
             raise ValueError('Host and port required for SSH connection')
 
         try:
-            self.connection=fabric.Connection(host=secrets.host,port=secrets.port,user=secrets.user)
+            self.connection=secrets.create_connection()
             self.connection.open()
             self.connection.transport.set_keepalive(30)
 
-            self.callback_connection=fabric.Connection(host=secrets.host,port=secrets.port,user=secrets.user)
+            self.callback_connection=secrets.create_connection()
 
-            self.command_connection=fabric.Connection(host=secrets.host,port=secrets.port,user=secrets.user)
+            self.command_connection=secrets.create_connection()
             #the command connection isn't used for long periods of time; prevent remote from closing it:
             self.command_connection.open()
             self.command_connection.transport.set_keepalive(30)

--- a/modules/cloud/NativeSCPFileSync.py
+++ b/modules/cloud/NativeSCPFileSync.py
@@ -13,6 +13,9 @@ class NativeSCPFileSync(BaseSSHFileSync):
                 "-P", str(secrets.port),
                 "-o", "StrictHostKeyChecking=no",
             ]
+        
+        if secrets.keyfile:
+            self.base_args.extend(["-i", secrets.keyfile])
 
     def __upload_batch(self,local_files,remote_dir : Path):
         args=self.base_args.copy()

--- a/modules/ui/CloudTab.py
+++ b/modules/ui/CloudTab.py
@@ -48,29 +48,35 @@ class CloudTab:
             ("FABRIC_SFTP", CloudFileSync.FABRIC_SFTP),
         ], self.ui_state, "cloud.file_sync")
 
+
         components.label(self.frame, 3, 0, "API key",
                          tooltip="Cloud service API key for RUNPOD. Leave empty for LINUX. This value is stored separately, not saved to your configuration file. ")
         components.entry(self.frame, 3, 1, self.ui_state, "secrets.cloud.api_key")
 
-        components.label(self.frame, 4, 0, "Hostname",
+        # SSH keyfile path component
+        components.label(self.frame, 4, 0, "SSH keyfile path",
+                         tooltip="Path to your SSH private key file used for authentication. Leave empty to use no key.")
+        components.entry(self.frame, 4, 1, self.ui_state, "secrets.cloud.keyfile")
+
+        components.label(self.frame, 5, 0, "Hostname",
                          tooltip="SSH server hostname or IP. Leave empty if you have a Cloud ID or want to automatically create a new cloud.")
-        components.entry(self.frame, 4, 1, self.ui_state, "secrets.cloud.host")
+        components.entry(self.frame, 5, 1, self.ui_state, "secrets.cloud.host")
 
-        components.label(self.frame, 5, 0, "Port",
+        components.label(self.frame, 6, 0, "Port",
                          tooltip="SSH server port. Leave empty if you have a Cloud ID or want to automatically create a new cloud.")
-        components.entry(self.frame, 5, 1, self.ui_state, "secrets.cloud.port")
+        components.entry(self.frame, 6, 1, self.ui_state, "secrets.cloud.port")
 
-        components.label(self.frame, 6, 0, "User",
+        components.label(self.frame, 7, 0, "User",
                          tooltip='SSH username. Use "root" for RUNPOD. Your SSH client must be set up to connect to the cloud using a public key, without a password. For RUNPOD, create an ed25519 key locally, and copy the contents of the public keyfile to your "SSH Public Keys" on the RunPod website.')
-        components.entry(self.frame, 6, 1, self.ui_state, "secrets.cloud.user")
+        components.entry(self.frame, 7, 1, self.ui_state, "secrets.cloud.user")
 
-        components.label(self.frame, 7, 0, "Cloud id",
+        components.label(self.frame, 8, 0, "Cloud id",
                          tooltip="RUNPOD Cloud ID. The cloud service must have a public IP and SSH service. Leave empty if you want to automatically create a new RUNPOD cloud, or if you're connecting to another cloud provider via SSH Hostname and Port.")
-        components.entry(self.frame, 7, 1, self.ui_state, "secrets.cloud.id")
+        components.entry(self.frame, 8, 1, self.ui_state, "secrets.cloud.id")
 
-        components.label(self.frame, 8, 0, "Tensorboard TCP tunnel",
+        components.label(self.frame, 9, 0, "Tensorboard TCP tunnel",
                          tooltip="Instead of starting tensorboard locally, make a TCP tunnel to a tensorboard on the cloud")
-        components.switch(self.frame, 8, 1, self.ui_state, "cloud.tensorboard_tunnel")
+        components.switch(self.frame, 9, 1, self.ui_state, "cloud.tensorboard_tunnel")
 
 
 

--- a/modules/util/config/CloudConfig.py
+++ b/modules/util/config/CloudConfig.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import fabric
+
 from modules.util.config.BaseConfig import BaseConfig
 from modules.util.enum.CloudAction import CloudAction
 from modules.util.enum.CloudFileSync import CloudFileSync
@@ -8,6 +10,7 @@ from modules.util.enum.CloudType import CloudType
 
 class CloudSecretsConfig(BaseConfig):
     api_key: str
+    keyfile: str
     host: str
     port: int
     user: str
@@ -16,11 +19,25 @@ class CloudSecretsConfig(BaseConfig):
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
 
+    def create_connection(self):
+        """Create a fabric connection using these secrets"""
+        if not self.host or not self.port:
+            raise ValueError('Host and port required for connection')
+        
+        connect_kwargs = {'key_filename': self.keyfile} if self.keyfile else {}
+        return fabric.Connection(
+            host=self.host,
+            port=self.port,
+            user=self.user,
+            connect_kwargs=connect_kwargs
+        )
+
     @staticmethod
     def default_values():
         data = []
 
         data.append(("api_key", "", str, False))
+        data.append(("keyfile", "", str, False))
         data.append(("id", "", str, False))
         data.append(("host", "", str, False))
         data.append(("port", 0, str, False))


### PR DESCRIPTION
Introduce support for SSH keyfiles to enhance the functionality of cloud training on Linux.