### PR TITLE
Bump pillow version

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -1,7 +1,7 @@
 # base requirements
 numpy==2.2.6
 opencv-python==4.11.0.86
-pillow==11.2.1
+pillow==11.3.0
 imagesize==1.4.1 #for concept statistics
 tqdm==4.67.1
 PyYAML==6.0.2


### PR DESCRIPTION
- [x] Does sampling still work
- [x] Does dataset tool still show the image
- [x] Do concept thumbnails show up
- [x] Do samples during training save?


If all yes then pillow should be safe to upgrade from 11.2.0 to 11.3.0 and close out the dependabot warning too.