### PR TITLE
Rename "prior" to "transformer" for transformer models

### DIFF
--- a/modules/cloud/BaseCloud.py
+++ b/modules/cloud/BaseCloud.py
@@ -43,6 +43,8 @@ class BaseCloud(metaclass=ABCMeta):
             self.file_sync.sync_up(local=Path(self.config.local_base_model_name),remote=Path(self.config.base_model_name))
         if hasattr(self.config.prior,"local_model_name"):
             self.file_sync.sync_up(local=Path(self.config.prior.local_model_name),remote=Path(self.config.prior.model_name))
+        if hasattr(self.config.transformer,"local_model_name"):
+            self.file_sync.sync_up(local=Path(self.config.transformer.local_model_name),remote=Path(self.config.transformer.model_name))
         if hasattr(self.config,"local_lora_model_name"):
             self.file_sync.sync_up(local=Path(self.config.local_lora_model_name),remote=Path(self.config.lora_model_name))
 

--- a/modules/modelLoader/chroma/ChromaModelLoader.py
+++ b/modules/modelLoader/chroma/ChromaModelLoader.py
@@ -98,15 +98,15 @@ class ChromaModelLoader(
             transformer = ChromaTransformer2DModel.from_single_file(
                 transformer_model_name,
                 #avoid loading the transformer in float32:
-                torch_dtype = torch.bfloat16 if weight_dtypes.prior.torch_dtype() is None else weight_dtypes.prior.torch_dtype()
+                torch_dtype = torch.bfloat16 if weight_dtypes.transformer.torch_dtype() is None else weight_dtypes.transformer.torch_dtype()
             )
             transformer = self._convert_diffusers_sub_module_to_dtype(
-                transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+                transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
             )
         else:
             transformer = self._load_diffusers_sub_module(
                 ChromaTransformer2DModel,
-                weight_dtypes.prior,
+                weight_dtypes.transformer,
                 weight_dtypes.train_dtype,
                 base_model_name,
                 "transformer",
@@ -142,7 +142,7 @@ class ChromaModelLoader(
 
         try:
             self.__load_internal(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:
@@ -150,7 +150,7 @@ class ChromaModelLoader(
 
         try:
             self.__load_diffusers(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:
@@ -158,7 +158,7 @@ class ChromaModelLoader(
 
         try:
             self.__load_safetensors(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:

--- a/modules/modelLoader/flux/FluxModelLoader.py
+++ b/modules/modelLoader/flux/FluxModelLoader.py
@@ -134,15 +134,15 @@ class FluxModelLoader(
             transformer = FluxTransformer2DModel.from_single_file(
                 transformer_model_name,
                 #avoid loading the transformer in float32:
-                torch_dtype = torch.bfloat16 if weight_dtypes.prior.torch_dtype() is None else weight_dtypes.prior.torch_dtype()
+                torch_dtype = torch.bfloat16 if weight_dtypes.transformer.torch_dtype() is None else weight_dtypes.transformer.torch_dtype()
             )
             transformer = self._convert_diffusers_sub_module_to_dtype(
-                transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+                transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
             )
         else:
             transformer = self._load_diffusers_sub_module(
                 FluxTransformer2DModel,
-                weight_dtypes.prior,
+                weight_dtypes.transformer,
                 weight_dtypes.train_dtype,
                 base_model_name,
                 "transformer",
@@ -171,7 +171,7 @@ class FluxModelLoader(
         transformer = FluxTransformer2DModel.from_single_file(
             #always load transformer separately even though FluxPipeLine.from_single_file() could load it, to avoid loading in float32:
             transformer_model_name if transformer_model_name else base_model_name,
-            torch_dtype = torch.bfloat16 if weight_dtypes.prior.torch_dtype() is None else weight_dtypes.prior.torch_dtype()
+            torch_dtype = torch.bfloat16 if weight_dtypes.transformer.torch_dtype() is None else weight_dtypes.transformer.torch_dtype()
         )
         pipeline = FluxPipeline.from_single_file(
             pretrained_model_link_or_path=base_model_name,
@@ -219,7 +219,7 @@ class FluxModelLoader(
             print("text encoder 2 (t5) not loaded, continuing without it")
 
         transformer = self._convert_diffusers_sub_module_to_dtype(
-            pipeline.transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+            pipeline.transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
         )
 
         model.model_type = model_type
@@ -242,7 +242,7 @@ class FluxModelLoader(
 
         try:
             self.__load_internal(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
                 model_names.include_text_encoder, model_names.include_text_encoder_2,
             )
             return
@@ -251,7 +251,7 @@ class FluxModelLoader(
 
         try:
             self.__load_diffusers(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
                 model_names.include_text_encoder, model_names.include_text_encoder_2,
             )
             return
@@ -260,7 +260,7 @@ class FluxModelLoader(
 
         try:
             self.__load_safetensors(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
                 model_names.include_text_encoder, model_names.include_text_encoder_2,
             )
             return

--- a/modules/modelLoader/hiDream/HiDreamModelLoader.py
+++ b/modules/modelLoader/hiDream/HiDreamModelLoader.py
@@ -187,7 +187,7 @@ class HiDreamModelLoader(
 
         transformer = self._load_diffusers_sub_module(
             HiDreamImageTransformer2DModel,
-            weight_dtypes.prior,
+            weight_dtypes.transformer,
             weight_dtypes.train_dtype,
             base_model_name,
             "transformer",
@@ -264,7 +264,7 @@ class HiDreamModelLoader(
             print("text encoder 2 (t5) not loaded, continuing without it")
 
         transformer = self._convert_diffusers_sub_module_to_dtype(
-            pipeline.transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+            pipeline.transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
         )
 
         model.model_type = model_type

--- a/modules/modelLoader/hunyuanVideo/HunyuanVideoModelLoader.py
+++ b/modules/modelLoader/hunyuanVideo/HunyuanVideoModelLoader.py
@@ -129,7 +129,7 @@ class HunyuanVideoModelLoader(
 
         transformer = self._load_diffusers_sub_module(
             HunyuanVideoTransformer3DModel,
-            weight_dtypes.prior,
+            weight_dtypes.transformer,
             weight_dtypes.train_dtype,
             base_model_name,
             "transformer",
@@ -192,7 +192,7 @@ class HunyuanVideoModelLoader(
             print("text encoder 2 (clip l) not loaded, continuing without it")
 
         transformer = self._convert_diffusers_sub_module_to_dtype(
-            pipeline.transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+            pipeline.transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
         )
 
         model.model_type = model_type

--- a/modules/modelLoader/pixartAlpha/PixArtAlphaModelLoader.py
+++ b/modules/modelLoader/pixartAlpha/PixArtAlphaModelLoader.py
@@ -74,7 +74,7 @@ class PixArtAlphaModelLoader(
 
         transformer = self._load_diffusers_sub_module(
             Transformer2DModel,
-            weight_dtypes.prior,
+            weight_dtypes.transformer,
             weight_dtypes.train_dtype,
             base_model_name,
             "transformer",

--- a/modules/modelLoader/qwen/QwenModelLoader.py
+++ b/modules/modelLoader/qwen/QwenModelLoader.py
@@ -100,15 +100,15 @@ class QwenModelLoader(
                 config=base_model_name,
                 subfolder="transformer",
                 #avoid loading the transformer in float32:
-                torch_dtype = torch.bfloat16 if weight_dtypes.prior.torch_dtype() is None else weight_dtypes.prior.torch_dtype()
+                torch_dtype = torch.bfloat16 if weight_dtypes.transformer.torch_dtype() is None else weight_dtypes.transformer.torch_dtype()
             )
             transformer = self._convert_diffusers_sub_module_to_dtype(
-                transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+                transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
             )
         else:
             transformer = self._load_diffusers_sub_module(
                 QwenImageTransformer2DModel,
-                weight_dtypes.prior,
+                weight_dtypes.transformer,
                 weight_dtypes.train_dtype,
                 base_model_name,
                 "transformer",
@@ -144,7 +144,7 @@ class QwenModelLoader(
 
         try:
             self.__load_internal(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:
@@ -152,7 +152,7 @@ class QwenModelLoader(
 
         try:
             self.__load_diffusers(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:
@@ -160,7 +160,7 @@ class QwenModelLoader(
 
         try:
             self.__load_safetensors(
-                model, model_type, weight_dtypes, model_names.base_model, model_names.prior_model, model_names.vae_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.transformer_model, model_names.vae_model,
             )
             return
         except Exception:

--- a/modules/modelLoader/sana/SanaModelLoader.py
+++ b/modules/modelLoader/sana/SanaModelLoader.py
@@ -74,7 +74,7 @@ class SanaModelLoader(
 
         transformer = self._load_diffusers_sub_module(
             SanaTransformer2DModel,
-            weight_dtypes.prior,
+            weight_dtypes.transformer,
             weight_dtypes.train_dtype,
             base_model_name,
             "transformer",

--- a/modules/modelLoader/stableDiffusion3/StableDiffusion3ModelLoader.py
+++ b/modules/modelLoader/stableDiffusion3/StableDiffusion3ModelLoader.py
@@ -129,7 +129,7 @@ class StableDiffusion3ModelLoader(
 
         transformer = self._load_diffusers_sub_module(
             SD3Transformer2DModel,
-            weight_dtypes.prior,
+            weight_dtypes.transformer,
             weight_dtypes.train_dtype,
             base_model_name,
             "transformer",
@@ -220,7 +220,7 @@ class StableDiffusion3ModelLoader(
             print("text encoder 3 (t5) not loaded, continuing without it")
 
         transformer = self._convert_diffusers_sub_module_to_dtype(
-            pipeline.transformer, weight_dtypes.prior, weight_dtypes.train_dtype
+            pipeline.transformer, weight_dtypes.transformer, weight_dtypes.train_dtype
         )
 
         model.model_type = model_type

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -50,7 +50,7 @@ class FluxSampler(BaseModelSampler):
             noise_scheduler: NoiseScheduler,
             text_encoder_1_layer_skip: int = 0,
             text_encoder_2_layer_skip: int = 0,
-            prior_attention_mask: bool = False,
+            transformer_attention_mask: bool = False,
             on_update_progress: Callable[[int, int], None] = lambda _, __: None,
     ) -> ModelSamplerOutput:
         with self.model.autocast_context:
@@ -75,7 +75,7 @@ class FluxSampler(BaseModelSampler):
                 train_device=self.train_device,
                 text_encoder_1_layer_skip=text_encoder_1_layer_skip,
                 text_encoder_2_layer_skip=text_encoder_2_layer_skip,
-                apply_attention_mask=prior_attention_mask,
+                apply_attention_mask=transformer_attention_mask,
             )
 
             self.model.text_encoder_to(self.temp_device)
@@ -199,7 +199,7 @@ class FluxSampler(BaseModelSampler):
             mask_image_path: str = "",
             text_encoder_1_layer_skip: int = 0,
             text_encoder_2_layer_skip: int = 0,
-            prior_attention_mask: bool = False,
+            transformer_attention_mask: bool = False,
             on_update_progress: Callable[[int, int], None] = lambda _, __: None,
     ) -> ModelSamplerOutput:
         with self.model.autocast_context:
@@ -315,7 +315,7 @@ class FluxSampler(BaseModelSampler):
                 train_device=self.train_device,
                 text_encoder_1_layer_skip=text_encoder_1_layer_skip,
                 text_encoder_2_layer_skip=text_encoder_2_layer_skip,
-                apply_attention_mask=prior_attention_mask,
+                apply_attention_mask=transformer_attention_mask,
             )
 
             self.model.text_encoder_to(self.temp_device)
@@ -435,7 +435,7 @@ class FluxSampler(BaseModelSampler):
                 mask_image_path=sample_config.mask_image_path,
                 text_encoder_1_layer_skip=sample_config.text_encoder_1_layer_skip,
                 text_encoder_2_layer_skip=sample_config.text_encoder_2_layer_skip,
-                prior_attention_mask=sample_config.prior_attention_mask,
+                transformer_attention_mask=sample_config.transformer_attention_mask,
                 on_update_progress=on_update_progress,
             )
         else:
@@ -451,7 +451,7 @@ class FluxSampler(BaseModelSampler):
                 noise_scheduler=sample_config.noise_scheduler,
                 text_encoder_1_layer_skip=sample_config.text_encoder_1_layer_skip,
                 text_encoder_2_layer_skip=sample_config.text_encoder_2_layer_skip,
-                prior_attention_mask=sample_config.prior_attention_mask,
+                transformer_attention_mask=sample_config.transformer_attention_mask,
                 on_update_progress=on_update_progress,
             )
 

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -45,7 +45,7 @@ class HiDreamSampler(BaseModelSampler):
             cfg_scale: float,
             noise_scheduler: NoiseScheduler,
             text_encoder_3_layer_skip: int = 0,
-            prior_attention_mask: bool = False,
+            transformer_attention_mask: bool = False,
             on_update_progress: Callable[[int, int], None] = lambda _, __: None,
     ) -> ModelSamplerOutput:
         with self.model.autocast_context:
@@ -71,7 +71,7 @@ class HiDreamSampler(BaseModelSampler):
                         text=prompt,
                         train_device=self.train_device,
                         text_encoder_3_layer_skip=text_encoder_3_layer_skip,
-                        apply_attention_mask=prior_attention_mask,
+                        apply_attention_mask=transformer_attention_mask,
                     ))
 
             negative_text_encoder_3_prompt_embedding, negative_text_encoder_4_prompt_embedding, negative_pooled_prompt_embedding = \
@@ -80,7 +80,7 @@ class HiDreamSampler(BaseModelSampler):
                         text=negative_prompt,
                         train_device=self.train_device,
                         text_encoder_3_layer_skip=text_encoder_3_layer_skip,
-                        apply_attention_mask=prior_attention_mask,
+                        apply_attention_mask=transformer_attention_mask,
                     ))
 
             combined_text_encoder_3_prompt_embedding = torch.cat(
@@ -181,7 +181,7 @@ class HiDreamSampler(BaseModelSampler):
             cfg_scale=sample_config.cfg_scale,
             noise_scheduler=sample_config.noise_scheduler,
             text_encoder_3_layer_skip=sample_config.text_encoder_3_layer_skip,
-            prior_attention_mask=sample_config.prior_attention_mask,
+            transformer_attention_mask=sample_config.transformer_attention_mask,
             on_update_progress=on_update_progress,
         )
 

--- a/modules/modelSampler/HunyuanVideoSampler.py
+++ b/modules/modelSampler/HunyuanVideoSampler.py
@@ -48,7 +48,7 @@ class HunyuanVideoSampler(BaseModelSampler):
             noise_scheduler: NoiseScheduler,
             text_encoder_1_layer_skip: int = 0,
             text_encoder_2_layer_skip: int = 0,
-            prior_attention_mask: bool = False,
+            transformer_attention_mask: bool = False,
             on_update_progress: Callable[[int, int], None] = lambda _, __: None,
     ) -> ModelSamplerOutput:
         with self.model.autocast_context:
@@ -195,7 +195,7 @@ class HunyuanVideoSampler(BaseModelSampler):
             noise_scheduler=sample_config.noise_scheduler,
             text_encoder_1_layer_skip=sample_config.text_encoder_1_layer_skip,
             text_encoder_2_layer_skip=sample_config.text_encoder_2_layer_skip,
-            prior_attention_mask=sample_config.prior_attention_mask,
+            transformer_attention_mask=sample_config.transformer_attention_mask,
             on_update_progress=on_update_progress,
         )
 

--- a/modules/modelSampler/StableDiffusion3Sampler.py
+++ b/modules/modelSampler/StableDiffusion3Sampler.py
@@ -47,7 +47,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
             text_encoder_1_layer_skip: int = 0,
             text_encoder_2_layer_skip: int = 0,
             text_encoder_3_layer_skip: int = 0,
-            prior_attention_mask: bool = False,
+            transformer_attention_mask: bool = False,
             on_update_progress: Callable[[int, int], None] = lambda _, __: None,
     ) -> ModelSamplerOutput:
         with self.model.autocast_context:
@@ -73,7 +73,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
                     text_encoder_1_layer_skip=text_encoder_1_layer_skip,
                     text_encoder_2_layer_skip=text_encoder_2_layer_skip,
                     text_encoder_3_layer_skip=text_encoder_3_layer_skip,
-                    apply_attention_mask=prior_attention_mask,
+                    apply_attention_mask=transformer_attention_mask,
                 ))
 
             negative_prompt_embedding, negative_pooled_prompt_embedding = self.model.combine_text_encoder_output(
@@ -83,7 +83,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
                     text_encoder_1_layer_skip=text_encoder_1_layer_skip,
                     text_encoder_2_layer_skip=text_encoder_2_layer_skip,
                     text_encoder_3_layer_skip=text_encoder_3_layer_skip,
-                    apply_attention_mask=prior_attention_mask,
+                    apply_attention_mask=transformer_attention_mask,
                 ))
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding], dim=0)
@@ -180,7 +180,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
             text_encoder_1_layer_skip=sample_config.text_encoder_1_layer_skip,
             text_encoder_2_layer_skip=sample_config.text_encoder_2_layer_skip,
             text_encoder_3_layer_skip=sample_config.text_encoder_3_layer_skip,
-            prior_attention_mask=sample_config.prior_attention_mask,
+            transformer_attention_mask=sample_config.transformer_attention_mask,
             on_update_progress=on_update_progress,
         )
 

--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -62,7 +62,7 @@ class BaseChromaSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().vae,
             config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -63,7 +63,7 @@ class BaseFluxSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().text_encoder_2,
             config.weight_dtypes().vae,
@@ -230,7 +230,7 @@ class BaseFluxSetup(
                     if 'text_encoder_2_hidden_state' in batch and not config.train_text_encoder_2_or_embedding() else None,
                 text_encoder_1_dropout_probability=config.text_encoder.dropout_probability,
                 text_encoder_2_dropout_probability=config.text_encoder_2.dropout_probability,
-                apply_attention_mask=config.prior.attention_mask,
+                apply_attention_mask=config.transformer.attention_mask,
             )
 
             latent_image = batch['latent_image']
@@ -268,7 +268,7 @@ class BaseFluxSetup(
                 latent_input = scaled_noisy_latent_image
 
             if model.transformer.config.guidance_embeds:
-                guidance = torch.tensor([config.prior.guidance_scale], device=self.train_device)
+                guidance = torch.tensor([config.transformer.guidance_scale], device=self.train_device)
                 guidance = guidance.expand(latent_input.shape[0])
             else:
                 guidance = None

--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -61,7 +61,7 @@ class BaseHiDreamSetup(
                     enable_checkpointing_for_llama_encoder_layers(model.text_encoder_4, config)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().text_encoder_2,
             config.weight_dtypes().text_encoder_3,
@@ -90,7 +90,7 @@ class BaseHiDreamSetup(
                 config.train_dtype,
                 config.fallback_train_dtype,
                 [
-                    config.weight_dtypes().prior,
+                    config.weight_dtypes().transformer,
                     config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,
                     config.weight_dtypes().embedding if config.train_any_embedding() else None,
                 ],
@@ -326,7 +326,7 @@ class BaseHiDreamSetup(
                     text_encoder_2_dropout_probability=config.text_encoder_2.dropout_probability,
                     text_encoder_3_dropout_probability=config.text_encoder_3.dropout_probability,
                     text_encoder_4_dropout_probability=config.text_encoder_4.dropout_probability,
-                    apply_attention_mask=config.prior.attention_mask,
+                    apply_attention_mask=config.transformer.attention_mask,
                 ))
 
             latent_image = batch['latent_image']

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -63,7 +63,7 @@ class BaseHunyuanVideoSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().text_encoder_2,
             config.weight_dtypes().vae,
@@ -77,7 +77,7 @@ class BaseHunyuanVideoSetup(
                 config.train_dtype,
                 config.fallback_train_dtype,
                 [
-                    config.weight_dtypes().prior,
+                    config.weight_dtypes().transformer,
                     config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,
                     config.weight_dtypes().embedding if config.train_any_embedding() else None,
                 ],
@@ -259,7 +259,7 @@ class BaseHunyuanVideoSetup(
             latent_input = scaled_noisy_latent_image
 
             if model.transformer.config.guidance_embeds:
-                guidance = torch.tensor([config.prior.guidance_scale * 1000.0], device=self.train_device)
+                guidance = torch.tensor([config.transformer.guidance_scale * 1000.0], device=self.train_device)
                 guidance = guidance.expand(latent_input.shape[0])
             else:
                 guidance = None

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -62,7 +62,7 @@ class BasePixArtAlphaSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().vae,
             config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -59,7 +59,7 @@ class BaseQwenSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().vae,
             config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -64,7 +64,7 @@ class BaseSanaSetup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().vae,
             config.weight_dtypes().lora if config.training_method == TrainingMethod.LORA else None,

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -63,7 +63,7 @@ class BaseStableDiffusion3Setup(
                 apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
-            config.weight_dtypes().prior,
+            config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,
             config.weight_dtypes().text_encoder_2,
             config.weight_dtypes().text_encoder_3,
@@ -284,7 +284,7 @@ class BaseStableDiffusion3Setup(
                 text_encoder_1_dropout_probability=config.text_encoder.dropout_probability,
                 text_encoder_2_dropout_probability=config.text_encoder_2.dropout_probability,
                 text_encoder_3_dropout_probability=config.text_encoder_3.dropout_probability,
-                apply_attention_mask=config.prior.attention_mask,
+                apply_attention_mask=config.transformer.attention_mask,
             ))
 
             latent_image = batch['latent_image']

--- a/modules/modelSetup/ChromaFineTuneSetup.py
+++ b/modules/modelSetup/ChromaFineTuneSetup.py
@@ -40,7 +40,7 @@ class ChromaFineTuneSetup(
                     "embeddings"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior, freeze=ModuleFilter.create(config), debug=config.debug_mode)
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer, freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         return parameter_group_collection
 
@@ -52,7 +52,7 @@ class ChromaFineTuneSetup(
         self._setup_embeddings_requires_grad(model, config)
 
         self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -95,7 +95,7 @@ class ChromaFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/ChromaLoRASetup.py
+++ b/modules/modelSetup/ChromaLoRASetup.py
@@ -41,7 +41,7 @@ class ChromaLoRASetup(
                     "embeddings"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -57,7 +57,7 @@ class ChromaLoRASetup(
         model.vae.requires_grad_(False)
 
         self._setup_model_part_requires_grad("text_encoder_lora", model.text_encoder_lora, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -123,7 +123,7 @@ class ChromaLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/FluxFineTuneSetup.py
+++ b/modules/modelSetup/FluxFineTuneSetup.py
@@ -47,7 +47,7 @@ class FluxFineTuneSetup(
                     "embeddings_2"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior,
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer,
                                            freeze=ModuleFilter.create(config), debug=config.debug_mode)
         return parameter_group_collection
 
@@ -60,7 +60,7 @@ class FluxFineTuneSetup(
 
         self._setup_model_part_requires_grad("text_encoder_1", model.text_encoder_1, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -117,7 +117,7 @@ class FluxFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/FluxLoRASetup.py
+++ b/modules/modelSetup/FluxLoRASetup.py
@@ -48,7 +48,7 @@ class FluxLoRASetup(
                     "embeddings_2"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
         return parameter_group_collection
 
     def __setup_requires_grad(
@@ -66,7 +66,7 @@ class FluxLoRASetup(
 
         self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -159,7 +159,7 @@ class FluxLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/HiDreamFineTuneSetup.py
+++ b/modules/modelSetup/HiDreamFineTuneSetup.py
@@ -63,7 +63,7 @@ class HiDreamFineTuneSetup(
                     "embeddings_4"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer)
 
         return parameter_group_collection
 
@@ -78,7 +78,7 @@ class HiDreamFineTuneSetup(
         self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_3", model.text_encoder_3, config.text_encoder_3, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_4", model.text_encoder_4, config.text_encoder_4, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress,
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress,
                                             freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         model.vae.requires_grad_(False)
@@ -164,7 +164,7 @@ class HiDreamFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/HiDreamLoRASetup.py
+++ b/modules/modelSetup/HiDreamLoRASetup.py
@@ -64,7 +64,7 @@ class HiDreamLoRASetup(
                     "embeddings_4"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -89,7 +89,7 @@ class HiDreamLoRASetup(
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_4_lora", model.text_encoder_4_lora, config.text_encoder_4, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -236,7 +236,7 @@ class HiDreamLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/HunyuanVideoFineTuneSetup.py
+++ b/modules/modelSetup/HunyuanVideoFineTuneSetup.py
@@ -48,7 +48,7 @@ class HunyuanVideoFineTuneSetup(
                     "embeddings_2"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior,
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer,
                                            freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         return parameter_group_collection
@@ -62,7 +62,7 @@ class HunyuanVideoFineTuneSetup(
 
         self._setup_model_part_requires_grad("text_encoder_1", model.text_encoder_1, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -117,7 +117,7 @@ class HunyuanVideoFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/HunyuanVideoLoRASetup.py
+++ b/modules/modelSetup/HunyuanVideoLoRASetup.py
@@ -50,7 +50,7 @@ class HunyuanVideoLoRASetup(
                     "embeddings_2"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -69,7 +69,7 @@ class HunyuanVideoLoRASetup(
 
         self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -162,7 +162,7 @@ class HunyuanVideoLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/PixArtAlphaFineTuneSetup.py
+++ b/modules/modelSetup/PixArtAlphaFineTuneSetup.py
@@ -39,7 +39,7 @@ class PixArtAlphaFineTuneSetup(
                 "embeddings"
             )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior,
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer,
                                            freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         return parameter_group_collection
@@ -58,7 +58,7 @@ class PixArtAlphaFineTuneSetup(
                                                                                   model.train_progress, i)
             embedding.text_encoder_vector.requires_grad_(train_embedding)
 
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -99,7 +99,7 @@ class PixArtAlphaFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/PixArtAlphaLoRASetup.py
+++ b/modules/modelSetup/PixArtAlphaLoRASetup.py
@@ -40,7 +40,7 @@ class PixArtAlphaLoRASetup(
                 "embeddings"
             )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -55,7 +55,7 @@ class PixArtAlphaLoRASetup(
         model.vae.requires_grad_(False)
 
         self._setup_model_part_requires_grad("text_encoder_lora", model.text_encoder_lora, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -119,7 +119,7 @@ class PixArtAlphaLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/QwenFineTuneSetup.py
+++ b/modules/modelSetup/QwenFineTuneSetup.py
@@ -32,7 +32,7 @@ class QwenFineTuneSetup(
         parameter_group_collection = NamedParameterGroupCollection()
 
         self._create_model_part_parameters(parameter_group_collection, "text_encoder", model.text_encoder, config.text_encoder)
-        self._create_model_part_parameters(parameter_group_collection,  "transformer", model.transformer,  config.prior, freeze=ModuleFilter.create(config), debug=config.debug_mode)
+        self._create_model_part_parameters(parameter_group_collection,  "transformer", model.transformer,  config.transformer, freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             raise NotImplementedError("Embeddings not implemented for Qwen")
@@ -45,7 +45,7 @@ class QwenFineTuneSetup(
             config: TrainConfig,
     ):
         self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -81,7 +81,7 @@ class QwenFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/QwenLoRASetup.py
+++ b/modules/modelSetup/QwenLoRASetup.py
@@ -33,7 +33,7 @@ class QwenLoRASetup(
         parameter_group_collection = NamedParameterGroupCollection()
 
         self._create_model_part_parameters(parameter_group_collection, "text_encoder", model.text_encoder_lora, config.text_encoder)
-        self._create_model_part_parameters(parameter_group_collection, "transformer",  model.transformer_lora,  config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer",  model.transformer_lora,  config.transformer)
 
         if config.train_any_embedding() or config.train_any_output_embedding():
             raise NotImplementedError("Embeddings not implemented for Qwen")
@@ -51,7 +51,7 @@ class QwenLoRASetup(
         model.vae.requires_grad_(False)
 
         self._setup_model_part_requires_grad("text_encoder", model.text_encoder_lora, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -110,7 +110,7 @@ class QwenLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/SanaFineTuneSetup.py
+++ b/modules/modelSetup/SanaFineTuneSetup.py
@@ -39,7 +39,7 @@ class SanaFineTuneSetup(
                 "embeddings"
             )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior,
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer,
                                            freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         return parameter_group_collection
@@ -52,7 +52,7 @@ class SanaFineTuneSetup(
         self._setup_embeddings_requires_grad(model, config)
 
         self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -93,7 +93,7 @@ class SanaFineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/SanaLoRASetup.py
+++ b/modules/modelSetup/SanaLoRASetup.py
@@ -40,7 +40,7 @@ class SanaLoRASetup(
                 "embeddings"
             )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -55,7 +55,7 @@ class SanaLoRASetup(
         model.vae.requires_grad_(False)
 
         self._setup_model_part_requires_grad("text_encoder_lora", model.text_encoder_lora, config.text_encoder, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -119,7 +119,7 @@ class SanaLoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/StableDiffusion3FineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusion3FineTuneSetup.py
@@ -54,7 +54,7 @@ class StableDiffusion3FineTuneSetup(
                     "embeddings_3"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.prior,
+        self._create_model_part_parameters(parameter_group_collection, "transformer", model.transformer, config.transformer,
                                            freeze=ModuleFilter.create(config), debug=config.debug_mode)
 
         return parameter_group_collection
@@ -69,7 +69,7 @@ class StableDiffusion3FineTuneSetup(
         self._setup_model_part_requires_grad("text_encoder_1", model.text_encoder_1, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2", model.text_encoder_2, config.text_encoder_2, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_3", model.text_encoder_3, config.text_encoder_3, model.train_progress)
-        self._setup_model_part_requires_grad("transformer", model.transformer, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer", model.transformer, config.transformer, model.train_progress)
 
         model.vae.requires_grad_(False)
 
@@ -139,7 +139,7 @@ class StableDiffusion3FineTuneSetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/modelSetup/StableDiffusion3LoRASetup.py
+++ b/modules/modelSetup/StableDiffusion3LoRASetup.py
@@ -55,7 +55,7 @@ class StableDiffusion3LoRASetup(
                     "embeddings_3"
                 )
 
-        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.prior)
+        self._create_model_part_parameters(parameter_group_collection, "transformer_lora", model.transformer_lora, config.transformer)
 
         return parameter_group_collection
 
@@ -77,7 +77,7 @@ class StableDiffusion3LoRASetup(
         self._setup_model_part_requires_grad("text_encoder_1_lora", model.text_encoder_1_lora, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_2_lora", model.text_encoder_2_lora, config.text_encoder_2, model.train_progress)
         self._setup_model_part_requires_grad("text_encoder_3_lora", model.text_encoder_3_lora, config.text_encoder_3, model.train_progress)
-        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.prior, model.train_progress)
+        self._setup_model_part_requires_grad("transformer_lora", model.transformer_lora, config.transformer, model.train_progress)
 
     def setup_model(
             self,
@@ -197,7 +197,7 @@ class StableDiffusion3LoRASetup(
 
         model.vae.eval()
 
-        if config.prior.train:
+        if config.transformer.train:
             model.transformer.train()
         else:
             model.transformer.eval()

--- a/modules/trainer/CloudTrainer.py
+++ b/modules/trainer/CloudTrainer.py
@@ -161,6 +161,7 @@ class CloudTrainer(BaseTrainer):
         adjust(remote,"cache_dir")
         adjust(remote,"base_model_name", if_exists=True)
         adjust(remote.prior,"model_name", if_exists=True)
+        adjust(remote.transformer,"model_name", if_exists=True)
         adjust(remote,"output_model_destination")
         adjust(remote,"lora_model_name")
 

--- a/modules/ui/ModelTab.py
+++ b/modules/ui/ModelTab.py
@@ -87,7 +87,7 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
+            has_transformer=True,
             has_text_encoder_1=True,
             has_text_encoder_2=True,
             has_text_encoder_3=True,
@@ -105,8 +105,8 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
-            allow_override_prior=True,
+            has_transformer=True,
+            allow_override_transformer=True,
             has_text_encoder_1=True,
             has_text_encoder_2=True,
             has_vae=True,
@@ -123,8 +123,8 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
-            allow_override_prior=True,
+            has_transformer=True,
+            allow_override_transformer=True,
             has_text_encoder_1=True,
             has_vae=True,
         )
@@ -140,8 +140,8 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
-            allow_override_prior=True,
+            has_transformer=True,
+            allow_override_transformer=True,
             has_text_encoder_1=True,
             has_vae=True,
         )
@@ -193,7 +193,7 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
+            has_transformer=True,
             has_text_encoder=True,
             has_vae=True,
         )
@@ -209,7 +209,7 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
+            has_transformer=True,
             has_text_encoder=True,
             has_vae=True,
         )
@@ -225,7 +225,7 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
+            has_transformer=True,
             has_text_encoder_1=True,
             has_text_encoder_2=True,
             has_vae=True,
@@ -242,7 +242,7 @@ class ModelTab:
         row = self.__create_base_dtype_components(row)
         row = self.__create_base_components(
             row,
-            has_prior=True,
+            has_transformer=True,
             has_text_encoder_1=True,
             has_text_encoder_2=True,
             has_text_encoder_3=True,
@@ -306,6 +306,8 @@ class ModelTab:
             has_unet: bool = False,
             has_prior: bool = False,
             allow_override_prior: bool = False,
+            has_transformer: bool = False,
+            allow_override_transformer: bool = False,
             allow_override_text_encoder_4: bool = False,
             has_text_encoder: bool = False,
             has_text_encoder_1: bool = False,
@@ -326,8 +328,8 @@ class ModelTab:
         if has_prior:
             if allow_override_prior:
                 # prior model
-                components.label(self.scroll_frame, row, 0, "Prior Model", #TODO rename; as more models support this, the name "Prior" gets confusing
-                                 tooltip="Filename, directory or Hugging Face repository of the prior model. For Flux, Chroma or Qwen, it must be a safetensors file that only contains the transformer.")
+                components.label(self.scroll_frame, row, 0, "Prior Model",
+                                 tooltip="Filename, directory or Hugging Face repository of the prior model")
                 components.file_entry(
                     self.scroll_frame, row, 1, self.ui_state, "prior.model_name",
                     path_modifier=lambda x: Path(x).parent.absolute() if x.endswith(".json") else x
@@ -338,6 +340,24 @@ class ModelTab:
                              tooltip="Overrides the prior weight data type")
             components.options_kv(self.scroll_frame, row, 4,  self.__create_dtype_options(),
                                   self.ui_state, "prior.weight_dtype")
+
+            row += 1
+
+        if has_transformer:
+            if allow_override_transformer:
+                # transformer model
+                components.label(self.scroll_frame, row, 0, "Override Transformer",
+                                 tooltip="Can be used to override the transformer in the base model. Local safetensors files and files on HuggingFace are supported.")
+                components.file_entry(
+                    self.scroll_frame, row, 1, self.ui_state, "transformer.model_name",
+                    path_modifier=lambda x: Path(x).parent.absolute() if x.endswith(".json") else x
+                )
+
+            # transformer weight dtype
+            components.label(self.scroll_frame, row, 3, "Override Transformer Data Type",
+                             tooltip="Overrides the transformer weight data type")
+            components.options_kv(self.scroll_frame, row, 4,  self.__create_dtype_options(),
+                                  self.ui_state, "transformer.weight_dtype")
 
             row += 1
 
@@ -379,7 +399,7 @@ class ModelTab:
 
         if has_text_encoder_4:
             if allow_override_text_encoder_4:
-                # prior model
+                # text encoder 4 weight dtype
                 components.label(self.scroll_frame, row, 0, "Text Encoder 4 Override",
                                  tooltip="Filename, directory or Hugging Face repository of the text encoder 4 model")
                 components.file_entry(

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -192,7 +192,7 @@ class TrainingTab:
         self.__create_embedding_frame(column_0, 2)
 
         self.__create_base2_frame(column_1, 0)
-        self.__create_prior_frame(column_1, 1)
+        self.__create_transformer_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2)
 
         self.__create_masked_frame(column_2, 1)
@@ -245,7 +245,7 @@ class TrainingTab:
         self.__create_embedding_frame(column_0, 2)
 
         self.__create_base2_frame(column_1, 0)
-        self.__create_prior_frame(column_1, 1)
+        self.__create_transformer_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2)
 
         self.__create_masked_frame(column_2, 1)
@@ -597,30 +597,30 @@ class TrainingTab:
         # train transformer
         components.label(frame, 0, 0, "Train Transformer",
                          tooltip="Enables training the Transformer model")
-        components.switch(frame, 0, 1, self.ui_state, "prior.train")
+        components.switch(frame, 0, 1, self.ui_state, "transformer.train")
 
         # train transformer epochs
         components.label(frame, 1, 0, "Stop Training After",
                          tooltip="When to stop training the Transformer")
-        components.time_entry(frame, 1, 1, self.ui_state, "prior.stop_training_after", "prior.stop_training_after_unit",
+        components.time_entry(frame, 1, 1, self.ui_state, "transformer.stop_training_after", "transformer.stop_training_after_unit",
                               supports_time_units=False)
 
         # transformer learning rate
         components.label(frame, 2, 0, "Transformer Learning Rate",
                          tooltip="The learning rate of the Transformer. Overrides the base learning rate")
-        components.entry(frame, 2, 1, self.ui_state, "prior.learning_rate")
+        components.entry(frame, 2, 1, self.ui_state, "transformer.learning_rate")
 
         if supports_force_attention_mask:
             # transformer learning rate
             components.label(frame, 3, 0, "Force Attention Mask",
                              tooltip="Force enables passing of a text embedding attention mask to the transformer. This can improve training on shorter captions.")
-            components.switch(frame, 3, 1, self.ui_state, "prior.attention_mask")
+            components.switch(frame, 3, 1, self.ui_state, "transformer.attention_mask")
 
         if supports_guidance_scale:
             # guidance scale
             components.label(frame, 4, 0, "Guidance Scale",
                              tooltip="The guidance scale of guidance distilled models passed to the transformer during training.")
-            components.entry(frame, 4, 1, self.ui_state, "prior.guidance_scale")
+            components.entry(frame, 4, 1, self.ui_state, "transformer.guidance_scale")
 
     def __create_noise_frame(self, master, row, supports_generalized_offset_noise: bool = False, supports_dynamic_timestep_shifting: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/util/ModelNames.py
+++ b/modules/util/ModelNames.py
@@ -13,6 +13,7 @@ class ModelNames:
             self,
             base_model: str = "",
             prior_model: str = "",
+            transformer_model: str = "",
             effnet_encoder_model: str = "",
             decoder_model: str = "",
             text_encoder_4: str = "",
@@ -27,6 +28,7 @@ class ModelNames:
     ):
         self.base_model = base_model
         self.prior_model = prior_model
+        self.transformer_model = transformer_model
         self.effnet_encoder_model = effnet_encoder_model
         self.decoder_model = decoder_model
         self.text_encoder_4 = text_encoder_4

--- a/modules/util/ModelWeightDtypes.py
+++ b/modules/util/ModelWeightDtypes.py
@@ -10,6 +10,7 @@ class ModelWeightDtypes:
             fallback_train_dtype: DataType,
             unet: DataType,
             prior: DataType,
+            transformer: DataType,
             text_encoder: DataType,
             text_encoder_2: DataType,
             text_encoder_3: DataType,
@@ -27,6 +28,7 @@ class ModelWeightDtypes:
 
         self.unet = unet
         self.prior = prior
+        self.transformer = transformer
         self.text_encoder = text_encoder
         self.text_encoder_2 = text_encoder_2
         self.text_encoder_3 = text_encoder_3
@@ -43,6 +45,7 @@ class ModelWeightDtypes:
         return [
             self.unet,
             self.prior,
+            self.transformer,
             self.text_encoder,
             self.text_encoder_2,
             self.text_encoder_3,

--- a/modules/util/config/SampleConfig.py
+++ b/modules/util/config/SampleConfig.py
@@ -22,7 +22,7 @@ class SampleConfig(BaseConfig):
     text_encoder_2_layer_skip: int
     text_encoder_3_layer_skip: int
     text_encoder_4_layer_skip: int
-    prior_attention_mask: bool
+    transformer_attention_mask: bool
     force_last_timestep: bool
 
     sample_inpainting: bool
@@ -37,7 +37,7 @@ class SampleConfig(BaseConfig):
         self.text_encoder_2_layer_skip = train_config.text_encoder_2_layer_skip
         self.text_encoder_3_layer_skip = train_config.text_encoder_3_layer_skip
         self.text_encoder_4_layer_skip = train_config.text_encoder_4_layer_skip
-        self.prior_attention_mask = train_config.prior.attention_mask
+        self.transformer_attention_mask = train_config.transformer.attention_mask
         self.force_last_timestep = train_config.rescale_noise_scheduler_to_zero_terminal_snr
 
     @staticmethod
@@ -61,7 +61,7 @@ class SampleConfig(BaseConfig):
         data.append(("text_encoder_2_layer_skip", 0, int, False))
         data.append(("text_encoder_3_layer_skip", 0, int, False))
         data.append(("text_encoder_4_layer_skip", 0, int, False))
-        data.append(("prior_attention_mask", False, bool, False))
+        data.append(("transformer_attention_mask", False, bool, False))
         data.append(("force_last_timestep", False, bool, False))
 
         data.append(("sample_inpainting", False, bool, False))

--- a/training_presets/#chroma Finetune 16GB.json
+++ b/training_presets/#chroma Finetune 16GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.4,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#chroma Finetune 24GB.json
+++ b/training_presets/#chroma Finetune 24GB.json
@@ -4,7 +4,7 @@
     "learning_rate": 1e-5,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#chroma Finetune 8GB.json
+++ b/training_presets/#chroma Finetune 8GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.85,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#chroma LoRA 16GB.json
+++ b/training_presets/#chroma LoRA 16GB.json
@@ -4,7 +4,7 @@
     "learning_rate": 0.0003,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8"
     },

--- a/training_presets/#chroma LoRA 24GB.json
+++ b/training_presets/#chroma LoRA 24GB.json
@@ -4,7 +4,7 @@
     "learning_rate": 0.0003,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#chroma LoRA 8GB.json
+++ b/training_presets/#chroma LoRA 8GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.6,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8"
     },

--- a/training_presets/#flux LoRA.json
+++ b/training_presets/#flux LoRA.json
@@ -7,7 +7,7 @@
     "output_model_destination": "models/lora.safetensors",
     "output_model_format": "SAFETENSORS",
     "resolution": "768",
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "NFLOAT_4"
     },

--- a/training_presets/#qwen Finetune 16GB.json
+++ b/training_presets/#qwen Finetune 16GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.75,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#qwen Finetune 24GB.json
+++ b/training_presets/#qwen Finetune 24GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.55,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"
     },

--- a/training_presets/#qwen LoRA 16GB.json
+++ b/training_presets/#qwen LoRA 16GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.5,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8"
     },

--- a/training_presets/#qwen LoRA 24GB.json
+++ b/training_presets/#qwen LoRA 24GB.json
@@ -7,7 +7,7 @@
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.1,
     "dataloader_threads": 1,
-    "prior": {
+    "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8"
     },

--- a/training_presets/#sd 3.json
+++ b/training_presets/#sd 3.json
@@ -4,7 +4,7 @@
     "output_dtype": "FLOAT_16",
     "output_model_destination": "models/model.safetensors",
     "output_model_format": "SAFETENSORS",
-    "prior": {
+    "transformer": {
         "weight_dtype": "FLOAT_32"
     },
     "resolution": "1024",


### PR DESCRIPTION
Using "Prior" for the transformer was already confusing, but not many people wanted to override the transformer.

With the upcoming GGUF support more people will do that, so I've renamed it to "Transformer" in this PR, except for models that actually have a model part called "Prior" (which is only Stable Cascade/Wuerstchen):

<img width="1064" height="85" alt="image" src="https://github.com/user-attachments/assets/d4754015-56c8-411f-9228-7e3b2a758747" />
