### PR TITLE
Require ckpt extension for ckpt files

### DIFF
--- a/modules/modelLoader/chroma/ChromaModelLoader.py
+++ b/modules/modelLoader/chroma/ChromaModelLoader.py
@@ -119,17 +119,6 @@ class ChromaModelLoader(
         model.vae = vae
         model.transformer = transformer
 
-    def __load_ckpt(
-            self,
-            model: ChromaModel,
-            model_type: ModelType,
-            weight_dtypes: ModelWeightDtypes,
-            base_model_name: str,
-            vae_model_name: str,
-    ):
-        # TODO
-        pass
-
     def __load_safetensors(
             self,
             model: ChromaModel,

--- a/modules/modelLoader/flux/FluxModelLoader.py
+++ b/modules/modelLoader/flux/FluxModelLoader.py
@@ -157,20 +157,6 @@ class FluxModelLoader(
         model.vae = vae
         model.transformer = transformer
 
-    def __load_ckpt(
-            self,
-            model: FluxModel,
-            model_type: ModelType,
-            weight_dtypes: ModelWeightDtypes,
-            base_model_name: str,
-            vae_model_name: str,
-            include_text_encoder_1: bool,
-            include_text_encoder_2: bool,
-            include_text_encoder_3: bool,
-    ):
-        # TODO
-        pass
-
     def __load_safetensors(
             self,
             model: FluxModel,

--- a/modules/modelLoader/hiDream/HiDreamModelLoader.py
+++ b/modules/modelLoader/hiDream/HiDreamModelLoader.py
@@ -206,22 +206,6 @@ class HiDreamModelLoader(
         model.vae = vae
         model.transformer = transformer
 
-    def __load_ckpt(
-            self,
-            model: HiDreamModel,
-            model_type: ModelType,
-            weight_dtypes: ModelWeightDtypes,
-            base_model_name: str,
-            text_encoder_4_model_name: str,
-            vae_model_name: str,
-            include_text_encoder_1: bool,
-            include_text_encoder_2: bool,
-            include_text_encoder_3: bool,
-            include_text_encoder_4: bool,
-    ):
-        # TODO
-        pass
-
     def __load_safetensors(
             self,
             model: HiDreamModel,

--- a/modules/modelLoader/hunyuanVideo/HunyuanVideoModelLoader.py
+++ b/modules/modelLoader/hunyuanVideo/HunyuanVideoModelLoader.py
@@ -144,19 +144,6 @@ class HunyuanVideoModelLoader(
         model.vae = vae
         model.transformer = transformer
 
-    def __load_ckpt(
-            self,
-            model: HunyuanVideoModel,
-            model_type: ModelType,
-            weight_dtypes: ModelWeightDtypes,
-            base_model_name: str,
-            vae_model_name: str,
-            include_text_encoder_1: bool,
-            include_text_encoder_2: bool,
-    ):
-        # TODO
-        pass
-
     def __load_safetensors(
             self,
             model: HunyuanVideoModel,

--- a/modules/modelLoader/mixin/LoRALoaderMixin.py
+++ b/modules/modelLoader/mixin/LoRALoaderMixin.py
@@ -73,11 +73,12 @@ class LoRALoaderMixin(metaclass=ABCMeta):
         except Exception:
             stacktraces.append(traceback.format_exc())
 
-        try:
-            self.__load_ckpt(model, model_names.lora)
-            return
-        except Exception:
-            stacktraces.append(traceback.format_exc())
+        if model_names.lora.endswith(".ckpt"):
+            try:
+                self.__load_ckpt(model, model_names.lora)
+                return
+            except Exception:
+                stacktraces.append(traceback.format_exc())
 
         try:
             self.__load_safetensors(model, model_names.lora)

--- a/modules/modelLoader/stableDiffusion/StableDiffusionModelLoader.py
+++ b/modules/modelLoader/stableDiffusion/StableDiffusionModelLoader.py
@@ -293,11 +293,13 @@ class StableDiffusionModelLoader(
         except Exception:
             stacktraces.append(traceback.format_exc())
 
-        try:
-            self.__load_ckpt(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)
-            return
-        except Exception:
-            stacktraces.append(traceback.format_exc())
+        if model_names.base_model.endswith(".ckpt"):
+            try:
+                self.__load_ckpt(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)
+                print("Warning: Legacy code is used to load ckpt files. Some features may not be supported.")
+                return
+            except Exception:
+                stacktraces.append(traceback.format_exc())
 
         for stacktrace in stacktraces:
             print(stacktrace)

--- a/modules/modelLoader/stableDiffusion3/StableDiffusion3ModelLoader.py
+++ b/modules/modelLoader/stableDiffusion3/StableDiffusion3ModelLoader.py
@@ -146,20 +146,6 @@ class StableDiffusion3ModelLoader(
         model.vae = vae
         model.transformer = transformer
 
-    def __load_ckpt(
-            self,
-            model: StableDiffusion3Model,
-            model_type: ModelType,
-            weight_dtypes: ModelWeightDtypes,
-            base_model_name: str,
-            vae_model_name: str,
-            include_text_encoder_1: bool,
-            include_text_encoder_2: bool,
-            include_text_encoder_3: bool,
-    ):
-        # TODO
-        pass
-
     def __load_safetensors(
             self,
             model: StableDiffusion3Model,

--- a/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
+++ b/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
@@ -258,11 +258,13 @@ class StableDiffusionXLModelLoader(
         except Exception:
             stacktraces.append(traceback.format_exc())
 
-        try:
-            self.__load_ckpt(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)
-            return
-        except Exception:
-            stacktraces.append(traceback.format_exc())
+        if model_names.base_model.endswith(".ckpt"):
+            try:
+                self.__load_ckpt(model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model)
+                print("Warning: Legacy code is used to load ckpt files. Some features may not be supported.")
+                return
+            except Exception:
+                stacktraces.append(traceback.format_exc())
 
         for stacktrace in stacktraces:
             print(stacktrace)

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,9 +236,6 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
-            temperature = 1.5
-            latent_noise *= temperature ** 0.5
-
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -307,7 +304,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
+            flow = latent_noise - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,6 +236,9 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            temperature = 1.5
+            latent_noise *= temperature ** 0.5
+
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
@@ -304,7 +307,7 @@ class BaseFluxSetup(
                 latent_input.shape[3],
             )
 
-            flow = latent_noise - scaled_latent_image
+            flow = latent_noise / (temperature ** 0.5) - scaled_latent_image
             model_output_data = {
                 'loss_type': 'target',
                 'timestep': timestep,


### PR DESCRIPTION
- Only load a file as ckpt if it has a ckpt extension, to avoid weird issues like this: https://github.com/Nerogar/OneTrainer/pull/989
- remove ckpt boilerplate from newer models that never supported ckpt