### PR TITLE
Add strict mode to load_state_dict and implement LoRA rank/alpha vali…

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -531,7 +531,7 @@ class LoRAModuleWrapper:
 
         if rank_key := next((k for k in state_dict if k.endswith((".lora_down.weight", ".hada_w1_a"))), None):
             if (checkpoint_rank := state_dict[rank_key].shape[0]) != self.rank:
-                raise ValueError(f"Rank mismatch: config={checkpoint_rank}, config={self.rank}, please correct in the UI.")
+                raise ValueError(f"Rank mismatch: checkpoint={checkpoint_rank}, config={self.rank}, please correct in the UI.")
 
     def load_state_dict(self, state_dict: dict[str, Tensor], strict: bool = True):
         """


### PR DESCRIPTION
Fixes #662 

Adds validation (console value error) when a user attempts to continue training with a Rank or Alpha not equal to what it was originally trained with.