### PR TITLE
Bugfix #1017

### DIFF
--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -345,8 +345,6 @@ class BaseHiDreamSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
-                latent_height=scaled_latent_image.shape[-2],
-                latent_width=scaled_latent_image.shape[-1],
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -302,8 +302,6 @@ class BaseStableDiffusion3Setup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
-                latent_height=scaled_latent_image.shape[-2],
-                latent_width=scaled_latent_image.shape[-1],
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(


### PR DESCRIPTION
remove old arguments for dynamic timestep shifting, for models that never supported it
amendment to https://github.com/Nerogar/OneTrainer/pull/998