### PR TITLE
Check intervals for modulo by 0

### DIFF
--- a/modules/util/TimedActionMixin.py
+++ b/modules/util/TimedActionMixin.py
@@ -23,7 +23,7 @@ class TimedActionMixin:
 
         match unit:
             case TimeUnit.EPOCH:
-                if interval == 0:
+                if int(interval) == 0:
                     return False
                 if start_at_zero:
                     return train_progress.epoch % int(interval) == 0 and train_progress.epoch_step == 0
@@ -32,7 +32,7 @@ class TimedActionMixin:
                     return train_progress.epoch % int(interval) == 0 and train_progress.epoch_step == 0 \
                         and train_progress.epoch > 0
             case TimeUnit.STEP:
-                if interval == 0:
+                if int(interval) == 0:
                     return False
                 if start_at_zero:
                     return train_progress.global_step % int(interval) == 0


### PR DESCRIPTION
This should avoid interrupting training just because you are changing saving or backup interval during training, and it might be 0 for a short time while you are typing.

- [x] quick test before merge