### PR TITLE
Avoid attention masks for Qwen and Chroma

### DIFF
--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -228,7 +228,7 @@ class BaseChromaSetup(
 
             image_seq_len = packed_latent_input.shape[1]
             image_attention_mask = torch.full((packed_latent_input.shape[0], image_seq_len), True, dtype=torch.bool, device=text_attention_mask.device)
-            attention_mask = torch.cat([text_attention_mask, image_attention_mask], dim=1)
+            attention_mask = torch.cat([text_attention_mask, image_attention_mask], dim=1) if not torch.all(text_attention_mask) else None
 
             packed_predicted_flow = model.transformer(
                 hidden_states=packed_latent_input.to(dtype=model.train_dtype.torch_dtype()),

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -147,7 +147,7 @@ class BaseQwenSetup(
             #FIXME bug workaround for https://github.com/huggingface/diffusers/issues/12294
             image_attention_mask=torch.ones((packed_latent_input.shape[0], packed_latent_input.shape[1]), dtype=torch.bool, device=latent_image.device)
             attention_mask = torch.cat([text_attention_mask, image_attention_mask], dim=1)
-            attention_mask_2d = attention_mask[:, None, None, :] * attention_mask[:, None, :, None]
+            attention_mask_2d = attention_mask[:, None, None, :] if not torch.all(text_attention_mask) else None
 
             packed_predicted_flow = model.transformer(
                 hidden_states=packed_latent_input.to(dtype=model.train_dtype.torch_dtype()),


### PR DESCRIPTION
torch SDPA automatically uses a flash attention algorithm if possible:

- if no attention mask is used, because flash attention doesn't support masks
- currently: if linux, but this PR, https://github.com/Nerogar/OneTrainer/pull/1107 or an upcoming torch version might change that

While torch automatically uses flash attention if there is no attention mask given at all, it does not recognize it if there is a no-op attention mask (mask is given, but no tokens are masked).

This PR detects that and uses no mask instead of a no-op mask, resulting in a significant speed-up of 20-25% in those cases. This is always the case if batch size is 1, and less often if batch size > 1.

  |   | Qwen bs1 1328 px RTX 6000 Ada | Chroma bs2 512 px RTX 4070
-- | -- | -- | --
OneTrainer | baseline | 8.6 | 2.3
OneTrainer | avoiding masks | 6.6 | 1.85
OneTrainer | +compiled | 5.1 |  
OneTrainer | +int8 | 3.4 |  

This in principle can be combined with other upcoming features that improve performance further, see last two lines.

thank you to @FurkanGozukara for pointing out this speed difference

- [x] only implemented for Qwen and Chroma. Hunyuan, HiDream and Pixart appear to use attention masks as well