### PR TITLE
Add `blocks` presets for filter

### DIFF
--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -27,6 +27,7 @@ from torch import Tensor
 PRESETS = {
     "attn-mlp": ["attn1", "ff_i"],
     "attn-only": ["attn1"],
+    "blocks": ["stream_block"],
     "full": [],
 }
 

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -28,6 +28,7 @@ from torch import Tensor
 PRESETS = {
     "attn-mlp": ["attn", "ff.net"],
     "attn-only": ["attn"],
+    "blocks": ["transformer_block"],
     "full": [],
 }
 

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -27,6 +27,7 @@ from torch import Tensor
 PRESETS = {
     "attn-mlp": ["attn1", "attn2", "ff.net"],
     "attn-only": ["attn1", "attn2"],
+    "blocks": ["transformer_block"],
     "full": [],
 }
 

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -27,6 +27,7 @@ from torch import Tensor
 PRESETS = {
     "attn-mlp": ["attn1", "attn2", "ff."],
     "attn-only": ["attn1", "attn2"],
+    "blocks": ["transformer_block"],
     "full": [],
 }
 

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -27,6 +27,7 @@ from torch import Tensor
 
 PRESETS = {
     "attn-only": ["attn"],
+    "blocks": ["transformer_block"],
     "full": [],
 }
 


### PR DESCRIPTION
Adds `blocks` preset for most models

 - can be useful for layer filter, if you want to train `full` but not the embedding and final layers
 - will be the recommended preset for quantization layer filter