### PR TITLE
Mixed resolution batching

### DIFF
--- a/modules/modelSampler/ChromaSampler.py
+++ b/modules/modelSampler/ChromaSampler.py
@@ -89,7 +89,7 @@ class ChromaSampler(BaseModelSampler):
                 self.model.train_dtype.torch_dtype()
             )
 
-            latent_image = self.model.pack_latents(
+            latent_image, _ = self.model.pack_latents(
                 latent_image,
                 latent_image.shape[0],
                 latent_image.shape[1],

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,9 +236,6 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
-            temperature = 1.5
-            latent_noise *= temperature ** 0.5
-
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -307,7 +304,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
+            flow = latent_noise - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -285,7 +285,6 @@ class BaseFluxSetup(
                 latent_input.shape[2],
                 latent_input.shape[3],
             )
-
             packed_predicted_flow = model.transformer(
                 hidden_states=packed_latent_input.to(dtype=model.train_dtype.torch_dtype()),
                 timestep=timestep / 1000,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,6 +236,9 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            temperature = 1.5
+            latent_noise *= temperature ** 0.5
+
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -304,7 +307,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise - scaled_latent_image
+            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,


### PR DESCRIPTION
Experimental implementation of mixed resolution batching. This is an alternative to Aspect Ratio Bucketing and other types of bucketing techniques:

**Advantages**
 - no scaling necessary
   - therefore no upscaling artifacts
   - only downscaling if input images are larger than the resolution setting
 - no cropping necessary
 - images are trained at their original resolution and their original aspect ratio
 - no bucketing necessary
   - no batch sample dropping
   - better randomization
   - ...

**Disadvantages**
 - it is less efficient to mix a high-res and low-res image in the same batch - but still more efficient that to upscale all low-res images
 - if you have a very large dataset, the disadvantages of bucketing disappear, so bucketing still has its place for efficiency
 - there is a performance cost in the current implementation, that could be eliminated, but would require a `diffusers` code change

**Technique**

Two batch samples:
<img width="460" height="274" alt="image" src="https://github.com/user-attachments/assets/8d66d23f-3deb-4728-a6f5-ae9b9caae33e" />

Their are padded to have the same, maximum shape:
<img width="460" height="308" alt="image" src="https://github.com/user-attachments/assets/6f0535f6-218c-4e73-84c3-7af4daf14ee7" />

Attention masking is used to have the transformer ignore the grey parts. Only The yellow and blue parts are trained
[Note: this is different from masked training and doesn't have the side effects of masked training: It is mathematically identical to train with or without the padding.]

The padded samples are combined into a batch:

<img width="220" height="289" alt="image" src="https://github.com/user-attachments/assets/268e9789-f8cc-42f6-a99b-aac3e795a2fd" />

Image tokens that are padded in both samples are pruned from the token sequence for better efficiency:
<img width="236" height="274" alt="image" src="https://github.com/user-attachments/assets/10806d5d-a0ae-48a1-bc3d-a8135ec64a1a" />

Resulting sample:
<img width="237" height="314" alt="image" src="https://github.com/user-attachments/assets/36690506-7364-4865-a46c-6b448454bbdd" />

Next step, not implemented:
Even after pruning the unnecessary tokens, the sum of the shape is still larger than a non-mixed batch would be: the yellow and the blue tokens are still inefficient, because they are processed for the entire batch by the transformer, even though they are only evaluated for one of the batch samples.

This could be avoided by pruning the padding tokens after packing the tokens into a 1D sequence for each batch sample:
<img width="1249" height="127" alt="image" src="https://github.com/user-attachments/assets/4ddc749e-3729-4b2c-ae9b-32e3e12c6819" />

However, this requires that the positional embeddings are set per batch sample, not for the entire batch. Otherwise the transformer will not understand the different shapes of the batch samples.
This is possible, but requires a `diffusers` code change because they thought this was unnecessary according to their commit history. Details here:
https://github.com/dxqb/OneTrainer/blob/c2e12c42582c8123fe730abd0bc346b7ab615359/modules/modelSetup/BaseChromaSetup.py#L242

- [ ] no UI yet. It's always activate in this PR. "Aspect Ratio Bucketing" setting is ignored
- [ ] only implemented for Chroma
- [ ] barely tested