### PR TITLE
Fixed python3 command making it python3 (instead of python)

### DIFF
--- a/lib.include.sh
+++ b/lib.include.sh
@@ -22,7 +22,7 @@ cd -- "${SCRIPT_DIR}"
 # since their script shadows "conda" as a shell-function instead of a binary!
 export OT_CONDA_CMD="${OT_CONDA_CMD:-${CONDA_EXE:-conda}}"
 export OT_CONDA_ENV="${OT_CONDA_ENV:-conda_env}"
-export OT_PYTHON_CMD="${OT_PYTHON_CMD:-python}"
+export OT_PYTHON_CMD="${OT_PYTHON_CMD:-python3}"
 export OT_PYTHON_VENV="${OT_PYTHON_VENV:-venv}"
 export OT_PREFER_VENV="${OT_PREFER_VENV:-false}"
 export OT_LAZY_UPDATES="${OT_LAZY_UPDATES:-false}"


### PR DESCRIPTION
Linux command is python3, not python. When I installed a right python version with pyenv, and updated the command to python3 in lib.include.sh - it launched ☺️