### PR TITLE
Fixing the long standing "transparency bug"

### DIFF
--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -43,6 +43,13 @@ import torch
 import customtkinter as ctk
 from customtkinter import AppearanceModeTracker
 
+# chunk for forcing Windows to ignore DPI scaling when moving between monitors
+# fixes the long standing transparency bug
+import ctypes
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(1)  # System DPI aware
+except Exception:
+    pass
 
 class TrainUI(ctk.CTk):
     set_step_progress: Callable[[int, int], None]


### PR DESCRIPTION
From my anecdotal testing, this should close #90.

---

**The issue seems to arise when Windows tries to rescale the UI based on the monitor's DPI scaling.**

I run a fairly non-standard monitor setup (two 1360x768 at 100% scaling and one 1920x1080 at 125% scaling) and dragging the window from my smaller monitors to the larger one causes the window to go transparent while it readjusts the UI scaling. 

I was running a slightly older build when I discovered this bug (the UI sometimes failing to repaint, leaving it permanently transparent) and an update somewhere down the line seems to have "fixed" it by locking the window in place while it rescales. While this does work, it makes the UI feel a bit unresponsive (especially with the whole thing going transparent for a few seconds).

**The DPI scaling being the cause would also explain why both people with multiple monitors _and_ people remoting into systems get this issue.**

---

**My solution pretty much just tells Windows, "hey, don't rescale this" and it seems to work fine.**

It uses ctypes, which is already built into python (meaning it doesn't require an extra library to be added).
It includes a pass as well, in case it ends up not working for some strange reason (falling back to the already "working" version).

---

The only issue I could see would be odd UI scaling based on different resolutions/scaling because of this change (which shouldn't affect 95% of users). I haven't notice any unusable UI elements with my set up though.

It could probably be adjusted to enable per-monitor DPI awareness, but I haven't personally tested it.

```
import ctypes
try:
    ctypes.windll.shcore.SetProcessDpiAwareness(2)  # 1=system DPI aware, 2=per-monitor DPI aware
except Exception:
    pass
```
[And Microsoft strongly prefers declaring DPI awareness in the application manifest](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process), but this shouldn't be an issue if there's not a plan to build an exe.

---

As for Linux/MacOS compatibility, this fix could technically be adjusted to this:

```
import sys
import ctypes

if sys.platform == "win32":
    try:
        ctypes.windll.shcore.SetProcessDpiAwareness(1)  # System DPI aware
    except Exception:
        pass
```

But it feels a bit excessive (since the try/except block will just silently fail regardless).
The option is there though.

---

Anyways, give it a shot and see if it works.

Even though this bug seems to be mostly a non-issue nowadays, I still find this fix to make the UI feel more "snappy" when moving between monitors.

