### PR TITLE
Fix for off-by-one error with v_prediction

### DIFF
--- a/modules/modelSampler/ChromaSampler.py
+++ b/modules/modelSampler/ChromaSampler.py
@@ -106,8 +106,10 @@ class ChromaSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # denoising loop
             extra_step_kwargs = {}

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -400,8 +400,10 @@ class FluxSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # denoising loop
             extra_step_kwargs = {}

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -135,8 +135,10 @@ class FluxSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # denoising loop
             extra_step_kwargs = {}

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -127,8 +127,10 @@ class HiDreamSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # denoising loop
             extra_step_kwargs = {}

--- a/modules/modelSampler/HunyuanVideoSampler.py
+++ b/modules/modelSampler/HunyuanVideoSampler.py
@@ -107,8 +107,10 @@ class HunyuanVideoSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # denoising loop
             extra_step_kwargs = {}

--- a/modules/modelSampler/PixArtAlphaSampler.py
+++ b/modules/modelSampler/PixArtAlphaSampler.py
@@ -91,8 +91,10 @@ class PixArtAlphaSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # prepare latent image
             num_channels_latents = transformer.config.in_channels

--- a/modules/modelSampler/SanaSampler.py
+++ b/modules/modelSampler/SanaSampler.py
@@ -91,8 +91,10 @@ class SanaSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # prepare latent image
             num_channels_latents = transformer.config.in_channels

--- a/modules/modelSampler/StableDiffusion3Sampler.py
+++ b/modules/modelSampler/StableDiffusion3Sampler.py
@@ -103,8 +103,10 @@ class StableDiffusion3Sampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # prepare latent image
             num_channels_latents = transformer.config.in_channels

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -88,7 +88,7 @@ class StableDiffusionSampler(BaseModelSampler):
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
-            
+
             if force_last_timestep:
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -88,13 +88,15 @@ class StableDiffusionSampler(BaseModelSampler):
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
-
+            print(timesteps)
             if force_last_timestep:
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # prepare latent image
             num_channels_latents = unet.config.in_channels

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -88,7 +88,7 @@ class StableDiffusionSampler(BaseModelSampler):
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
-            print(timesteps)
+            
             if force_last_timestep:
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
@@ -300,8 +300,10 @@ class StableDiffusionSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             # prepare latent image
             num_channels_latents = latent_conditioning_image.shape[1]

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -337,8 +337,10 @@ class StableDiffusionXLSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             original_height = height
             original_width = width

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -97,8 +97,10 @@ class StableDiffusionXLSampler(BaseModelSampler):
                 last_timestep = torch.ones(1, device=self.train_device, dtype=torch.int64) \
                                 * (noise_scheduler.config.num_train_timesteps - 1)
 
-                # add the final timestep to force predicting with zero snr
-                timesteps = torch.cat([last_timestep, timesteps])
+                # add the final timestep to force predicting with zero snr if it's not already here
+                if timesteps[0] != last_timestep:
+                    noise_scheduler.set_timesteps(diffusion_steps + 1, device=self.train_device)
+                    timesteps = torch.cat([last_timestep, timesteps])
 
             original_height = height
             original_width = width


### PR DESCRIPTION
It should fix all samplers for v_prediction/zero-terminal SNR models with standard models. Most likely that's just step that most schedulers do on it's own so we did end up with duplicated step.

Models using squaredcos_cap_v2 scheduler still won't sample with kerras scheduler as sigmas are rounded that's why depending on model timesteps off-by one error can still appear with those models. Fixing it would require rewritting some sampling code, but that's chunk of work for models that do not exist.