### PR TITLE
Layer filter for full finetuning

### DIFF
--- a/modules/dataLoader/ChromaBaseDataLoader.py
+++ b/modules/dataLoader/ChromaBaseDataLoader.py
@@ -137,7 +137,7 @@ class ChromaBaseDataLoader(
             sort_names = [x for x in sort_names if x not in image_aggregate_names]
             sort_names = [x for x in sort_names if x not in image_split_names]
 
-            if not config.train_text_encoder_or_embedding() or not config.train_text_encoder_or_embedding():
+            if not config.train_text_encoder_or_embedding():
                 modules.append(text_disk_cache)
                 sort_names = [x for x in sort_names if x not in text_split_names]
 
@@ -185,11 +185,9 @@ class ChromaBaseDataLoader(
             model.vae_to(self.train_device)
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
-        decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)
         decode_prompt = DecodeTokens(in_name='tokens', out_name='decoded_prompt', tokenizer=model.tokenizer)
         save_image = SaveImage(image_in_name='decoded_image', original_path_in_name='image_path', path=debug_dir, in_range_min=-1, in_range_max=1, before_save_fun=before_save_fun)
-        save_conditioning_image = SaveImage(image_in_name='decoded_conditioning_image', original_path_in_name='image_path', path=debug_dir, in_range_min=-1, in_range_max=1, before_save_fun=before_save_fun)
         # SaveImage(image_in_name='latent_mask', original_path_in_name='image_path', path=debug_dir, in_range_min=0, in_range_max=1, before_save_fun=before_save_fun)
         save_mask = SaveImage(image_in_name='decoded_mask', original_path_in_name='image_path', path=debug_dir, in_range_min=0, in_range_max=1, before_save_fun=before_save_fun)
         save_prompt = SaveText(text_in_name='decoded_prompt', original_path_in_name='image_path', path=debug_dir, before_save_fun=before_save_fun)
@@ -202,10 +200,6 @@ class ChromaBaseDataLoader(
 
         modules.append(decode_image)
         modules.append(save_image)
-
-        if config.model_type.has_conditioning_image_input():
-            modules.append(decode_conditioning_image)
-            modules.append(save_conditioning_image)
 
         if config.masked_training or config.model_type.has_mask_input():
             modules.append(upscale_mask)

--- a/modules/model/ChromaModel.py
+++ b/modules/model/ChromaModel.py
@@ -241,22 +241,16 @@ class ChromaModel(BaseModel):
 
         return latent_image_ids.to(device=device, dtype=dtype)
 
-    def pack_latents(
-            self,
-            latents: Tensor,
-            batch_size: int,
-            num_channels_latents: int,
-            height: int,
-            width: int,
-    ) -> Tensor:
-        latents = latents.view(batch_size, num_channels_latents, height // 2, 2, width // 2, 2)
+    def pack_latents(self, latents: Tensor) -> Tensor:
+        batch_size, channels, height, width = latents.shape
+        latents = latents.view(batch_size, channels, height // 2, 2, width // 2, 2)
         latents = latents.permute(0, 2, 4, 1, 3, 5)
-        latents = latents.reshape(batch_size, (height // 2) * (width // 2), num_channels_latents * 4)
+        latents = latents.reshape(batch_size, (height // 2) * (width // 2), channels * 4)
 
         return latents
 
-    def unpack_latents(self, latents, height, width):
-        batch_size, num_patches, channels = latents.shape
+    def unpack_latents(self, latents, height: int, width: int):
+        batch_size, _, channels = latents.shape
 
         height = height // 2
         width = width // 2

--- a/modules/modelSampler/ChromaSampler.py
+++ b/modules/modelSampler/ChromaSampler.py
@@ -89,13 +89,8 @@ class ChromaSampler(BaseModelSampler):
                 self.model.train_dtype.torch_dtype()
             )
 
-            latent_image = self.model.pack_latents(
-                latent_image,
-                latent_image.shape[0],
-                latent_image.shape[1],
-                height // vae_scale_factor,
-                width // vae_scale_factor,
-            )
+            latent_image = self.model.pack_latents(latent_image)
+
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
 

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -336,15 +336,9 @@ class FluxSampler(BaseModelSampler):
                 self.model.train_dtype.torch_dtype()
             )
 
-            mu = self.model.calculate_timestep_shift(latent_image.shape[-2], latent_image.shape[-1])
-            latent_image = self.model.pack_latents(
-                latent_image,
-                latent_image.shape[0],
-                latent_image.shape[1],
-                height // vae_scale_factor,
-                width // vae_scale_factor,
-            )
-            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=mu)
+            shift = self.model.calculate_timestep_shift(latent_image.shape[-2], latent_image.shape[-1])
+            latent_image = self.model.pack_latents(latent_image)
+            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=math.log(shift))
             timesteps = noise_scheduler.timesteps
 
             # denoising loop

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import math
 from collections.abc import Callable
 
 from modules.model.FluxModel import FluxModel
@@ -34,19 +35,6 @@ class FluxSampler(BaseModelSampler):
         self.model = model
         self.model_type = model_type
         self.pipeline = model.create_pipeline()
-
-    def __calculate_shift(
-            self,
-            image_seq_len,
-            base_seq_len: int = 256,
-            max_seq_len: int = 4096,
-            base_shift: float = 0.5,
-            max_shift: float = 1.15,
-    ):
-        m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
-        b = base_shift - m * base_seq_len
-        mu = image_seq_len * m + b
-        return mu
 
     @torch.no_grad()
     def __sample_base(
@@ -108,25 +96,11 @@ class FluxSampler(BaseModelSampler):
                 self.model.train_dtype.torch_dtype()
             )
 
-            latent_image = self.model.pack_latents(
-                latent_image,
-                latent_image.shape[0],
-                latent_image.shape[1],
-                height // vae_scale_factor,
-                width // vae_scale_factor,
-            )
-
-            image_seq_len = latent_image.shape[1]
+            shift = self.model.calculate_timestep_shift(latent_image.shape[-2], latent_image.shape[-1])
+            latent_image = self.model.pack_latents(latent_image)
 
             # prepare timesteps
-            mu = self.__calculate_shift(
-                image_seq_len,
-                noise_scheduler.config.base_image_seq_len,
-                noise_scheduler.config.max_image_seq_len,
-                noise_scheduler.config.base_shift,
-                noise_scheduler.config.max_shift,
-            )
-            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=mu)
+            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=math.log(shift))
             timesteps = noise_scheduler.timesteps
 
             # denoising loop
@@ -362,23 +336,13 @@ class FluxSampler(BaseModelSampler):
                 self.model.train_dtype.torch_dtype()
             )
 
+            mu = self.model.calculate_timestep_shift(latent_image.shape[-2], latent_image.shape[-1])
             latent_image = self.model.pack_latents(
                 latent_image,
                 latent_image.shape[0],
                 latent_image.shape[1],
                 height // vae_scale_factor,
                 width // vae_scale_factor,
-            )
-
-            image_seq_len = latent_image.shape[1]
-
-            # prepare timesteps
-            mu = self.__calculate_shift(
-                image_seq_len,
-                noise_scheduler.config.base_image_seq_len,
-                noise_scheduler.config.max_image_seq_len,
-                noise_scheduler.config.base_shift,
-                noise_scheduler.config.max_shift,
             )
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=mu)
             timesteps = noise_scheduler.timesteps

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -32,19 +32,6 @@ class HiDreamSampler(BaseModelSampler):
         self.model_type = model_type
         self.pipeline = model.create_pipeline(use_original_modules=False)
 
-    def __calculate_shift(
-            self,
-            image_seq_len,
-            base_seq_len: int = 256,
-            max_seq_len: int = 4096,
-            base_shift: float = 0.5,
-            max_shift: float = 1.15,
-    ):
-        m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
-        b = base_shift - m * base_seq_len
-        mu = image_seq_len * m + b
-        return mu
-
     @torch.no_grad()
     def __sample_base(
             self,
@@ -115,8 +102,12 @@ class HiDreamSampler(BaseModelSampler):
             )
 
             # prepare timesteps
-            mu = self.__calculate_shift(
-                self.model.transformer.max_seq,
+            mu = self._calculate_timestep_shift(
+                self.model.transformer.max_seq, #FIXME https://github.com/Nerogar/OneTrainer/issues/979
+                base_seq_len=256,
+                max_seq_len=4096,
+                base_shift=0.5,
+                max_shift=1.15,
             )
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=mu)
             timesteps = noise_scheduler.timesteps

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -101,15 +101,7 @@ class HiDreamSampler(BaseModelSampler):
                 dtype=torch.float32,
             )
 
-            # prepare timesteps
-            mu = self._calculate_timestep_shift(
-                self.model.transformer.max_seq, #FIXME https://github.com/Nerogar/OneTrainer/issues/979
-                base_seq_len=256,
-                max_seq_len=4096,
-                base_shift=0.5,
-                max_shift=1.15,
-            )
-            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device, mu=mu)
+            noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
 
             # denoising loop

--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -179,7 +179,7 @@ class BaseChromaSetup(
                 text_encoder_layer_skip=config.text_encoder_layer_skip,
                 text_encoder_output=batch['text_encoder_hidden_state'] \
                     if 'text_encoder_hidden_state' in batch and not config.train_text_encoder_or_embedding() else None,
-                text_encoder_dropout_probability=config.text_encoder_2.dropout_probability,
+                text_encoder_dropout_probability=config.text_encoder.dropout_probability,
             )
 
             latent_image = batch['latent_image']
@@ -193,8 +193,6 @@ class BaseChromaSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
-                latent_height=scaled_latent_image.shape[-2],
-                latent_width=scaled_latent_image.shape[-1],
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(
@@ -218,13 +216,7 @@ class BaseChromaSetup(
                 model.train_dtype.torch_dtype()
             )
 
-            packed_latent_input = model.pack_latents(
-                latent_input,
-                latent_input.shape[0],
-                latent_input.shape[1],
-                latent_input.shape[2],
-                latent_input.shape[3],
-            )
+            packed_latent_input = model.pack_latents(latent_input)
 
             image_seq_len = packed_latent_input.shape[1]
             image_attention_mask = torch.full((packed_latent_input.shape[0], image_seq_len), True, dtype=torch.bool, device=text_attention_mask.device)

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -236,14 +236,14 @@ class BaseFluxSetup(
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 
+            shift = model.calculate_timestep_shift(scaled_latent_image.shape[-2], scaled_latent_image.shape[-1])
             timestep = self._get_timestep_discrete(
                 model.noise_scheduler.config['num_train_timesteps'],
                 deterministic,
                 generator,
                 scaled_latent_image.shape[0],
                 config,
-                latent_height=scaled_latent_image.shape[-2],
-                latent_width=scaled_latent_image.shape[-1],
+                shift = shift if config.dynamic_timestep_shifting else config.timestep_shift,
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(
@@ -278,13 +278,7 @@ class BaseFluxSetup(
                 model.train_dtype.torch_dtype()
             )
 
-            packed_latent_input = model.pack_latents(
-                latent_input,
-                latent_input.shape[0],
-                latent_input.shape[1],
-                latent_input.shape[2],
-                latent_input.shape[3],
-            )
+            packed_latent_input = model.pack_latents(latent_input)
 
             packed_predicted_flow = model.transformer(
                 hidden_states=packed_latent_input.to(dtype=model.train_dtype.torch_dtype()),

--- a/modules/modelSetup/FluxLoRASetup.py
+++ b/modules/modelSetup/FluxLoRASetup.py
@@ -2,7 +2,7 @@ from modules.model.FluxModel import FluxModel
 from modules.modelSetup.BaseFluxSetup import BaseFluxSetup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -38,19 +38,8 @@ class FluxLoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2_lora.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -65,13 +54,7 @@ class FluxLoRASetup(
                     "embeddings_2"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
-
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
         return parameter_group_collection
 
     def __setup_requires_grad(
@@ -87,20 +70,9 @@ class FluxLoRASetup(
         model.transformer.requires_grad_(False)
         model.vae.requires_grad_(False)
 
-        if model.text_encoder_1_lora is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1_lora.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2_lora is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2_lora.requires_grad_(train_text_encoder_2)
-
-        if model.transformer_lora is not None:
-            train_transformer = config.prior.train and \
-                         not self.stop_prior_training_elapsed(config, model.train_progress)
-            model.transformer_lora.requires_grad_(train_transformer)
+        self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/HiDreamLoRASetup.py
+++ b/modules/modelSetup/HiDreamLoRASetup.py
@@ -93,8 +93,8 @@ class HiDreamLoRASetup(
 
         self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_1_lora, config.text_encoder_3, model.train_progress)
-        self._setup_model_part_requires_grad("text_encoder_4_lora", model.text_encoder_2_lora, config.text_encoder_4, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_4_lora", model.text_encoder_4_lora, config.text_encoder_4, model.train_progress)
         self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(

--- a/modules/modelSetup/HiDreamLoRASetup.py
+++ b/modules/modelSetup/HiDreamLoRASetup.py
@@ -4,7 +4,7 @@ from modules.model.HiDreamModel import HiDreamModel
 from modules.modelSetup.BaseHiDreamSetup import BaseHiDreamSetup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -40,33 +40,10 @@ class HiDreamLoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2_lora.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
-
-        if config.text_encoder_3.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_3",
-                parameters=model.text_encoder_3_lora.parameters(),
-                learning_rate=config.text_encoder_3.learning_rate,
-            ))
-
-        if config.text_encoder_4.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_4",
-                parameters=model.text_encoder_4_lora.parameters(),
-                learning_rate=config.text_encoder_4.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_4_lora", model.text_encoder_4_lora, config.text_encoder_4)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -93,12 +70,7 @@ class HiDreamLoRASetup(
                     "embeddings_4"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
 
         return parameter_group_collection
 
@@ -119,30 +91,11 @@ class HiDreamLoRASetup(
         model.transformer.requires_grad_(False)
         model.vae.requires_grad_(False)
 
-        if model.text_encoder_1_lora is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1_lora.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2_lora is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2_lora.requires_grad_(train_text_encoder_2)
-
-        if model.text_encoder_3_lora is not None:
-            train_text_encoder_3 = config.text_encoder_3.train and \
-                                   not self.stop_text_encoder_3_training_elapsed(config, model.train_progress)
-            model.text_encoder_3_lora.requires_grad_(train_text_encoder_3)
-
-        if model.text_encoder_4_lora is not None:
-            train_text_encoder_4 = config.text_encoder_4.train and \
-                                   not self.stop_text_encoder_4_training_elapsed(config, model.train_progress)
-            model.text_encoder_4_lora.requires_grad_(train_text_encoder_4)
-
-        if model.transformer_lora is not None:
-            train_transformer = config.prior.train and \
-                         not self.stop_prior_training_elapsed(config, model.train_progress)
-            model.transformer_lora.requires_grad_(train_transformer)
+        self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_1_lora, config.text_encoder_3, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_4_lora", model.text_encoder_2_lora, config.text_encoder_4, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/HunyuanVideoFineTuneSetup.py
+++ b/modules/modelSetup/HunyuanVideoFineTuneSetup.py
@@ -2,7 +2,7 @@
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
 from modules.modelSetup.BaseHunyuanVideoSetup import BaseHunyuanVideoSetup
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
@@ -31,19 +31,8 @@ class HunyuanVideoFineTuneSetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1", model.text_encoder_1, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2", model.text_encoder_2, config.text_encoder_2)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -58,12 +47,7 @@ class HunyuanVideoFineTuneSetup(
                     "embeddings_2"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior)
 
         return parameter_group_collection
 
@@ -74,19 +58,9 @@ class HunyuanVideoFineTuneSetup(
     ):
         self._setup_embeddings_requires_grad(model, config)
 
-        if model.text_encoder_1 is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2 is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2.requires_grad_(train_text_encoder_2)
-
-        train_transformer = config.prior.train and \
-                     not self.stop_prior_training_elapsed(config, model.train_progress)
-        model.transformer.requires_grad_(train_transformer)
+        self._setup_model_part_requires_grad("text_encoder_1", model.text_encoder_1, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
 
         model.vae.requires_grad_(False)
 

--- a/modules/modelSetup/HunyuanVideoLoRASetup.py
+++ b/modules/modelSetup/HunyuanVideoLoRASetup.py
@@ -4,7 +4,7 @@ from modules.model.HunyuanVideoModel import HunyuanVideoModel
 from modules.modelSetup.BaseHunyuanVideoSetup import BaseHunyuanVideoSetup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -40,19 +40,8 @@ class HunyuanVideoLoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2_lora.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -67,12 +56,7 @@ class HunyuanVideoLoRASetup(
                     "embeddings_2"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
 
         return parameter_group_collection
 
@@ -89,20 +73,9 @@ class HunyuanVideoLoRASetup(
         model.transformer.requires_grad_(False)
         model.vae.requires_grad_(False)
 
-        if model.text_encoder_1_lora is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1_lora.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2_lora is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2_lora.requires_grad_(train_text_encoder_2)
-
-        if model.transformer_lora is not None:
-            train_transformer = config.prior.train and \
-                                not self.stop_prior_training_elapsed(config, model.train_progress)
-            model.transformer_lora.requires_grad_(train_transformer)
+        self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/PixArtAlphaFineTuneSetup.py
+++ b/modules/modelSetup/PixArtAlphaFineTuneSetup.py
@@ -1,7 +1,7 @@
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
 from modules.modelSetup.BasePixArtAlphaSetup import BasePixArtAlphaSetup
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
@@ -30,12 +30,7 @@ class PixArtAlphaFineTuneSetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder",
-                parameters=model.text_encoder.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder", model.text_encoder, config.text_encoder)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             self._add_embedding_param_groups(
@@ -43,12 +38,7 @@ class PixArtAlphaFineTuneSetup(
                 "embeddings"
             )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior)
 
         return parameter_group_collection
 
@@ -57,9 +47,7 @@ class PixArtAlphaFineTuneSetup(
             model: PixArtAlphaModel,
             config: TrainConfig,
     ):
-        train_text_encoder = config.text_encoder.train and \
-                             not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-        model.text_encoder.requires_grad_(train_text_encoder)
+        self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
 
         for i, embedding in enumerate(model.additional_embeddings):
             embedding_config = config.additional_embeddings[i]
@@ -68,9 +56,7 @@ class PixArtAlphaFineTuneSetup(
                                                                                   model.train_progress, i)
             embedding.text_encoder_vector.requires_grad_(train_embedding)
 
-        train_prior = config.prior.train and \
-                      not self.stop_prior_training_elapsed(config, model.train_progress)
-        model.transformer.requires_grad_(train_prior)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
 
         model.vae.requires_grad_(False)
 

--- a/modules/modelSetup/SanaFineTuneSetup.py
+++ b/modules/modelSetup/SanaFineTuneSetup.py
@@ -1,7 +1,7 @@
 from modules.model.SanaModel import SanaModel
 from modules.modelSetup.BaseSanaSetup import BaseSanaSetup
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
@@ -30,12 +30,7 @@ class SanaFineTuneSetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder",
-                parameters=model.text_encoder.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder", model.text_encoder, config.text_encoder)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             self._add_embedding_param_groups(
@@ -43,12 +38,7 @@ class SanaFineTuneSetup(
                 "embeddings"
             )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior)
 
         return parameter_group_collection
 
@@ -59,13 +49,8 @@ class SanaFineTuneSetup(
     ):
         self._setup_embeddings_requires_grad(model, config)
 
-        train_text_encoder = config.text_encoder.train and \
-                             not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-        model.text_encoder.requires_grad_(train_text_encoder)
-
-        train_prior = config.prior.train and \
-                      not self.stop_prior_training_elapsed(config, model.train_progress)
-        model.transformer.requires_grad_(train_prior)
+        self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
 
         model.vae.requires_grad_(False)
 

--- a/modules/modelSetup/SanaLoRASetup.py
+++ b/modules/modelSetup/SanaLoRASetup.py
@@ -2,7 +2,7 @@ from modules.model.SanaModel import SanaModel
 from modules.modelSetup.BaseSanaSetup import BaseSanaSetup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -38,12 +38,7 @@ class SanaLoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_lora",
-                parameters=model.text_encoder_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_lora", model.text_encoder_lora, config.text_encoder)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             self._add_embedding_param_groups(
@@ -51,12 +46,7 @@ class SanaLoRASetup(
                 "embeddings"
             )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer_lora",
-                parameters=model.transformer_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
 
         return parameter_group_collection
 
@@ -70,15 +60,8 @@ class SanaLoRASetup(
         model.transformer.requires_grad_(False)
         model.vae.requires_grad_(False)
 
-        if model.text_encoder_lora is not None:
-            train_text_encoder = config.text_encoder.train and \
-                                 not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_lora.requires_grad_(train_text_encoder)
-
-        if model.transformer_lora is not None:
-            train_prior = config.prior.train and \
-                          not self.stop_prior_training_elapsed(config, model.train_progress)
-            model.transformer_lora.requires_grad_(train_prior)
+        self._setup_model_part_requires_grad("text_encoder_lora", model.text_encoder_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/StableDiffusion3FineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusion3FineTuneSetup.py
@@ -1,7 +1,7 @@
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
 from modules.modelSetup.BaseStableDiffusion3Setup import BaseStableDiffusion3Setup
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
@@ -30,26 +30,9 @@ class StableDiffusion3FineTuneSetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
-
-        if config.text_encoder_3.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_3",
-                parameters=model.text_encoder_3.parameters(),
-                learning_rate=config.text_encoder_3.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1", model.text_encoder_1, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2", model.text_encoder_2, config.text_encoder_2)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_3", model.text_encoder_3, config.text_encoder_3)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -70,12 +53,7 @@ class StableDiffusion3FineTuneSetup(
                     "embeddings_3"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior)
 
         return parameter_group_collection
 
@@ -86,24 +64,10 @@ class StableDiffusion3FineTuneSetup(
     ):
         self._setup_embeddings_requires_grad(model, config)
 
-        if model.text_encoder_1 is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2 is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2.requires_grad_(train_text_encoder_2)
-
-        if model.text_encoder_3 is not None:
-            train_text_encoder_3 = config.text_encoder_3.train and \
-                                   not self.stop_text_encoder_3_training_elapsed(config, model.train_progress)
-            model.text_encoder_3.requires_grad_(train_text_encoder_3)
-
-        train_transformer = config.prior.train and \
-                     not self.stop_prior_training_elapsed(config, model.train_progress)
-        model.transformer.requires_grad_(train_transformer)
+        self._setup_model_part_requires_grad("text_encoder_1", model.text_encoder_1, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_3", model.text_encoder_3, config.text_encoder_3, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
 
         model.vae.requires_grad_(False)
 

--- a/modules/modelSetup/StableDiffusion3LoRASetup.py
+++ b/modules/modelSetup/StableDiffusion3LoRASetup.py
@@ -2,7 +2,7 @@ from modules.model.StableDiffusion3Model import StableDiffusion3Model
 from modules.modelSetup.BaseStableDiffusion3Setup import BaseStableDiffusion3Setup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -37,26 +37,9 @@ class StableDiffusion3LoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_1",
-                parameters=model.text_encoder_1_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
-
-        if config.text_encoder_2.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_2",
-                parameters=model.text_encoder_2_lora.parameters(),
-                learning_rate=config.text_encoder_2.learning_rate,
-            ))
-
-        if config.text_encoder_3.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="text_encoder_3",
-                parameters=model.text_encoder_3_lora.parameters(),
-                learning_rate=config.text_encoder_3.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2)
+        self._create_model_part_parameters(parameter_group_collection, "text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             if config.text_encoder.train_embedding and model.text_encoder_1 is not None:
@@ -77,12 +60,7 @@ class StableDiffusion3LoRASetup(
                     "embeddings_3"
                 )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="transformer",
-                parameters=model.transformer_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
 
         return parameter_group_collection
 
@@ -101,26 +79,10 @@ class StableDiffusion3LoRASetup(
         model.transformer.requires_grad_(False)
         model.vae.requires_grad_(False)
 
-        if model.text_encoder_1_lora is not None:
-            train_text_encoder_1 = config.text_encoder.train and \
-                                   not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.text_encoder_1_lora.requires_grad_(train_text_encoder_1)
-
-        if model.text_encoder_2_lora is not None:
-            train_text_encoder_2 = config.text_encoder_2.train and \
-                                   not self.stop_text_encoder_2_training_elapsed(config, model.train_progress)
-            model.text_encoder_2_lora.requires_grad_(train_text_encoder_2)
-
-        if model.text_encoder_3_lora is not None:
-            train_text_encoder_3 = config.text_encoder_3.train and \
-                                   not self.stop_text_encoder_3_training_elapsed(config, model.train_progress)
-            model.text_encoder_3_lora.requires_grad_(train_text_encoder_3)
-
-        if model.transformer_lora is not None:
-            train_transformer = config.prior.train and \
-                         not self.stop_prior_training_elapsed(config, model.train_progress)
-            model.transformer_lora.requires_grad_(train_transformer)
-
+        self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_1_lora, config.text_encoder_3, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/StableDiffusion3LoRASetup.py
+++ b/modules/modelSetup/StableDiffusion3LoRASetup.py
@@ -81,7 +81,7 @@ class StableDiffusion3LoRASetup(
 
         self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_1_lora, config.text_encoder_3, model.train_progress)
+        self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3, model.train_progress)
         self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
 
     def setup_model(

--- a/modules/modelSetup/WuerstchenFineTuneSetup.py
+++ b/modules/modelSetup/WuerstchenFineTuneSetup.py
@@ -1,7 +1,7 @@
 from modules.model.WuerstchenModel import WuerstchenModel
 from modules.modelSetup.BaseWuerstchenSetup import BaseWuerstchenSetup
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
@@ -30,12 +30,7 @@ class WuerstchenFineTuneSetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="prior_text_encoder",
-                parameters=model.prior_text_encoder.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "prior_text_encoder", model.prior_text_encoder, config.text_encoder)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             self._add_embedding_param_groups(
@@ -43,12 +38,7 @@ class WuerstchenFineTuneSetup(
                 "prior_embeddings"
             )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="prior_prior",
-                parameters=model.prior_prior.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "prior_prior", model.prior_prior, config.prior)
 
         return parameter_group_collection
 
@@ -64,13 +54,8 @@ class WuerstchenFineTuneSetup(
         model.decoder_vqgan.requires_grad_(False)
         model.effnet_encoder.requires_grad_(False)
 
-        train_text_encoder = config.text_encoder.train and \
-                             not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-        model.prior_text_encoder.requires_grad_(train_text_encoder)
-
-        train_prior = config.prior.train and \
-                      not self.stop_prior_training_elapsed(config, model.train_progress)
-        model.prior_prior.requires_grad_(train_prior)
+        self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("prior_prior", model.prior_prior, config.prior, model.train_progress)
 
     def setup_model(
             self,

--- a/modules/modelSetup/WuerstchenLoRASetup.py
+++ b/modules/modelSetup/WuerstchenLoRASetup.py
@@ -2,7 +2,7 @@ from modules.model.WuerstchenModel import WuerstchenModel
 from modules.modelSetup.BaseWuerstchenSetup import BaseWuerstchenSetup
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
+from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
@@ -43,12 +43,7 @@ class WuerstchenLoRASetup(
     ) -> NamedParameterGroupCollection:
         parameter_group_collection = NamedParameterGroupCollection()
 
-        if config.text_encoder.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="prior_text_encoder_lora",
-                parameters=model.prior_text_encoder_lora.parameters(),
-                learning_rate=config.text_encoder.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "prior_text_encoder_lora", model.prior_text_encoder_lora, config.text_encoder)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             self._add_embedding_param_groups(
@@ -56,12 +51,7 @@ class WuerstchenLoRASetup(
                 "prior_embeddings"
             )
 
-        if config.prior.train:
-            parameter_group_collection.add_group(NamedParameterGroup(
-                unique_name="prior_prior_lora",
-                parameters=model.prior_prior_lora.parameters(),
-                learning_rate=config.prior.learning_rate,
-            ))
+        self._create_model_part_parameters(parameter_group_collection, "prior_prior_lora", model.prior_prior_lora, config.prior)
 
         return parameter_group_collection
 
@@ -79,15 +69,8 @@ class WuerstchenLoRASetup(
         model.decoder_vqgan.requires_grad_(False)
         model.effnet_encoder.requires_grad_(False)
 
-        if model.prior_text_encoder_lora is not None:
-            train_text_encoder = config.text_encoder.train and \
-                                 not self.stop_text_encoder_training_elapsed(config, model.train_progress)
-            model.prior_text_encoder_lora.requires_grad_(train_text_encoder)
-
-        if model.prior_prior_lora is not None:
-            train_unet = config.unet.train and \
-                         not self.stop_unet_training_elapsed(config, model.train_progress)
-            model.prior_prior_lora.requires_grad_(train_unet)
+        self._setup_model_part_requires_grad("prior_text_encoder_lora", model.prior_text_encoder_lora, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("prior_prior_lora", model.prior_prior_lora, config.prior, model.train_progress)
 
     def setup_model(
             self,


### PR DESCRIPTION
This PR move the LoRA layer filter to the `training` tab, and applies it to LoRA training and to Full Finetuning.

The motivation is that newer models such as Chroma and Qwen (and possibly Flux and others) tend to break when you train certain layers, such as the `distilled_guidance_layer` in Chroma