### PR TITLE
Graceful fail for sampling if config becomes corrupted or missing after training 

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -283,11 +283,14 @@ class GenericTrainer(BaseTrainer):
                         samples[i] = SampleConfig.default_values().from_dict(samples[i])
                     sample_params_list = samples
             # We absolutely do not want to fail training just because the sample definition file becomes missing or broken during training.
-            except (FileNotFoundError, json.JSONDecodeError, ValueError, KeyError) as e:
-                print(f"Warning: Unable to load or parse sample definition file '{self.config.sample_definition_file_name}': {e}. Skipping sampling.")
+            except FileNotFoundError as e:
+                print(f"Warning: {e}. Skipping sampling.")
+                sample_params_list = []
+            except (json.JSONDecodeError, ValueError, KeyError) as e:
+                print(f"Warning: Sample definition file '{self.config.sample_definition_file_name}' is invalid or corrupted: {e}. Skipping sampling.")
                 sample_params_list = []
             except Exception as e:
-                print(f"Warning: Unexpected error loading sample definition file '{self.config.sample_definition_file_name}': {e}. Skipping sampling.")
+                print(f"Warning: Unexpected error: {e}. Skipping sampling.")
                 sample_params_list = []
         else:
             is_custom_sample = True

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -284,13 +284,13 @@ class GenericTrainer(BaseTrainer):
                     sample_params_list = samples
             # We absolutely do not want to fail training just because the sample definition file becomes missing or broken during training.
             except FileNotFoundError as e:
-                print(f"Warning: {e}. Skipping sampling.")
+                print(f" Warning: {e}. Skipping sampling.")
                 sample_params_list = []
             except (json.JSONDecodeError, ValueError, KeyError) as e:
-                print(f"Warning: Sample definition file '{self.config.sample_definition_file_name}' is invalid or corrupted: {e}. Skipping sampling.")
+                print(f" Warning: Sample definition file '{self.config.sample_definition_file_name}' is invalid or corrupted: {e}. Skipping sampling.")
                 sample_params_list = []
             except Exception as e:
-                print(f"Warning: Unexpected error: {e}. Skipping sampling.")
+                print(f" Warning: Unexpected error: {e}. Skipping sampling.")
                 sample_params_list = []
         else:
             is_custom_sample = True

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -283,8 +283,9 @@ class GenericTrainer(BaseTrainer):
                         samples[i] = SampleConfig.default_values().from_dict(samples[i])
                     sample_params_list = samples
             # We absolutely do not want to fail training just because the sample definition file becomes missing or broken right before sampling.
-            except Exception as e:
-                print(f" Warning: Unexpected error: {e}. Skipping sampling.")
+            except Exception:
+                traceback.print_exc()
+                print("Error during loading the sample definition file, proceeding without sampling")
                 sample_params_list = []
         else:
             is_custom_sample = True

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -282,13 +282,7 @@ class GenericTrainer(BaseTrainer):
                     for i in range(len(samples)):
                         samples[i] = SampleConfig.default_values().from_dict(samples[i])
                     sample_params_list = samples
-            # We absolutely do not want to fail training just because the sample definition file becomes missing or broken during training.
-            except FileNotFoundError as e:
-                print(f" Warning: {e}. Skipping sampling.")
-                sample_params_list = []
-            except (json.JSONDecodeError, ValueError, KeyError) as e:
-                print(f" Warning: Sample definition file '{self.config.sample_definition_file_name}' is invalid or corrupted: {e}. Skipping sampling.")
-                sample_params_list = []
+            # We absolutely do not want to fail training just because the sample definition file becomes missing or broken right before sampling.
             except Exception as e:
                 print(f" Warning: Unexpected error: {e}. Skipping sampling.")
                 sample_params_list = []


### PR DESCRIPTION
Fixes #327

<img width="1088" height="269" alt="image" src="https://github.com/user-attachments/assets/ce34df11-b843-4c8a-8cfb-a9e6f458f529" />

Decided to split this fix out of Dataset Tools rework given its immense size.