### PR TITLE
SMMF (Square-Matricized Momentum Factorization)

### DIFF
--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -165,6 +165,8 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
             'vector_reshape': {'title': 'vector_reshape', 'tooltip': 'If True (default), 1D tensors (like bias terms) are reshaped into 2D matrices and factorized for maximum memory savings. If False, they are updated using a standard, non-factorized method, which may improve stability at a negligible memory cost.', 'type': 'bool'},
             'beta1_growth_rate': {'title': 'beta1 growth rate', 'tooltip': 'First Momentum Growth Rate (lambda). SMMF-specific hyperparameter that modifies the beta coefficient over time. A value less than 1.0 gradually reduces the influence of the first moments history, allowing the optimizer to adapt more to recent gradients later in training.', 'type': 'float'},
             'factored_sign': {'title': 'factored sign', 'tooltip': 'An experimental feature. If True, the optimizer will mathematically decompose the first momentum matrix (M) into its positive (M pos) and negative (M neg) components, and then approximate each using its own rank-1 factorization. This pushes memory savings even further at the cost of an additional approximation.', 'type': 'bool'},
+            'use_orthograd': {'title': 'use_orthograd', 'tooltip': 'Prevents "naïve loss minimization" (NLM) that can lead to overfitting by removing the gradient component parallel to the weight, thus improving generalization.', 'type': 'bool'},
+            'use_atan2': {'title': 'use_atan2', 'tooltip': 'A robust replacement for eps (no tuning required), which also incorporates gradient clipping. (If True, eps is ignored).', 'type': 'bool'},
         }
         # @formatter:on
 

--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -161,6 +161,9 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
             'use_grams': {'title': 'use_grams', 'tooltip': 'Use grams method', 'type': 'bool'},
             'use_adopt': {'title': 'use_adopt', 'tooltip': 'Use adopt method', 'type': 'bool'},
             'use_focus': {'title': 'use_focus', 'tooltip': 'Use focus method', 'type': 'bool'},
+            'vector_reshape': {'title': 'vector_reshape', 'tooltip': ' If True (default), 1D tensors (like bias terms) are reshaped into 2D matrices and factorized for maximum memory savings. If False, they are updated using a standard, non-factorized method, which may improve stability at a negligible memory cost.', 'type': 'bool'},
+            'use_bmf': {'title': 'use_bmf', 'tooltip': 'Binary Matrix Factorization. An experimental feature. If True, the optimizer will attempt to also factorize the 1-bit sign matrix of the first momentum, pushing memory savings even further at the cost of an additional approximation.', 'type': 'bool'},
+            'beta1_growth_rate': {'title': 'beta1 growth rate', 'tooltip': 'First Momentum Growth Rate (lambda). SMMF-specific hyperparameter that modifies the beta coefficient over time. A value less than 1.0 gradually reduces the influence of the first moments history, allowing the optimizer to adapt more to recent gradients later in training.', 'type': 'float'},
         }
         # @formatter:on
 

--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -163,7 +163,6 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
             'use_adopt': {'title': 'use_adopt', 'tooltip': 'Use adopt method', 'type': 'bool'},
             'use_focus': {'title': 'use_focus', 'tooltip': 'Use focus method', 'type': 'bool'},
             'vector_reshape': {'title': 'vector_reshape', 'tooltip': ' If True (default), 1D tensors (like bias terms) are reshaped into 2D matrices and factorized for maximum memory savings. If False, they are updated using a standard, non-factorized method, which may improve stability at a negligible memory cost.', 'type': 'bool'},
-            'use_bmf': {'title': 'use_bmf', 'tooltip': 'Binary Matrix Factorization. An experimental feature. If True, the optimizer will attempt to also factorize the 1-bit sign matrix of the first momentum, pushing memory savings even further at the cost of an additional approximation.', 'type': 'bool'},
             'beta1_growth_rate': {'title': 'beta1 growth rate', 'tooltip': 'First Momentum Growth Rate (lambda). SMMF-specific hyperparameter that modifies the beta coefficient over time. A value less than 1.0 gradually reduces the influence of the first moments history, allowing the optimizer to adapt more to recent gradients later in training.', 'type': 'float'},
         }
         # @formatter:on

--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -162,8 +162,9 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
             'use_grams': {'title': 'use_grams', 'tooltip': 'Use grams method', 'type': 'bool'},
             'use_adopt': {'title': 'use_adopt', 'tooltip': 'Use adopt method', 'type': 'bool'},
             'use_focus': {'title': 'use_focus', 'tooltip': 'Use focus method', 'type': 'bool'},
-            'vector_reshape': {'title': 'vector_reshape', 'tooltip': ' If True (default), 1D tensors (like bias terms) are reshaped into 2D matrices and factorized for maximum memory savings. If False, they are updated using a standard, non-factorized method, which may improve stability at a negligible memory cost.', 'type': 'bool'},
+            'vector_reshape': {'title': 'vector_reshape', 'tooltip': 'If True (default), 1D tensors (like bias terms) are reshaped into 2D matrices and factorized for maximum memory savings. If False, they are updated using a standard, non-factorized method, which may improve stability at a negligible memory cost.', 'type': 'bool'},
             'beta1_growth_rate': {'title': 'beta1 growth rate', 'tooltip': 'First Momentum Growth Rate (lambda). SMMF-specific hyperparameter that modifies the beta coefficient over time. A value less than 1.0 gradually reduces the influence of the first moments history, allowing the optimizer to adapt more to recent gradients later in training.', 'type': 'float'},
+            'factored_sign': {'title': 'factored sign', 'tooltip': 'An experimental feature. If True, the optimizer will mathematically decompose the first momentum matrix (M) into its positive (M pos) and negative (M neg) components, and then approximate each using its own rank-1 factorization. This pushes memory savings even further at the cost of an additional approximation.', 'type': 'bool'},
         }
         # @formatter:on
 

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -107,6 +107,9 @@ class TrainOptimizerConfig(BaseConfig):
     use_grams: False
     use_adopt: False
     use_focus: False
+    vector_reshape: False
+    use_bmf: False
+    beta1_growth_rate: float
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
@@ -190,6 +193,9 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("use_grams", False, bool, False))
         data.append(("use_adopt", False, bool, False))
         data.append(("use_focus", False, bool, False))
+        data.append(("vector_reshape", False, bool, False))
+        data.append(("use_bmf", False, bool, False))
+        data.append(("beta1_growth_rate", None, float, True))
 
         return TrainOptimizerConfig(data)
 

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -111,6 +111,8 @@ class TrainOptimizerConfig(BaseConfig):
     vector_reshape: False
     beta1_growth_rate: float
     factored_sign: False
+    use_orthograd: False
+    use_atan2: False
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
@@ -198,6 +200,8 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("vector_reshape", False, bool, False))
         data.append(("beta1_growth_rate", None, float, True))
         data.append(("factored_sign", False, bool, False))
+        data.append(("use_orthograd", False, bool, False))
+        data.append(("use_atan2", False, bool, False))
 
         return TrainOptimizerConfig(data)
 

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -109,7 +109,6 @@ class TrainOptimizerConfig(BaseConfig):
     use_adopt: False
     use_focus: False
     vector_reshape: False
-    use_bmf: False
     beta1_growth_rate: float
 
     def __init__(self, data: list[(str, Any, type, bool)]):
@@ -196,7 +195,6 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("use_adopt", False, bool, False))
         data.append(("use_focus", False, bool, False))
         data.append(("vector_reshape", False, bool, False))
-        data.append(("use_bmf", False, bool, False))
         data.append(("beta1_growth_rate", None, float, True))
 
         return TrainOptimizerConfig(data)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -110,6 +110,7 @@ class TrainOptimizerConfig(BaseConfig):
     use_focus: False
     vector_reshape: False
     beta1_growth_rate: float
+    factored_sign: False
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
@@ -196,6 +197,7 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("use_focus", False, bool, False))
         data.append(("vector_reshape", False, bool, False))
         data.append(("beta1_growth_rate", None, float, True))
+        data.append(("factored_sign", False, bool, False))
 
         return TrainOptimizerConfig(data)
 

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -959,7 +959,7 @@ def create_optimizer(
                 lr=config.learning_rate,
                 eps=optimizer_config.eps if optimizer_config.eps is not None else 1e-8,
                 decay_rate=optimizer_config.decay_rate if optimizer_config.decay_rate is not None else -0.8,
-                beta1=optimizer_config.beta1 if optimizer_config.beta1 is not None else 0.9,
+                beta1=optimizer_config.beta1 if optimizer_config.beta1 is not None else None,
                 weight_decay=optimizer_config.weight_decay if optimizer_config.weight_decay is not None else 0,
                 vector_reshape=optimizer_config.vector_reshape,
                 use_bmf=optimizer_config.use_bmf,

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -982,6 +982,7 @@ def create_optimizer(
                 vector_reshape=optimizer_config.vector_reshape,
                 beta1_growth_rate=optimizer_config.beta1_growth_rate if optimizer_config.beta1_growth_rate is not None else 0.999,
                 stochastic_rounding=optimizer_config.stochastic_rounding,
+                factored_sign=optimizer_config.factored_sign if optimizer_config.factored_sign is not None else False,
             )
 
         # ADABELIEF Optimizer

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -951,6 +951,22 @@ def create_optimizer(
                 use_cautious=optimizer_config.use_cautious,
             )
 
+        # SMMF Optimizer
+        case Optimizer.SMMF:
+            from modules.util.optimizer.SMMF import SMMF
+            optimizer = SMMF(
+                params=parameters,
+                lr=config.learning_rate,
+                eps=optimizer_config.eps if optimizer_config.eps is not None else 1e-8,
+                decay_rate=optimizer_config.decay_rate if optimizer_config.decay_rate is not None else -0.8,
+                beta1=optimizer_config.beta1 if optimizer_config.beta1 is not None else 0.9,
+                weight_decay=optimizer_config.weight_decay if optimizer_config.weight_decay is not None else 0,
+                vector_reshape=optimizer_config.vector_reshape,
+                use_bmf=optimizer_config.use_bmf,
+                beta1_growth_rate=optimizer_config.beta1_growth_rate if optimizer_config.beta1_growth_rate is not None else 0.999,
+                stochastic_rounding=optimizer_config.stochastic_rounding,
+            )
+
         # ADABELIEF Optimizer
         case Optimizer.ADABELIEF:
             from timm.optim.adabelief import AdaBelief

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -983,6 +983,9 @@ def create_optimizer(
                 beta1_growth_rate=optimizer_config.beta1_growth_rate if optimizer_config.beta1_growth_rate is not None else 0.999,
                 stochastic_rounding=optimizer_config.stochastic_rounding,
                 factored_sign=optimizer_config.factored_sign if optimizer_config.factored_sign is not None else False,
+                use_grams=optimizer_config.use_grams if optimizer_config.use_grams is not None else False,
+                use_orthograd=optimizer_config.use_orthograd if optimizer_config.use_orthograd is not None else False,
+                use_atan2=optimizer_config.use_atan2 if optimizer_config.use_atan2 is not None else False,
             )
 
         # ADABELIEF Optimizer

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -980,7 +980,6 @@ def create_optimizer(
                 beta1=optimizer_config.beta1 if optimizer_config.beta1 is not None else None,
                 weight_decay=optimizer_config.weight_decay if optimizer_config.weight_decay is not None else 0,
                 vector_reshape=optimizer_config.vector_reshape,
-                use_bmf=optimizer_config.use_bmf,
                 beta1_growth_rate=optimizer_config.beta1_growth_rate if optimizer_config.beta1_growth_rate is not None else 0.999,
                 stochastic_rounding=optimizer_config.stochastic_rounding,
             )

--- a/modules/util/enum/Optimizer.py
+++ b/modules/util/enum/Optimizer.py
@@ -60,6 +60,9 @@ class Optimizer(Enum):
     # CAME
     CAME = 'CAME'
 
+    # SMMF
+    SMMF = 'SMMF'
+
     #Pytorch Optimizers
     ADABELIEF = 'ADABELIEF'
     TIGER = 'TIGER'
@@ -90,6 +93,7 @@ class Optimizer(Enum):
         return self in [
             Optimizer.ADAFACTOR,
             Optimizer.CAME,
+            Optimizer.SMMF,
             Optimizer.ADAM,
             Optimizer.ADAMW,
             Optimizer.PRODIGY_PLUS_SCHEDULE_FREE,

--- a/modules/util/optimizer/SMMF.py
+++ b/modules/util/optimizer/SMMF.py
@@ -5,6 +5,7 @@
 # This version incorporates:
 # - A structure that supports fused backward passes.
 # - Stochastic rounding from "Revisiting BFloat16 Training" (https://arxiv.org/abs/2010.06192) for the final parameter update.
+# - Decoupling the direction and magnitude of parameter updates, using current gradients for the update direction and momentum solely for adaptive magnitude scaling, as described in "Grams: Gradient Descent with Adaptive Momentum Scaling" (https://arxiv.org/abs/2412.17107).
 # - A toggleable 'factored_sign' mode for maximum memory efficiency.
 #
 
@@ -26,11 +27,14 @@ class SMMF(torch.optim.Optimizer):
         beta1 (Optional[float], optional): coefficient for computing running average of gradient (default: 0.9)
         eps (float, optional): term added to the denominator to improve numerical stability (default: 1e-8)
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
-        decay_rate (float, optional): decay-rate for 2nd moment ('gamma' in paper) (default: -0.5)
+        decay_rate (float, optional): decay-rate for 2nd moment ('gamma' in paper) (default: -0.8)
         beta1_growth_rate (Optional[float], optional): growth-rate for 1st moment ('lambda' in paper) (default: 0.999)
         vector_reshape (bool, optional): whether to reshape 1D vectors into 2D matrices (default: True)
         stochastic_rounding (bool, optional): whether to use stochastic rounding for BF16 (default: True)
         factored_sign (bool, optional): whether to use the memory-efficient pos/neg factorization instead of a sign matrix (default: False)
+        use_grams (bool, optional): whether to use the grams method, Decoupling the direction and magnitude of parameter updates (default: False)
+        use_orthograd (bool): whether to use OrthoGrad.  (default: False)
+        use_atan2 (bool): whether to use the atan2 update rule. (default: False)
     """
 
     def __init__(
@@ -45,6 +49,9 @@ class SMMF(torch.optim.Optimizer):
         vector_reshape: bool = True,
         stochastic_rounding: bool = True,
         factored_sign: bool = False,
+        use_grams: bool = False,
+        use_orthograd: bool = False,
+        use_atan2: bool = False,
     ):
         if not (lr >= 0.0):
             raise ValueError(f"Learning-rate should be >= 0.0. Got {lr}")
@@ -58,7 +65,9 @@ class SMMF(torch.optim.Optimizer):
             raise ValueError(f"Decay-rate should be in [-1.0, 0.0]. Got {decay_rate}")
         if beta1_growth_rate is not None and not (0.0 <= beta1_growth_rate <= 1.0):
             raise ValueError(f"Growth-rate should be in [0.0, 1.0]. Got {beta1_growth_rate}")
-
+        if use_grams and factored_sign:
+            raise ValueError("Cannot use both 'use_grams' and 'factored_sign' modes simultaneously as they are mutually exclusive.")
+        
         defaults = {
             "lr": lr, "beta1": beta1, "eps": eps, "weight_decay": weight_decay,
             "decay_rate": decay_rate, "beta1_growth_rate": beta1_growth_rate,
@@ -66,7 +75,39 @@ class SMMF(torch.optim.Optimizer):
             "factored_sign": factored_sign,
         }
         self.stochastic_rounding = stochastic_rounding
+        self.factored_sign = factored_sign
+        self.use_grams = use_grams
+        self.use_orthograd = use_orthograd
+        self.use_atan2 = use_atan2
         super().__init__(params, defaults)
+
+    @staticmethod
+    def _orthogonalize_gradient(p: torch.Tensor, grad: torch.Tensor) -> torch.Tensor:
+        """
+        Projects the gradient `grad` to be orthogonal to the parameter `p`,
+        and then re-scales the result to have the same norm as the original gradient.
+
+        This method is based on the `OrthoGrad` optimizer from the paper
+        "Grokking at the Edge of Numerical Stability" (Prieto et al., 2025). It is
+        intended to prevent Naïve Loss Minimization (NLM) by removing the component
+        of the gradient that is parallel to the weight vector.
+        """
+        if grad.is_sparse:
+            raise RuntimeError("OrthoGrad logic does not support sparse gradients.")
+        original_shape = grad.shape
+        w = p.view(-1).float()
+        g = grad.view(-1).float()
+        # Project g onto w: proj_w(g) = (w·g / w·w) * w
+        # The small epsilon is for numerical stability.
+        w_norm_sq = torch.dot(w, w).add_(1e-30)
+        proj = torch.dot(w, g) / w_norm_sq
+        # The orthogonal component: g_orth = g - proj_w(g)
+        g_orth = g.sub(w, alpha=proj)
+        # Rescale g_orth to have the same L2 norm as the original gradient g.
+        g_norm = g.norm(2)
+        g_orth_norm = g_orth.norm(2).add_(1e-30)
+        g_orth_scaled = g_orth * (g_norm / g_orth_norm)
+        return g_orth_scaled.view(original_shape)
 
     @property
     def supports_fused_back_pass(self):
@@ -116,33 +157,43 @@ class SMMF(torch.optim.Optimizer):
         """Decompresses a momentum tensor from its factorized form."""
         if momentum_name != 'momentum_m':
             return self._unnmf(state[momentum_name])
-        if not group['factored_sign']:
+        if not self.factored_sign:
             # Original method (with patch for resume-spike)
             update = self._unnmf(state['momentum_m'])
-            if state['sign'].dtype != torch.bool:
-                state['sign'] = state['sign'].to(torch.bool)
-            torch.where(state['sign'], update, -update, out=update)
+            if not self.use_grams:
+                if state['sign'].dtype != torch.bool:
+                    state['sign'] = state['sign'].to(torch.bool)
+                torch.where(state['sign'], update, -update, out=update)
             return update
         else:
-            # True Factorization method
             m_pos = self._unnmf(state['momentum_m_pos'])
             m_neg = self._unnmf(state['momentum_m_neg'])
-            return torch.sub(m_pos, m_neg, out=m_pos) # In-place subtraction
+            return torch.sub(m_pos, m_neg, out=m_pos)
 
     def _compress_momentum(self, matrix: torch.Tensor, state, momentum_name: str, group: dict):
         """Compresses a momentum tensor into its factorized form."""
-        if momentum_name != 'momentum_m':
-            self._nnmf(matrix, out=state[momentum_name])
+        # The second moment 'v' is always non-negative. Handle its compression simply.
+        if momentum_name == 'momentum_v':
+            # We take abs() to be safe against any minor numerical noise, though v should be >= 0.
+            self._nnmf(torch.abs(matrix), out=state['momentum_v'])
             return
 
-        if not group['factored_sign']:
-            state['sign'] = matrix > 0
-            self._nnmf(torch.abs(matrix), out=state['momentum_name'])
-        else:
+        # The logic depends on the optimizer mode (use_grams, factored_sign, or default).
+        if self.use_grams:
+            # Grams mode: store magnitude only.
+            self._nnmf(torch.abs(matrix), out=state['momentum_m'])
+            
+        elif self.factored_sign:
+            # Factored sign mode: store positive and negative parts in separate factors.
             m_pos = matrix.relu()
             m_neg = matrix.neg().relu_()
             self._nnmf(m_pos, out=state['momentum_m_pos'])
             self._nnmf(m_neg, out=state['momentum_m_neg'])
+            
+        else:
+            # Default: store magnitude and a separate boolean sign matrix.
+            state['sign'] = matrix > 0
+            self._nnmf(torch.abs(matrix), out=state['momentum_m'])
 
     @torch.no_grad()
     def step_parameter(self, p: torch.Tensor, group: dict, i: int | None = None):
@@ -151,6 +202,13 @@ class SMMF(torch.optim.Optimizer):
             return
 
         grad = p.grad
+
+        if grad.dtype != torch.float32:
+            grad = grad.float()
+
+        if self.use_orthograd:
+            grad = self._orthogonalize_gradient(p, grad)
+
         state = self.state[p]
 
         # State Initialization
@@ -166,18 +224,20 @@ class SMMF(torch.optim.Optimizer):
                 shape0, shape1 = state['effective_shape']
 
                 if group['beta1'] is not None:
-                    if group['factored_sign']:
-                        state['momentum_m_pos'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device))
-                        state['momentum_m_neg'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device))
-                    else:
-                        state['momentum_m'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device))
-                        state['sign'] = torch.zeros(state['effective_shape'], dtype=torch.bool, device=device)
+                    if self.factored_sign: 
+                        state['momentum_m_pos'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device)) 
+                        state['momentum_m_neg'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device)) 
+                    elif not self.use_grams: # Only initialize sign if not using grams
+                        state['momentum_m'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device)) 
+                        state['sign'] = torch.zeros(state['effective_shape'], dtype=torch.bool, device=device) 
+                    else: 
+                        state['momentum_m'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device)) 
 
                 state['momentum_v'] = (torch.zeros(shape0, device=device), torch.zeros(shape1, device=device))
             else:  # not factored
                 if group['beta1'] is not None:
-                    state['momentum_m'] = torch.zeros_like(p)
-                state['momentum_v'] = torch.zeros_like(p)
+                    state['momentum_m'] = torch.zeros_like(p, dtype=torch.float32)
+                state['momentum_v'] = torch.zeros_like(p, dtype=torch.float32)
 
         state['step'] += 1
 
@@ -211,13 +271,23 @@ class SMMF(torch.optim.Optimizer):
             update_v.mul_(beta_v).addcmul_(grad_reshaped, grad_reshaped, value=1.0 - beta_v)
 
             # 3. Compute the final update using the full local matrices
-            update = update_m / (update_v.sqrt() + eps)
+            if self.use_atan2:
+                a = 1.2732395
+                update = torch.atan2(update_m, update_v.sqrt()).mul_(a)
+            else:
+                update = update_m / (update_v.sqrt() + eps)
+
+            if self.use_grams:
+                update = grad_reshaped.sign() * update.abs()
+
             update = update.contiguous().view(original_shape)
 
             # 4. Compress the updated full local matrices back into state ONCE
             if beta1 is not None:
                 self._compress_momentum(update_m, state, 'momentum_m', group)
+                del update_m
             self._compress_momentum(update_v, state, 'momentum_v', group)
+            del update_v
 
         else:  # Non-factorized path
             if beta1 is not None:
@@ -230,8 +300,17 @@ class SMMF(torch.optim.Optimizer):
             update_v = state['momentum_v']
             beta_v = 1.0 - (state['step'] ** decay_rate)
             update_v.mul_(beta_v).addcmul_(grad, grad, value=1.0 - beta_v)
+            
             # Compute parameter update
-            update = update_m / (update_v.sqrt() + eps)
+            if self.use_atan2:
+                a = 1.2732395
+                update = torch.atan2(update_m, update_v.sqrt()).mul_(a)
+            else:
+                update = update_m / (update_v.sqrt() + eps)
+            del update_m, update_v
+
+            if self.use_grams:
+                update = grad.sign() * update.abs()
 
         if group["weight_decay"] != 0:
             if p.dtype == torch.bfloat16 and self.stochastic_rounding:
@@ -247,6 +326,7 @@ class SMMF(torch.optim.Optimizer):
             add_stochastic_(p.data, -update)
         else:
             p.data.add_(-update)
+        del update
 
 
 

--- a/modules/util/optimizer/SMMF.py
+++ b/modules/util/optimizer/SMMF.py
@@ -1,0 +1,253 @@
+#
+# SMMF optimizer, refactored for better integration and readability.
+# Original paper: "SMMF: Square-Matricized Momentum Factorization for Memory-Efficient Optimization" (https://arxiv.org/abs/2412.08894)
+#
+# This version incorporates:
+# - A structure that supports fused backward passes.
+# - Stochastic rounding from "Revisiting BFloat16 Training" (https://arxiv.org/abs/2010.06192) for the final parameter update.
+# - Optional Binary Matrix Factorization (BMF) for sign matrices, as suggested by the SMMF paper.
+#
+
+import torch
+import torch.optim
+from typing import Optional
+
+from modules.util.bf16_stochastic_rounding import add_stochastic_
+
+
+class SMMF(torch.optim.Optimizer):
+    """
+    Implements SMMF algorithm.
+    This implementation is based on:
+    `SMMF: Square-Matricized Momentum Factorization for Memory-Efficient Optimization`
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining parameter groups
+        lr (float, optional): learning rate (default: 1e-3)
+        beta1 (Optional[float], optional): coefficient for computing running average of gradient (default: 0.9)
+        eps (float, optional): term added to the denominator to improve numerical stability (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        decay_rate (float, optional): decay-rate for 2nd moment ('gamma' in paper) (default: -0.5)
+        beta1_growth_rate (Optional[float], optional): growth-rate for 1st moment ('lambda' in paper) (default: 0.999)
+        vector_reshape (bool, optional): whether to reshape 1D vectors into 2D matrices (default: True)
+        stochastic_rounding (bool, optional): whether to use stochastic rounding for BF16 (default: False)
+        use_bmf (bool, optional): whether to use Binary Matrix Factorization for signs (default: False)
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        beta1: Optional[float] = 0.9,
+        eps: float = 1e-8,
+        weight_decay: float = 0.0,
+        decay_rate: float = -0.8,
+        beta1_growth_rate: Optional[float] = 0.999,
+        vector_reshape: bool = True,
+        stochastic_rounding: bool = False,
+        use_bmf: bool = False,
+    ):
+        if not (0.0 <= lr):
+            raise ValueError(f"Learning-rate should be >= 0.0. Got {lr}")
+        if beta1 is not None and not (0.0 <= beta1 <= 1.0):
+            raise ValueError(f"beta1 should be in [0.0, 1.0]. Got {beta1}")
+        if not (0.0 <= eps):
+            raise ValueError(f"Epsilon should be >= 0.0. Got {eps}")
+        if not (0.0 <= weight_decay):
+            raise ValueError(f"Weight-decay should be >= 0.0. Got {weight_decay}")
+        if not (-1.0 <= decay_rate <= 0.0):
+            raise ValueError(f"Decay-rate should be in [-1.0, 0.0]. Got {decay_rate}")
+        if beta1_growth_rate is not None and not (0.0 <= beta1_growth_rate <= 1.0):
+            raise ValueError(f"Growth-rate should be in [0.0, 1.0]. Got {beta1_growth_rate}")
+
+        defaults = dict(
+            lr=lr, beta1=beta1, eps=eps, weight_decay=weight_decay,
+            decay_rate=decay_rate, beta1_growth_rate=beta1_growth_rate,
+            vector_reshape=vector_reshape,
+        )
+        self.stochastic_rounding = stochastic_rounding
+        self.use_bmf = use_bmf
+        super().__init__(params, defaults)
+
+    @property
+    def supports_fused_back_pass(self):
+        return True
+
+    @property
+    def supports_memory_efficient_fp16(self):
+        return True
+
+    @property
+    def supports_flat_params(self):
+        return False
+
+    def _get_effective_shape(self, numel: int) -> tuple:
+        """Finds two factors of numel that are closest to its square root."""
+        sqrt_num_sq = int(numel ** 0.5) ** 2
+        if numel == sqrt_num_sq:
+            sqrt_num = int(numel ** 0.5)
+            return (sqrt_num, sqrt_num)
+        
+        for i in reversed(range(1, int(numel ** 0.5) + 1)):
+            if numel % i == 0:
+                return (numel // i, i)
+        return (numel, 1)
+
+    def _unnmf(self, row_col: tuple) -> torch.Tensor:
+        """Reconstructs a matrix from its rank-1 factors (outer product)."""
+        return torch.outer(row_col[0], row_col[1])
+
+    def _nnmf(self, matrix: torch.Tensor, out: tuple):
+        """Performs a rank-1 non-negative matrix factorization."""
+        shape = matrix.shape
+        torch.sum(matrix, dim=1, out=out[0])
+        torch.sum(matrix, dim=0, out=out[1])
+
+        # Normalize one of the factors for stability
+        if shape[0] < shape[1]:
+            scale = out[0].sum()
+            if scale != 0:
+                out[0].div_(scale)
+        else:
+            scale = out[1].sum()
+            if scale != 0:
+                out[1].div_(scale)
+
+    def _decompress_momentum(self, state, momentum_name: str) -> torch.Tensor:
+        """Decompresses a momentum tensor from its factorized form."""
+        update = self._unnmf(state[momentum_name])
+        if momentum_name == 'momentum_m':
+            if self.use_bmf:
+                sign_approx = self._unnmf(state['sign'])
+                sign = sign_approx > 0.5
+            else:
+                sign = state['sign']
+            
+            if sign.dtype != torch.bool:
+                sign = sign.type(torch.bool)
+            torch.where(sign, update, -update, out=update)
+        return update
+        
+    def _compress_momentum(self, matrix: torch.Tensor, state, momentum_name: str):
+        """Compresses a momentum tensor into its factorized form."""
+        if momentum_name == 'momentum_m':
+            sign_matrix = matrix > 0
+            if self.use_bmf:
+                self._nnmf(sign_matrix.float(), out=state['sign'])
+            else:
+                state['sign'] = sign_matrix
+            self._nnmf(torch.abs(matrix), out=state[momentum_name])
+        else:  # for momentum_v
+            self._nnmf(matrix, out=state[momentum_name])
+
+    @torch.no_grad()
+    def step_parameter(self, p: torch.Tensor, group: dict, i: Optional[int] = None):
+        """Performs a single optimization step on a single parameter."""
+        if p.grad is None:
+            return
+        
+        grad = p.grad
+        state = self.state[p]
+        
+        # State Initialization
+        if len(state) == 0:
+            state['step'] = 0
+            
+            dimension = len(grad.squeeze().shape)
+            state['factored'] = not (dimension == 1 and not group['vector_reshape'])
+            
+            if state['factored']:
+                state['effective_shape'] = self._get_effective_shape(p.numel())
+                device = p.device
+                
+                if group['beta1'] is not None:
+                    state['momentum_m'] = (
+                        torch.zeros(state['effective_shape'][0], device=device),
+                        torch.zeros(state['effective_shape'][1], device=device),
+                    )
+                    if self.use_bmf:
+                        state['sign'] = (
+                            torch.zeros(state['effective_shape'][0], device=device),
+                            torch.zeros(state['effective_shape'][1], device=device),
+                        )
+                    else:
+                        state['sign'] = torch.zeros(state['effective_shape'], dtype=torch.bool, device=device)
+                
+                state['momentum_v'] = (
+                    torch.zeros(state['effective_shape'][0], device=device),
+                    torch.zeros(state['effective_shape'][1], device=device),
+                )
+            else:  # not factored
+                if group['beta1'] is not None:
+                    state['momentum_m'] = torch.zeros_like(p)
+                state['momentum_v'] = torch.zeros_like(p)
+        
+        state['step'] += 1
+        
+        # Weight decay
+        if group['weight_decay'] != 0.0:
+            p.mul_(1 - group['lr'] * group['weight_decay'])
+        
+        beta1 = group['beta1']
+        eps = group['eps']
+        decay_rate = group['decay_rate']
+        beta1_growth_rate = group['beta1_growth_rate']
+        
+        if state['factored']:
+            original_shape = p.shape
+            if not grad.is_contiguous():
+                grad = grad.contiguous()
+            grad_reshaped = grad.view(state['effective_shape'])
+
+            # Decompress, update, and compress momentums
+            if beta1 is not None:
+                update_m = self._decompress_momentum(state, 'momentum_m')
+                beta_m = beta1 * (beta1_growth_rate ** (state['step'] - 1.0))
+                update_m.mul_(beta_m).add_(grad_reshaped, alpha=(1.0 - beta_m))
+                self._compress_momentum(update_m, state, 'momentum_m')
+
+            update_v = self._decompress_momentum(state, 'momentum_v')
+            beta_v = 1.0 - (state['step'] ** decay_rate)
+            update_v.mul_(beta_v).addcmul_(grad_reshaped, grad_reshaped, value=1.0 - beta_v)
+            self._compress_momentum(update_v, state, 'momentum_v')
+
+            # Compute parameter update
+            if beta1 is not None:
+                update = update_m / (update_v.sqrt() + eps)
+            else:
+                update = grad_reshaped / (update_v.sqrt() + eps)
+            update = update.contiguous().view(original_shape)
+        
+        else:  # Non-factorized path
+            if beta1 is not None:
+                update_m = state['momentum_m']
+                beta_m = beta1 * (beta1_growth_rate ** (state['step'] - 1.0))
+                update_m.mul_(beta_m).add_(grad, alpha=(1.0 - beta_m))
+
+            update_v = state['momentum_v']
+            beta_v = 1.0 - (state['step'] ** decay_rate)
+            update_v.mul_(beta_v).addcmul_(grad, grad, value=1.0 - beta_v)
+            
+            # Compute parameter update
+            if beta1 is not None:
+                update = update_m / (update_v.sqrt() + eps)
+            else:
+                update = grad / (update_v.sqrt() + eps)
+
+        # Apply final update to parameter with optional stochastic rounding
+        if p.dtype == torch.bfloat16 and self.stochastic_rounding:
+            add_stochastic_(p.data, update, alpha=-group['lr'])
+        else:
+            p.data.add_(update, alpha=-group['lr'])
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Performs a single optimization step (or handles the closure)."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+            
+        for group in self.param_groups:
+            for i, p in enumerate(group['params']):
+                self.step_parameter(p, group, i)
+        return loss

--- a/modules/util/optimizer/SMMF.py
+++ b/modules/util/optimizer/SMMF.py
@@ -112,6 +112,74 @@ class SMMF(torch.optim.Optimizer):
             if scale != 0:
                 out[1].div_(scale)
 
+    def _bmf(self, matrix: torch.Tensor, out: tuple):
+        """
+        Performs a rank-1 Binary Matrix Factorization (BMF) heuristic.
+        It includes a False Discovery Rate (FDR) control mechanism inspired by:
+        "The Trustworthy Pal: Controlling the False Discovery Rate in Boolean Matrix Factorization"
+        This implementation uses the full probability bound from Theorem 3.1, including
+        the union bound (via binomial coefficients) to correct for multiple testing.
+        This is a very strict test that asks "what is the probability of a tile this
+        dense appearing *anywhere* in a random matrix of this size?".
+        Calculations are performed in log-space to avoid numerical overflow from the
+        extremely large binomial coefficients.
+        """
+        p_noise = 0.1 # This is the assumed probability that a "1" in the matrix is just random noise, not part of a meaningful pattern.
+        q_fdr = 0.01 # This is the False Discovery Rate (FDR) threshold. It's the maximum proportion of "discoveries" (identified blocks) that the algorithm is willing to tolerate being false positives. A lower q_fdr means a stricter test.
+
+        m, n = matrix.shape
+
+        # 1. Propose a candidate tile using a simple heuristic (row/column sums)
+        row_sum = torch.sum(matrix, dim=1)
+        col_sum = torch.sum(matrix, dim=0)        
+        
+        u_candidate = (row_sum > 0).to(row_sum.dtype)
+        v_candidate = (col_sum > 0).to(col_sum.dtype)
+        
+        # 2. Calculate tile properties
+        a = u_candidate.sum()
+        b = v_candidate.sum()    
+
+        # If the proposed tile is empty, it's trivially insignificant. Reject.
+        if a == 0 or b == 0:
+            out[0].zero_()
+            out[1].zero_()
+            return
+        
+        # Density (delta) of 1s in the candidate tile
+        # Use .item() to get scalar values for calculation to avoid creating graphs
+        a_val, b_val = a.item(), b.item()
+        captured_ones = torch.dot(matrix @ v_candidate, u_candidate)
+        delta = captured_ones / (a_val * b_val)
+
+        # 3. Apply FDR check in log-space to avoid numerical instability
+        density_diff_sq = (max(0.0, delta.item() - p_noise))**2
+        log_q_fdr = torch.log(torch.tensor(q_fdr, device=matrix.device))
+
+        # Probability from Hoeffding's inequality for a *specific* tile
+        # This is log( exp(-2ab(delta-p)^2) )
+        log_prob_specific_tile = -2.0 * a_val * b_val * density_diff_sq
+
+        # Log of the binomial coefficients: log(C(m,a)) and log(C(n,b))
+        # Inputs must be Tensors.
+        device = matrix.device
+        # This is the log of the union bound correction factor.
+        # log(C(k, r)) = lgamma(k+1) - lgamma(r+1) - lgamma(k-r+1)
+        log_comb_m = torch.lgamma(torch.tensor(m + 1., device=device)) - torch.lgamma(torch.tensor(a_val + 1., device=device)) - torch.lgamma(torch.tensor(m - a_val + 1., device=device))
+        log_comb_n = torch.lgamma(torch.tensor(n + 1., device=device)) - torch.lgamma(torch.tensor(b_val + 1., device=device)) - torch.lgamma(torch.tensor(n - b_val + 1., device=device))
+
+        # Total log-probability bound: log(C(m,a)) + log(C(n,b)) + log_prob
+        log_p_total = log_comb_m + log_comb_n + log_prob_specific_tile
+
+        # If the log-probability of a false discovery is greater than the log of our
+        # significance level, we reject the tile.
+        if log_p_total > log_q_fdr:
+            out[0].zero_()
+            out[1].zero_()
+        else:
+            out[0].copy_(u_candidate)
+            out[1].copy_(v_candidate)
+
     def _decompress_momentum(self, state, momentum_name: str) -> torch.Tensor:
         """Decompresses a momentum tensor from its factorized form."""
         update = self._unnmf(state[momentum_name])
@@ -126,13 +194,13 @@ class SMMF(torch.optim.Optimizer):
                 sign = sign.type(torch.bool)
             torch.where(sign, update, -update, out=update)
         return update
-
+        
     def _compress_momentum(self, matrix: torch.Tensor, state, momentum_name: str):
         """Compresses a momentum tensor into its factorized form."""
         if momentum_name == 'momentum_m':
             sign_matrix = matrix > 0
             if self.use_bmf:
-                self._nnmf(sign_matrix.float(), out=state['sign'])
+                self._bmf(sign_matrix.float(), out=state['sign'])
             else:
                 state['sign'] = sign_matrix
             self._nnmf(torch.abs(matrix), out=state[momentum_name])
@@ -195,23 +263,29 @@ class SMMF(torch.optim.Optimizer):
             grad_reshaped = grad.view(state['effective_shape'])
 
             # Decompress, update, and compress momentums
+            # 1. Decompress momentums ONCE into full local matrices
             if beta1 is not None:
                 update_m = self._decompress_momentum(state, 'momentum_m')
+            update_v = self._decompress_momentum(state, 'momentum_v')
+
+            # 2. Update the full local matrices
+            if beta1 is not None:
                 beta_m = beta1 * (beta1_growth_rate ** (state['step'] - 1.0))
                 update_m.mul_(beta_m).add_(grad_reshaped, alpha=(1.0 - beta_m))
-                self._compress_momentum(update_m, state, 'momentum_m')
-
-            update_v = self._decompress_momentum(state, 'momentum_v')
             beta_v = 1.0 - (state['step'] ** decay_rate)
             update_v.mul_(beta_v).addcmul_(grad_reshaped, grad_reshaped, value=1.0 - beta_v)
-            self._compress_momentum(update_v, state, 'momentum_v')
 
-            # Compute parameter update
+            # 3. Compute the final update using the full local matrices
             if beta1 is not None:
                 update = update_m / (update_v.sqrt() + eps)
             else:
                 update = grad_reshaped / (update_v.sqrt() + eps)
             update = update.contiguous().view(original_shape)
+
+            # 4. Compress the updated full local matrices back into state ONCE
+            if beta1 is not None:
+                self._compress_momentum(update_m, state, 'momentum_m')
+            self._compress_momentum(update_v, state, 'momentum_v')
 
         else:  # Non-factorized path
             if beta1 is not None:
@@ -222,7 +296,6 @@ class SMMF(torch.optim.Optimizer):
             update_v = state['momentum_v']
             beta_v = 1.0 - (state['step'] ** decay_rate)
             update_v.mul_(beta_v).addcmul_(grad, grad, value=1.0 - beta_v)
-
             # Compute parameter update
             update = update_m / (update_v.sqrt() + eps) if beta1 is not None else grad / (update_v.sqrt() + eps)
 

--- a/modules/util/optimizer/SMMF.py
+++ b/modules/util/optimizer/SMMF.py
@@ -59,11 +59,11 @@ class SMMF(torch.optim.Optimizer):
         if beta1_growth_rate is not None and not (0.0 <= beta1_growth_rate <= 1.0):
             raise ValueError(f"Growth-rate should be in [0.0, 1.0]. Got {beta1_growth_rate}")
 
-        defaults = dict(
-            lr=lr, beta1=beta1, eps=eps, weight_decay=weight_decay,
-            decay_rate=decay_rate, beta1_growth_rate=beta1_growth_rate,
-            vector_reshape=vector_reshape,
-        )
+        defaults = {
+            "lr": lr, "beta1": beta1, "eps": eps, "weight_decay": weight_decay,
+            "decay_rate": decay_rate, "beta1_growth_rate": beta1_growth_rate,
+            "vector_reshape": vector_reshape,
+        }
         self.stochastic_rounding = stochastic_rounding
         self.use_bmf = use_bmf
         super().__init__(params, defaults)
@@ -224,10 +224,7 @@ class SMMF(torch.optim.Optimizer):
             update_v.mul_(beta_v).addcmul_(grad, grad, value=1.0 - beta_v)
             
             # Compute parameter update
-            if beta1 is not None:
-                update = update_m / (update_v.sqrt() + eps)
-            else:
-                update = grad / (update_v.sqrt() + eps)
+            update = update_m / (update_v.sqrt() + eps) if beta1 is not None else grad / (update_v.sqrt() + eps)
 
         if group["weight_decay"] != 0:
             if p.dtype == torch.bfloat16 and self.stochastic_rounding:

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -88,6 +88,7 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "vector_reshape": True,
         "beta1_growth_rate": 0.999,
         "stochastic_rounding": True,
+        "factored_sign": False,
         "fused_back_pass": False,
     },
     Optimizer.ADAGRAD: {

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -89,6 +89,9 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "beta1_growth_rate": 0.999,
         "stochastic_rounding": True,
         "factored_sign": False,
+        "use_grams": False,
+        "use_orthograd": False,
+        "use_atan2": False,
         "fused_back_pass": False,
     },
     Optimizer.ADAGRAD: {

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -80,6 +80,17 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "stochastic_rounding": True,
         "fused_back_pass": False,
     },
+    Optimizer.SMMF: {
+        "eps": 1e-8,
+        "decay_rate": -0.8,
+        "beta1": 0.9,
+        "weight_decay": 0.0,
+        "vector_reshape": True,
+        "use_bmf": False,
+        "beta1_growth_rate": 0.999,
+        "stochastic_rounding": True,
+        "fused_back_pass": False,
+    },
     Optimizer.ADAGRAD: {
         "lr_decay": 0,
         "weight_decay": 0,

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -86,7 +86,6 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "beta1": 0.9,
         "weight_decay": 0.0,
         "vector_reshape": True,
-        "use_bmf": False,
         "beta1_growth_rate": 0.999,
         "stochastic_rounding": True,
         "fused_back_pass": False,


### PR DESCRIPTION
SMMF (Square-Matricized Momentum Factorization) is a memory-efficient optimizer that reduces the optimizer state memory required by adaptive learning rate methods (e.g., Adam) by up to 96%. Based on the paper "[SMMF: Square-Matricized Momentum Factorization for Memory-Efficient Optimization](https://www.google.com/url?sa=E&q=https%3A%2F%2Farxiv.org%2Fabs%2F2412.08894)," its core innovation is a two-step process:
* Square-Matricization: It reshapes any momentum tensor (vector, matrix, or high-rank tensor) into a 2D matrix that is as close to square as possible.
* Factorization: It applies an efficient rank-1 factorization to this matrix, storing only two small vectors instead of the full momentum state.

This implementation is refactored for clarity and includes features such as support for fused backward pass, stochastic rounding for BF16 training, and an experimental option for Binary Matrix Factorization (BMF) to further compress sign information.

![CNN_ACC](https://github.com/user-attachments/assets/c6cd3861-d528-485f-8d7b-45415073675c)


References:
https://github.com/eai-lab/SMMF
https://arxiv.org/abs/2412.08894