### PR TITLE
Bugfix for #934 and #776

### DIFF
--- a/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
+++ b/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
@@ -210,7 +210,7 @@ class StableDiffusionXLModelLoader(
             )
 
         text_encoder_1 = self._convert_transformers_sub_module_to_dtype(
-            pipeline.text_encoder_1, weight_dtypes.text_encoder, weight_dtypes.train_dtype
+            pipeline.text_encoder, weight_dtypes.text_encoder, weight_dtypes.train_dtype
         )
         text_encoder_2 = self._convert_transformers_sub_module_to_dtype(
             pipeline.text_encoder_2, weight_dtypes.text_encoder_2, weight_dtypes.train_dtype

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,9 +236,6 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
-            temperature = 1.5
-            latent_noise *= temperature ** 0.5
-
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -307,7 +304,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
+            flow = latent_noise - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,6 +236,9 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            temperature = 1.5
+            latent_noise *= temperature ** 0.5
+
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -304,7 +307,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise - scaled_latent_image
+            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,


### PR DESCRIPTION
#934 and #776 describe how FP8 training on SDXL requires more vram than expected.

Steps why this change https://github.com/Nerogar/OneTrainer/pull/989/files#diff-eaab6bd7bca752fedce03a486d2e1b8724eb9a0358dbebae493bde074d35fe8d fixes that:

- diffusers.StableDiffusionXLPipeline does not have a `text_encoder_1` property. Text encoder 1 is just named just `text_encoder`.
- This raises a python exception
- All exceptions are caught here https://github.com/Nerogar/OneTrainer/blob/12d1812db22c6ec32c1001e3886bfe7d8918d078/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py#L258
- Loading as safetensors failed, we continue with trying to load as ckpt
- __load_ckpt successfully loads the file, even though it is a safetensors file, because it uses the same diffusers API calls that can also load safetensors: https://github.com/Nerogar/OneTrainer/blob/12d1812db22c6ec32c1001e3886bfe7d8918d078/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py#L139
- quantization is not implemented in ckpt loading. It's only in safetensors loading: https://github.com/Nerogar/OneTrainer/blob/12d1812db22c6ec32c1001e3886bfe7d8918d078/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py#L212
 - Everything was loaded in float32. There are type conversions here https://github.com/Nerogar/OneTrainer/blob/12d1812db22c6ec32c1001e3886bfe7d8918d078/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py#L156 but this is a no-op for FLOAT_8: https://github.com/Nerogar/OneTrainer/blob/12d1812db22c6ec32c1001e3886bfe7d8918d078/modules/util/enum/DataType.py#L36



