### PR TITLE
Code deduplication

### DIFF
--- a/modules/modelLoader/ChromaEmbeddingModelLoader.py
+++ b/modules/modelLoader/ChromaEmbeddingModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.ChromaModel import ChromaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.chroma.ChromaEmbeddingLoader import ChromaEmbeddingLoader
 from modules.modelLoader.chroma.ChromaModelLoader import ChromaModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class ChromaEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.CHROMA_1:
-                return "resources/sd_model_spec/chroma-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> ChromaModel | None:
-        base_model_loader = ChromaModelLoader()
-        embedding_loader = ChromaEmbeddingLoader()
-
-        model = ChromaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+ChromaEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={ModelType.CHROMA_1: "resources/sd_model_spec/chroma-embedding.json"},
+    model_class=ChromaModel,
+    model_loader_class=ChromaModelLoader,
+    embedding_loader_class=ChromaEmbeddingLoader,
+)

--- a/modules/modelLoader/ChromaFineTuneModelLoader.py
+++ b/modules/modelLoader/ChromaFineTuneModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.ChromaModel import ChromaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.chroma.ChromaEmbeddingLoader import ChromaEmbeddingLoader
 from modules.modelLoader.chroma.ChromaModelLoader import ChromaModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class ChromaFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.CHROMA_1:
-                return "resources/sd_model_spec/chroma.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> ChromaModel | None:
-        base_model_loader = ChromaModelLoader()
-        embedding_loader = ChromaEmbeddingLoader()
-
-        model = ChromaModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+ChromaFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={ModelType.CHROMA_1: "resources/sd_model_spec/chroma.json"},
+    model_class=ChromaModel,
+    model_loader_class=ChromaModelLoader,
+    embedding_loader_class=ChromaEmbeddingLoader,
+)

--- a/modules/modelLoader/ChromaLoRAModelLoader.py
+++ b/modules/modelLoader/ChromaLoRAModelLoader.py
@@ -1,50 +1,14 @@
 from modules.model.ChromaModel import ChromaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.chroma.ChromaEmbeddingLoader import ChromaEmbeddingLoader
 from modules.modelLoader.chroma.ChromaLoRALoader import ChromaLoRALoader
 from modules.modelLoader.chroma.ChromaModelLoader import ChromaModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class ChromaLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.CHROMA_1:
-                return "resources/sd_model_spec/chroma-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> ChromaModel | None:
-        base_model_loader = ChromaModelLoader()
-        lora_model_loader = ChromaLoRALoader()
-        embedding_loader = ChromaEmbeddingLoader()
-
-        model = ChromaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+ChromaLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={ModelType.CHROMA_1: "resources/sd_model_spec/chroma-lora.json"},
+    model_class=ChromaModel,
+    model_loader_class=ChromaModelLoader,
+    embedding_loader_class=ChromaEmbeddingLoader,
+    lora_loader_class=ChromaLoRALoader,
+)

--- a/modules/modelLoader/FluxEmbeddingModelLoader.py
+++ b/modules/modelLoader/FluxEmbeddingModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.FluxModel import FluxModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.flux.FluxEmbeddingLoader import FluxEmbeddingLoader
 from modules.modelLoader.flux.FluxModelLoader import FluxModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class FluxEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.FLUX_DEV_1:
-                return "resources/sd_model_spec/flux_dev_1.0-embedding.json"
-            case ModelType.FLUX_FILL_DEV_1:
-                return "resources/sd_model_spec/flux_dev_fill_1.0-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> FluxModel | None:
-        base_model_loader = FluxModelLoader()
-        embedding_loader = FluxEmbeddingLoader()
-
-        model = FluxModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+FluxEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.FLUX_DEV_1: "resources/sd_model_spec/flux_dev_1.0-embedding.json",
+        ModelType.FLUX_FILL_DEV_1: "resources/sd_model_spec/flux_dev_fill_1.0-embedding.json",
+    },
+    model_class=FluxModel,
+    model_loader_class=FluxModelLoader,
+    embedding_loader_class=FluxEmbeddingLoader,
+)

--- a/modules/modelLoader/FluxFineTuneModelLoader.py
+++ b/modules/modelLoader/FluxFineTuneModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.FluxModel import FluxModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.flux.FluxEmbeddingLoader import FluxEmbeddingLoader
 from modules.modelLoader.flux.FluxModelLoader import FluxModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class FluxFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.FLUX_DEV_1:
-                return "resources/sd_model_spec/flux_dev_1.0.json"
-            case ModelType.FLUX_FILL_DEV_1:
-                return "resources/sd_model_spec/flux_dev_fill_1.0.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> FluxModel | None:
-        base_model_loader = FluxModelLoader()
-        embedding_loader = FluxEmbeddingLoader()
-
-        model = FluxModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+FluxFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.FLUX_DEV_1: "resources/sd_model_spec/flux_dev_1.0.json",
+        ModelType.FLUX_FILL_DEV_1: "resources/sd_model_spec/flux_dev_fill_1.0.json",
+    },
+    model_class=FluxModel,
+    model_loader_class=FluxModelLoader,
+    embedding_loader_class=FluxEmbeddingLoader,
+)

--- a/modules/modelLoader/FluxLoRAModelLoader.py
+++ b/modules/modelLoader/FluxLoRAModelLoader.py
@@ -1,52 +1,17 @@
 from modules.model.FluxModel import FluxModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelLoader.flux.FluxEmbeddingLoader import FluxEmbeddingLoader
 from modules.modelLoader.flux.FluxLoRALoader import FluxLoRALoader
 from modules.modelLoader.flux.FluxModelLoader import FluxModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class FluxLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.FLUX_DEV_1:
-                return "resources/sd_model_spec/flux_dev_1.0-lora.json"
-            case ModelType.FLUX_FILL_DEV_1:
-                return "resources/sd_model_spec/flux_dev_fill_1.0-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> FluxModel | None:
-        base_model_loader = FluxModelLoader()
-        lora_model_loader = FluxLoRALoader()
-        embedding_loader = FluxEmbeddingLoader()
-
-        model = FluxModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+FluxLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.FLUX_DEV_1: "resources/sd_model_spec/flux_dev_1.0-lora.json",
+        ModelType.FLUX_FILL_DEV_1: "resources/sd_model_spec/flux_dev_fill_1.0-lora.json",
+    },
+    model_class=FluxModel,
+    model_loader_class=FluxModelLoader,
+    embedding_loader_class=FluxEmbeddingLoader,
+    lora_loader_class=FluxLoRALoader,
+)

--- a/modules/modelLoader/GenericEmbeddingModelLoader.py
+++ b/modules/modelLoader/GenericEmbeddingModelLoader.py
@@ -1,0 +1,48 @@
+from modules.model.BaseModel import BaseModel
+from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
+from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.util.enum.ModelType import ModelType
+from modules.util.ModelNames import ModelNames
+from modules.util.ModelWeightDtypes import ModelWeightDtypes
+
+
+def make_embedding_model_loader(
+    model_spec_map: dict[ModelType, str],
+    model_class: type[BaseModel],
+    model_loader_class: type,
+    embedding_loader_class: type,
+):
+    class GenericEmbeddingModelLoader(
+        BaseModelLoader,
+        ModelSpecModelLoaderMixin,
+        InternalModelLoaderMixin,
+    ):
+        def __init__(self):
+            super().__init__()
+
+        def _default_model_spec_name(
+                self,
+                model_type: ModelType,
+        ) -> str | None:
+            return model_spec_map.get(model_type)
+
+        def load(
+                self,
+                model_type: ModelType,
+                model_names: ModelNames,
+                weight_dtypes: ModelWeightDtypes,
+        ) -> model_class | None:
+            base_model_loader = model_loader_class()
+            embedding_loader = embedding_loader_class()
+
+            model = model_class(model_type=model_type)
+            self._load_internal_data(model, model_names.embedding.model_name)
+            model.model_spec = self._load_default_model_spec(model_type)
+
+            if model_names.base_model is not None:
+                base_model_loader.load(model, model_type, model_names, weight_dtypes)
+            embedding_loader.load(model, model_names.embedding.model_name, model_names)
+
+            return model
+    return GenericEmbeddingModelLoader

--- a/modules/modelLoader/GenericFineTuneModelLoader.py
+++ b/modules/modelLoader/GenericFineTuneModelLoader.py
@@ -1,0 +1,51 @@
+from modules.model.BaseModel import BaseModel
+from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
+from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.util.enum.ModelType import ModelType
+from modules.util.ModelNames import ModelNames
+from modules.util.ModelWeightDtypes import ModelWeightDtypes
+
+
+def make_fine_tune_model_loader(
+    model_spec_map: dict[ModelType, str],
+    model_class: type[BaseModel],
+    model_loader_class: type,
+    embedding_loader_class: type | None,
+):
+    class GenericFineTuneModelLoader(
+        BaseModelLoader,
+        ModelSpecModelLoaderMixin,
+        InternalModelLoaderMixin,
+    ):
+        def __init__(self):
+            super().__init__()
+
+        def _default_model_spec_name(
+                self,
+                model_type: ModelType,
+        ) -> str | None:
+            return model_spec_map.get(model_type)
+
+        def load(
+                self,
+                model_type: ModelType,
+                model_names: ModelNames,
+                weight_dtypes: ModelWeightDtypes,
+        ) -> model_class | None:
+            base_model_loader = model_loader_class()
+            if embedding_loader_class is not None:
+                embedding_loader = embedding_loader_class()
+
+            model = model_class(model_type=model_type)
+
+            self._load_internal_data(model, model_names.base_model)
+            model.model_spec = self._load_default_model_spec(model_type)
+
+            base_model_loader.load(model, model_type, model_names, weight_dtypes)
+            if embedding_loader_class is not None:
+                embedding_loader.load(model, model_names.base_model, model_names)
+
+            return model
+
+    return GenericFineTuneModelLoader

--- a/modules/modelLoader/GenericLoRAModelLoader.py
+++ b/modules/modelLoader/GenericLoRAModelLoader.py
@@ -1,0 +1,54 @@
+from modules.model.BaseModel import BaseModel
+from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
+from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.util.enum.ModelType import ModelType
+from modules.util.ModelNames import ModelNames
+from modules.util.ModelWeightDtypes import ModelWeightDtypes
+
+
+def make_lora_model_loader(
+    model_spec_map: dict[ModelType, str],
+    model_class: type[BaseModel],
+    model_loader_class: type,
+    embedding_loader_class: type | None,
+    lora_loader_class: type,
+):
+    class GenericLoRAModelLoader(
+        BaseModelLoader,
+        ModelSpecModelLoaderMixin,
+        InternalModelLoaderMixin,
+    ):
+        def __init__(self):
+            super().__init__()
+
+        def _default_model_spec_name(
+                self,
+                model_type: ModelType,
+        ) -> str | None:
+            return model_spec_map.get(model_type)
+
+        def load(
+                self,
+                model_type: ModelType,
+                model_names: ModelNames,
+                weight_dtypes: ModelWeightDtypes,
+        ) -> model_class | None:
+            base_model_loader = model_loader_class()
+            lora_model_loader = lora_loader_class()
+            if embedding_loader_class is not None:
+                embedding_loader = embedding_loader_class()
+
+            model = model_class(model_type=model_type)
+            self._load_internal_data(model, model_names.lora)
+            model.model_spec = self._load_default_model_spec(model_type)
+
+            if model_names.base_model is not None:
+                base_model_loader.load(model, model_type, model_names, weight_dtypes)
+            lora_model_loader.load(model, model_names)
+            if embedding_loader_class is not None:
+                embedding_loader.load(model, model_names.lora, model_names)
+
+            return model
+
+    return GenericLoRAModelLoader

--- a/modules/modelLoader/HiDreamEmbeddingModelLoader.py
+++ b/modules/modelLoader/HiDreamEmbeddingModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.HiDreamModel import HiDreamModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.hiDream.HiDreamEmbeddingLoader import HiDreamEmbeddingLoader
 from modules.modelLoader.hiDream.HiDreamModelLoader import HiDreamModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HiDreamEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HI_DREAM_FULL:
-                return "resources/sd_model_spec/hi_dream_full-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HiDreamModel | None:
-        base_model_loader = HiDreamModelLoader()
-        embedding_loader = HiDreamEmbeddingLoader()
-
-        model = HiDreamModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+HiDreamEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={ModelType.HI_DREAM_FULL: "resources/sd_model_spec/hi_dream_full-embedding.json"},
+    model_class=HiDreamModel,
+    model_loader_class=HiDreamModelLoader,
+    embedding_loader_class=HiDreamEmbeddingLoader,
+)

--- a/modules/modelLoader/HiDreamFineTuneModelLoader.py
+++ b/modules/modelLoader/HiDreamFineTuneModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.HiDreamModel import HiDreamModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.hiDream.HiDreamEmbeddingLoader import HiDreamEmbeddingLoader
 from modules.modelLoader.hiDream.HiDreamModelLoader import HiDreamModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HiDreamFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HI_DREAM_FULL:
-                return "resources/sd_model_spec/hi_dream_full.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HiDreamModel | None:
-        base_model_loader = HiDreamModelLoader()
-        embedding_loader = HiDreamEmbeddingLoader()
-
-        model = HiDreamModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+HiDreamFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={ModelType.HI_DREAM_FULL: "resources/sd_model_spec/hi_dream_full.json"},
+    model_class=HiDreamModel,
+    model_loader_class=HiDreamModelLoader,
+    embedding_loader_class=HiDreamEmbeddingLoader,
+)

--- a/modules/modelLoader/HiDreamLoRAModelLoader.py
+++ b/modules/modelLoader/HiDreamLoRAModelLoader.py
@@ -1,50 +1,14 @@
 from modules.model.HiDreamModel import HiDreamModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.hiDream.HiDreamEmbeddingLoader import HiDreamEmbeddingLoader
 from modules.modelLoader.hiDream.HiDreamLoRALoader import HiDreamLoRALoader
 from modules.modelLoader.hiDream.HiDreamModelLoader import HiDreamModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HiDreamLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HI_DREAM_FULL:
-                return "resources/sd_model_spec/hi_dream_full-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HiDreamModel | None:
-        base_model_loader = HiDreamModelLoader()
-        lora_model_loader = HiDreamLoRALoader()
-        embedding_loader = HiDreamEmbeddingLoader()
-
-        model = HiDreamModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+HiDreamLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={ModelType.HI_DREAM_FULL: "resources/sd_model_spec/hi_dream_full-lora.json"},
+    model_class=HiDreamModel,
+    model_loader_class=HiDreamModelLoader,
+    embedding_loader_class=HiDreamEmbeddingLoader,
+    lora_loader_class=HiDreamLoRALoader,
+)

--- a/modules/modelLoader/HunyuanVideoEmbeddingModelLoader.py
+++ b/modules/modelLoader/HunyuanVideoEmbeddingModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoEmbeddingLoader import HunyuanVideoEmbeddingLoader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoModelLoader import HunyuanVideoModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HunyuanVideoEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HUNYUAN_VIDEO:
-                return "resources/sd_model_spec/hunyuan_video-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HunyuanVideoModel | None:
-        base_model_loader = HunyuanVideoModelLoader()
-        embedding_loader = HunyuanVideoEmbeddingLoader()
-
-        model = HunyuanVideoModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+HunyuanVideoEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={ModelType.HUNYUAN_VIDEO: "resources/sd_model_spec/hunyuan_video-embedding.json"},
+    model_class=HunyuanVideoModel,
+    model_loader_class=HunyuanVideoModelLoader,
+    embedding_loader_class=HunyuanVideoEmbeddingLoader,
+)

--- a/modules/modelLoader/HunyuanVideoFineTuneModelLoader.py
+++ b/modules/modelLoader/HunyuanVideoFineTuneModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoEmbeddingLoader import HunyuanVideoEmbeddingLoader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoModelLoader import HunyuanVideoModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HunyuanVideoFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HUNYUAN_VIDEO:
-                return "resources/sd_model_spec/hunyuan_video.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HunyuanVideoModel | None:
-        base_model_loader = HunyuanVideoModelLoader()
-        embedding_loader = HunyuanVideoEmbeddingLoader()
-
-        model = HunyuanVideoModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+HunyuanVideoFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={ModelType.HUNYUAN_VIDEO: "resources/sd_model_spec/hunyuan_video.json"},
+    model_class=HunyuanVideoModel,
+    model_loader_class=HunyuanVideoModelLoader,
+    embedding_loader_class=HunyuanVideoEmbeddingLoader,
+)

--- a/modules/modelLoader/HunyuanVideoLoRAModelLoader.py
+++ b/modules/modelLoader/HunyuanVideoLoRAModelLoader.py
@@ -1,50 +1,14 @@
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoEmbeddingLoader import HunyuanVideoEmbeddingLoader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoLoRALoader import HunyuanVideoLoRALoader
 from modules.modelLoader.hunyuanVideo.HunyuanVideoModelLoader import HunyuanVideoModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class HunyuanVideoLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.HUNYUAN_VIDEO:
-                return "resources/sd_model_spec/hunyuan_video-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> HunyuanVideoModel | None:
-        base_model_loader = HunyuanVideoModelLoader()
-        lora_model_loader = HunyuanVideoLoRALoader()
-        embedding_loader = HunyuanVideoEmbeddingLoader()
-
-        model = HunyuanVideoModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+HunyuanVideoLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={ModelType.HUNYUAN_VIDEO: "resources/sd_model_spec/hunyuan_video-lora.json"},
+    model_class=HunyuanVideoModel,
+    model_loader_class=HunyuanVideoModelLoader,
+    embedding_loader_class=HunyuanVideoEmbeddingLoader,
+    lora_loader_class=HunyuanVideoLoRALoader,
+)

--- a/modules/modelLoader/PixArtAlphaEmbeddingModelLoader.py
+++ b/modules/modelLoader/PixArtAlphaEmbeddingModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.pixartAlpha.PixArtAlphaEmbeddingLoader import PixArtAlphaEmbeddingLoader
 from modules.modelLoader.pixartAlpha.PixArtAlphaModelLoader import PixArtAlphaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class PixArtAlphaEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.PIXART_ALPHA:
-                return "resources/sd_model_spec/pixart_alpha_1.0-embedding.json"
-            case ModelType.PIXART_SIGMA:
-                return "resources/sd_model_spec/pixart_sigma_1.0-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> PixArtAlphaModel | None:
-        base_model_loader = PixArtAlphaModelLoader()
-        embedding_loader = PixArtAlphaEmbeddingLoader()
-
-        model = PixArtAlphaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+PixArtAlphaEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.PIXART_ALPHA: "resources/sd_model_spec/pixart_alpha_1.0-embedding.json",
+        ModelType.PIXART_SIGMA: "resources/sd_model_spec/pixart_sigma_1.0-embedding.json",
+    },
+    model_class=PixArtAlphaModel,
+    model_loader_class=PixArtAlphaModelLoader,
+    embedding_loader_class=PixArtAlphaEmbeddingLoader,
+)

--- a/modules/modelLoader/PixArtAlphaFineTuneModelLoader.py
+++ b/modules/modelLoader/PixArtAlphaFineTuneModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.pixartAlpha.PixArtAlphaEmbeddingLoader import PixArtAlphaEmbeddingLoader
 from modules.modelLoader.pixartAlpha.PixArtAlphaModelLoader import PixArtAlphaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class PixArtAlphaFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.PIXART_ALPHA:
-                return "resources/sd_model_spec/pixart_alpha_1.0.json"
-            case ModelType.PIXART_SIGMA:
-                return "resources/sd_model_spec/pixart_sigma_1.0.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> PixArtAlphaModel | None:
-        base_model_loader = PixArtAlphaModelLoader()
-        embedding_loader = PixArtAlphaEmbeddingLoader()
-
-        model = PixArtAlphaModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+PixArtAlphaFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.PIXART_ALPHA: "resources/sd_model_spec/pixart_alpha_1.0.json",
+        ModelType.PIXART_SIGMA: "resources/sd_model_spec/pixart_sigma_1.0.json",
+    },
+    model_class=PixArtAlphaModel,
+    model_loader_class=PixArtAlphaModelLoader,
+    embedding_loader_class=PixArtAlphaEmbeddingLoader,
+)

--- a/modules/modelLoader/PixArtAlphaLoRAModelLoader.py
+++ b/modules/modelLoader/PixArtAlphaLoRAModelLoader.py
@@ -1,52 +1,17 @@
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.pixartAlpha.PixArtAlphaEmbeddingLoader import PixArtAlphaEmbeddingLoader
 from modules.modelLoader.pixartAlpha.PixArtAlphaLoRALoader import PixArtAlphaLoRALoader
 from modules.modelLoader.pixartAlpha.PixArtAlphaModelLoader import PixArtAlphaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class PixArtAlphaLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.PIXART_ALPHA:
-                return "resources/sd_model_spec/pixart_alpha_1.0-lora.json"
-            case ModelType.PIXART_SIGMA:
-                return "resources/sd_model_spec/pixart_sigma_1.0-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> PixArtAlphaModel | None:
-        base_model_loader = PixArtAlphaModelLoader()
-        lora_model_loader = PixArtAlphaLoRALoader()
-        embedding_loader = PixArtAlphaEmbeddingLoader()
-
-        model = PixArtAlphaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+PixArtAlphaLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.PIXART_ALPHA: "resources/sd_model_spec/pixart_alpha_1.0-lora.json",
+        ModelType.PIXART_SIGMA: "resources/sd_model_spec/pixart_sigma_1.0-lora.json",
+    },
+    model_class=PixArtAlphaModel,
+    model_loader_class=PixArtAlphaModelLoader,
+    embedding_loader_class=PixArtAlphaEmbeddingLoader,
+    lora_loader_class=PixArtAlphaLoRALoader,
+)

--- a/modules/modelLoader/QwenFineTuneModelLoader.py
+++ b/modules/modelLoader/QwenFineTuneModelLoader.py
@@ -1,43 +1,11 @@
 from modules.model.QwenModel import QwenModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.qwen.QwenModelLoader import QwenModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class QwenFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.QWEN:
-                return "resources/sd_model_spec/qwen.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> QwenModel | None:
-        base_model_loader = QwenModelLoader()
-        model = QwenModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-
-        return model
+QwenFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={ModelType.QWEN: "resources/sd_model_spec/qwen.json"},
+    model_class=QwenModel,
+    model_loader_class=QwenModelLoader,
+    embedding_loader_class=None,
+)

--- a/modules/modelLoader/QwenLoRAModelLoader.py
+++ b/modules/modelLoader/QwenLoRAModelLoader.py
@@ -1,47 +1,13 @@
 from modules.model.QwenModel import QwenModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.qwen.QwenLoRALoader import QwenLoRALoader
 from modules.modelLoader.qwen.QwenModelLoader import QwenModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class QwenLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.QWEN:
-                return "resources/sd_model_spec/qwen-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> QwenModel | None:
-        base_model_loader = QwenModelLoader()
-        lora_model_loader = QwenLoRALoader()
-
-        model = QwenModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-
-        return model
+QwenLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={ModelType.QWEN: "resources/sd_model_spec/qwen-lora.json"},
+    model_class=QwenModel,
+    model_loader_class=QwenModelLoader,
+    embedding_loader_class=None,
+    lora_loader_class=QwenLoRALoader,
+)

--- a/modules/modelLoader/SanaEmbeddingModelLoader.py
+++ b/modules/modelLoader/SanaEmbeddingModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.SanaModel import SanaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.sana.SanaEmbeddingLoader import SanaEmbeddingLoader
 from modules.modelLoader.sana.SanaModelLoader import SanaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class SanaEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.SANA:
-                return "resources/sd_model_spec/sana-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> SanaModel | None:
-        base_model_loader = SanaModelLoader()
-        embedding_loader = SanaEmbeddingLoader()
-
-        model = SanaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+SanaEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={ModelType.SANA: "resources/sd_model_spec/sana-embedding.json"},
+    model_class=SanaModel,
+    model_loader_class=SanaModelLoader,
+    embedding_loader_class=SanaEmbeddingLoader,
+)

--- a/modules/modelLoader/SanaFineTuneModelLoader.py
+++ b/modules/modelLoader/SanaFineTuneModelLoader.py
@@ -1,47 +1,12 @@
 from modules.model.SanaModel import SanaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.sana.SanaEmbeddingLoader import SanaEmbeddingLoader
 from modules.modelLoader.sana.SanaModelLoader import SanaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class SanaFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.SANA:
-                return "resources/sd_model_spec/sana.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> SanaModel | None:
-        base_model_loader = SanaModelLoader()
-        embedding_loader = SanaEmbeddingLoader()
-
-        model = SanaModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+SanaFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={ModelType.SANA: "resources/sd_model_spec/sana.json"},
+    model_class=SanaModel,
+    model_loader_class=SanaModelLoader,
+    embedding_loader_class=SanaEmbeddingLoader,
+)

--- a/modules/modelLoader/SanaLoRAModelLoader.py
+++ b/modules/modelLoader/SanaLoRAModelLoader.py
@@ -1,50 +1,14 @@
 from modules.model.SanaModel import SanaModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.sana.SanaEmbeddingLoader import SanaEmbeddingLoader
 from modules.modelLoader.sana.SanaLoRALoader import SanaLoRALoader
 from modules.modelLoader.sana.SanaModelLoader import SanaModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class SanaLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.SANA:
-                return "resources/sd_model_spec/sana-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> SanaModel | None:
-        base_model_loader = SanaModelLoader()
-        lora_model_loader = SanaLoRALoader()
-        embedding_loader = SanaEmbeddingLoader()
-
-        model = SanaModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+SanaLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={ModelType.SANA: "resources/sd_model_spec/sana-lora.json"},
+    model_class=SanaModel,
+    model_loader_class=SanaModelLoader,
+    embedding_loader_class=SanaEmbeddingLoader,
+    lora_loader_class=SanaLoRALoader,
+)

--- a/modules/modelLoader/StableDiffusion3EmbeddingModelLoader.py
+++ b/modules/modelLoader/StableDiffusion3EmbeddingModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3EmbeddingLoader import StableDiffusion3EmbeddingLoader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3ModelLoader import StableDiffusion3ModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusion3EmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_3:
-                return "resources/sd_model_spec/sd_3_2b_1.0-embedding.json"
-            case ModelType.STABLE_DIFFUSION_35:
-                return "resources/sd_model_spec/sd_3.5_1.0-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusion3Model | None:
-        base_model_loader = StableDiffusion3ModelLoader()
-        embedding_loader = StableDiffusion3EmbeddingLoader()
-
-        model = StableDiffusion3Model(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+StableDiffusion3EmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_3: "resources/sd_model_spec/sd_3_2b_1.0-embedding.json",
+        ModelType.STABLE_DIFFUSION_35: "resources/sd_model_spec/sd_3.5_1.0-embedding.json",
+    },
+    model_class=StableDiffusion3Model,
+    model_loader_class=StableDiffusion3ModelLoader,
+    embedding_loader_class=StableDiffusion3EmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusion3FineTuneModelLoader.py
+++ b/modules/modelLoader/StableDiffusion3FineTuneModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3EmbeddingLoader import StableDiffusion3EmbeddingLoader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3ModelLoader import StableDiffusion3ModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusion3FineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_3:
-                return "resources/sd_model_spec/sd_3_2b_1.0.json"
-            case ModelType.STABLE_DIFFUSION_35:
-                return "resources/sd_model_spec/sd_3.5_1.0.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusion3Model | None:
-        base_model_loader = StableDiffusion3ModelLoader()
-        embedding_loader = StableDiffusion3EmbeddingLoader()
-
-        model = StableDiffusion3Model(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+StableDiffusion3FineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_3: "resources/sd_model_spec/sd_3_2b_1.0.json",
+        ModelType.STABLE_DIFFUSION_35: "resources/sd_model_spec/sd_3.5_1.0.json",
+    },
+    model_class=StableDiffusion3Model,
+    model_loader_class=StableDiffusion3ModelLoader,
+    embedding_loader_class=StableDiffusion3EmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusion3LoRAModelLoader.py
+++ b/modules/modelLoader/StableDiffusion3LoRAModelLoader.py
@@ -1,52 +1,17 @@
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3EmbeddingLoader import StableDiffusion3EmbeddingLoader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3LoRALoader import StableDiffusion3LoRALoader
 from modules.modelLoader.stableDiffusion3.StableDiffusion3ModelLoader import StableDiffusion3ModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusion3LoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_3:
-                return "resources/sd_model_spec/sd_3_2b_1.0-lora.json"
-            case ModelType.STABLE_DIFFUSION_35:
-                return "resources/sd_model_spec/sd_3.5_1.0-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusion3Model | None:
-        base_model_loader = StableDiffusion3ModelLoader()
-        lora_model_loader = StableDiffusion3LoRALoader()
-        embedding_loader = StableDiffusion3EmbeddingLoader()
-
-        model = StableDiffusion3Model(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+StableDiffusion3LoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_3: "resources/sd_model_spec/sd_3_2b_1.0-lora.json",
+        ModelType.STABLE_DIFFUSION_35: "resources/sd_model_spec/sd_3.5_1.0-lora.json",
+    },
+    model_class=StableDiffusion3Model,
+    model_loader_class=StableDiffusion3ModelLoader,
+    embedding_loader_class=StableDiffusion3EmbeddingLoader,
+    lora_loader_class=StableDiffusion3LoRALoader,
+)

--- a/modules/modelLoader/StableDiffusionEmbeddingModelLoader.py
+++ b/modules/modelLoader/StableDiffusionEmbeddingModelLoader.py
@@ -1,61 +1,21 @@
 from modules.model.StableDiffusionModel import StableDiffusionModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.stableDiffusion.StableDiffusionEmbeddingLoader import StableDiffusionEmbeddingLoader
 from modules.modelLoader.stableDiffusion.StableDiffusionModelLoader import StableDiffusionModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_15:
-                return "resources/sd_model_spec/sd_1.5-embedding.json"
-            case ModelType.STABLE_DIFFUSION_15_INPAINTING:
-                return "resources/sd_model_spec/sd_1.5_inpainting-embedding.json"
-            case ModelType.STABLE_DIFFUSION_20:
-                return "resources/sd_model_spec/sd_2.0-embedding.json"
-            case ModelType.STABLE_DIFFUSION_20_BASE:
-                return "resources/sd_model_spec/sd_2.0-embedding.json"
-            case ModelType.STABLE_DIFFUSION_20_INPAINTING:
-                return "resources/sd_model_spec/sd_2.0_inpainting-embedding.json"
-            case ModelType.STABLE_DIFFUSION_20_DEPTH:
-                return "resources/sd_model_spec/sd_2.0_depth-embedding.json"
-            case ModelType.STABLE_DIFFUSION_21:
-                return "resources/sd_model_spec/sd_2.1-embedding.json"
-            case ModelType.STABLE_DIFFUSION_21_BASE:
-                return "resources/sd_model_spec/sd_2.1-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionModel | None:
-        base_model_loader = StableDiffusionModelLoader()
-        embedding_loader = StableDiffusionEmbeddingLoader()
-
-        model = StableDiffusionModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+StableDiffusionEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_15: "resources/sd_model_spec/sd_1.5-embedding.json",
+        ModelType.STABLE_DIFFUSION_15_INPAINTING: "resources/sd_model_spec/sd_1.5_inpainting-embedding.json",
+        ModelType.STABLE_DIFFUSION_20: "resources/sd_model_spec/sd_2.0-embedding.json",
+        ModelType.STABLE_DIFFUSION_20_BASE: "resources/sd_model_spec/sd_2.0-embedding.json",
+        ModelType.STABLE_DIFFUSION_20_INPAINTING: "resources/sd_model_spec/sd_2.0_inpainting-embedding.json",
+        ModelType.STABLE_DIFFUSION_20_DEPTH: "resources/sd_model_spec/sd_2.0_depth-embedding.json",
+        ModelType.STABLE_DIFFUSION_21: "resources/sd_model_spec/sd_2.1-embedding.json",
+        ModelType.STABLE_DIFFUSION_21_BASE: "resources/sd_model_spec/sd_2.1-embedding.json",
+    },
+    model_class=StableDiffusionModel,
+    model_loader_class=StableDiffusionModelLoader,
+    embedding_loader_class=StableDiffusionEmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusionFineTuneModelLoader.py
+++ b/modules/modelLoader/StableDiffusionFineTuneModelLoader.py
@@ -1,61 +1,21 @@
 from modules.model.StableDiffusionModel import StableDiffusionModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.stableDiffusion.StableDiffusionEmbeddingLoader import StableDiffusionEmbeddingLoader
 from modules.modelLoader.stableDiffusion.StableDiffusionModelLoader import StableDiffusionModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_15:
-                return "resources/sd_model_spec/sd_1.5.json"
-            case ModelType.STABLE_DIFFUSION_15_INPAINTING:
-                return "resources/sd_model_spec/sd_1.5_inpainting.json"
-            case ModelType.STABLE_DIFFUSION_20:
-                return "resources/sd_model_spec/sd_2.0.json"
-            case ModelType.STABLE_DIFFUSION_20_BASE:
-                return "resources/sd_model_spec/sd_2.0.json"
-            case ModelType.STABLE_DIFFUSION_20_INPAINTING:
-                return "resources/sd_model_spec/sd_2.0_inpainting.json"
-            case ModelType.STABLE_DIFFUSION_20_DEPTH:
-                return "resources/sd_model_spec/sd_2.0_depth.json"
-            case ModelType.STABLE_DIFFUSION_21:
-                return "resources/sd_model_spec/sd_2.1.json"
-            case ModelType.STABLE_DIFFUSION_21_BASE:
-                return "resources/sd_model_spec/sd_2.1.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionModel | None:
-        base_model_loader = StableDiffusionModelLoader()
-        embedding_loader = StableDiffusionEmbeddingLoader()
-
-        model = StableDiffusionModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+StableDiffusionFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_15: "resources/sd_model_spec/sd_3_2b_1.0.json",
+        ModelType.STABLE_DIFFUSION_15_INPAINTING: "resources/sd_model_spec/sd_3.5_1.0.json",
+        ModelType.STABLE_DIFFUSION_20: "resources/sd_model_spec/sd_2.0.json",
+        ModelType.STABLE_DIFFUSION_20_BASE: "resources/sd_model_spec/sd_2.0.json",
+        ModelType.STABLE_DIFFUSION_20_INPAINTING: "resources/sd_model_spec/sd_2.0_inpainting.json",
+        ModelType.STABLE_DIFFUSION_20_DEPTH: "resources/sd_model_spec/sd_2.0_depth.json",
+        ModelType.STABLE_DIFFUSION_21: "resources/sd_model_spec/sd_2.1.json",
+        ModelType.STABLE_DIFFUSION_21_BASE: "resources/sd_model_spec/sd_2.1.json",
+    },
+    model_class=StableDiffusionModel,
+    model_loader_class=StableDiffusionModelLoader,
+    embedding_loader_class=StableDiffusionEmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusionLoRAModelLoader.py
+++ b/modules/modelLoader/StableDiffusionLoRAModelLoader.py
@@ -1,64 +1,23 @@
 from modules.model.StableDiffusionModel import StableDiffusionModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.stableDiffusion.StableDiffusionEmbeddingLoader import StableDiffusionEmbeddingLoader
 from modules.modelLoader.stableDiffusion.StableDiffusionLoRALoader import StableDiffusionLoRALoader
 from modules.modelLoader.stableDiffusion.StableDiffusionModelLoader import StableDiffusionModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_15:
-                return "resources/sd_model_spec/sd_1.5-lora.json"
-            case ModelType.STABLE_DIFFUSION_15_INPAINTING:
-                return "resources/sd_model_spec/sd_1.5_inpainting-lora.json"
-            case ModelType.STABLE_DIFFUSION_20:
-                return "resources/sd_model_spec/sd_2.0-lora.json"
-            case ModelType.STABLE_DIFFUSION_20_BASE:
-                return "resources/sd_model_spec/sd_2.0-lora.json"
-            case ModelType.STABLE_DIFFUSION_20_INPAINTING:
-                return "resources/sd_model_spec/sd_2.0_inpainting-lora.json"
-            case ModelType.STABLE_DIFFUSION_20_DEPTH:
-                return "resources/sd_model_spec/sd_2.0_depth-lora.json"
-            case ModelType.STABLE_DIFFUSION_21:
-                return "resources/sd_model_spec/sd_2.1-lora.json"
-            case ModelType.STABLE_DIFFUSION_21_BASE:
-                return "resources/sd_model_spec/sd_2.1-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionModel | None:
-        base_model_loader = StableDiffusionModelLoader()
-        lora_model_loader = StableDiffusionLoRALoader()
-        embedding_loader = StableDiffusionEmbeddingLoader()
-
-        model = StableDiffusionModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+StableDiffusionLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_15: "resources/sd_model_spec/sd_1.5-lora.json",
+        ModelType.STABLE_DIFFUSION_15_INPAINTING: "resources/sd_model_spec/sd_1.5_inpainting-lora.json",
+        ModelType.STABLE_DIFFUSION_20: "resources/sd_model_spec/sd_2.0-lora.json",
+        ModelType.STABLE_DIFFUSION_20_BASE: "resources/sd_model_spec/sd_2.0-lora.json",
+        ModelType.STABLE_DIFFUSION_20_INPAINTING: "resources/sd_model_spec/sd_2.0_inpainting-lora.json",
+        ModelType.STABLE_DIFFUSION_20_DEPTH: "resources/sd_model_spec/sd_2.0_depth-lora.json",
+        ModelType.STABLE_DIFFUSION_21: "resources/sd_model_spec/sd_2.1-lora.json",
+        ModelType.STABLE_DIFFUSION_21_BASE: "resources/sd_model_spec/sd_2.1-lora.json",
+    },
+    model_class=StableDiffusionModel,
+    model_loader_class=StableDiffusionModelLoader,
+    embedding_loader_class=StableDiffusionEmbeddingLoader,
+    lora_loader_class=StableDiffusionLoRALoader,
+)

--- a/modules/modelLoader/StableDiffusionXLEmbeddingModelLoader.py
+++ b/modules/modelLoader/StableDiffusionXLEmbeddingModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLEmbeddingLoader import StableDiffusionXLEmbeddingLoader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLModelLoader import StableDiffusionXLModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionXLEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE:
-                return "resources/sd_model_spec/sd_xl_base_1.0-embedding.json"
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING:
-                return "resources/sd_model_spec/sd_xl_base_1.0_inpainting-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionXLModel | None:
-        base_model_loader = StableDiffusionXLModelLoader()
-        embedding_loader = StableDiffusionXLEmbeddingLoader()
-
-        model = StableDiffusionXLModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+StableDiffusionXLEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_XL_10_BASE: "resources/sd_model_spec/sd_xl_base_1.0-embedding.json",
+        ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING: "resources/sd_model_spec/sd_xl_base_1.0_inpainting-embedding.json",
+    },
+    model_class=StableDiffusionXLModel,
+    model_loader_class=StableDiffusionXLModelLoader,
+    embedding_loader_class=StableDiffusionXLEmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusionXLFineTuneModelLoader.py
+++ b/modules/modelLoader/StableDiffusionXLFineTuneModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLEmbeddingLoader import StableDiffusionXLEmbeddingLoader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLModelLoader import StableDiffusionXLModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionXLFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE:
-                return "resources/sd_model_spec/sd_xl_base_1.0.json"
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING:
-                return "resources/sd_model_spec/sd_xl_base_1.0_inpainting.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionXLModel | None:
-        base_model_loader = StableDiffusionXLModelLoader()
-        embedding_loader = StableDiffusionXLEmbeddingLoader()
-
-        model = StableDiffusionXLModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+StableDiffusionXLFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_XL_10_BASE: "resources/sd_model_spec/sd_xl_base_1.0.json",
+        ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING: "resources/sd_model_spec/sd_xl_base_1.0_inpainting.json",
+    },
+    model_class=StableDiffusionXLModel,
+    model_loader_class=StableDiffusionXLModelLoader,
+    embedding_loader_class=StableDiffusionXLEmbeddingLoader,
+)

--- a/modules/modelLoader/StableDiffusionXLLoRAModelLoader.py
+++ b/modules/modelLoader/StableDiffusionXLLoRAModelLoader.py
@@ -1,52 +1,17 @@
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLEmbeddingLoader import StableDiffusionXLEmbeddingLoader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLLoRALoader import StableDiffusionXLLoRALoader
 from modules.modelLoader.stableDiffusionXL.StableDiffusionXLModelLoader import StableDiffusionXLModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class StableDiffusionXLLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE:
-                return "resources/sd_model_spec/sd_xl_base_1.0-lora.json"
-            case ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING:
-                return "resources/sd_model_spec/sd_xl_base_1.0_inpainting-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> StableDiffusionXLModel | None:
-        base_model_loader = StableDiffusionXLModelLoader()
-        lora_model_loader = StableDiffusionXLLoRALoader()
-        embedding_loader = StableDiffusionXLEmbeddingLoader()
-
-        model = StableDiffusionXLModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+StableDiffusionXLLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.STABLE_DIFFUSION_XL_10_BASE: "resources/sd_model_spec/sd_xl_base_1.0-lora.json",
+        ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING: "resources/sd_model_spec/sd_xl_base_1.0_inpainting-lora.json",
+    },
+    model_class=StableDiffusionXLModel,
+    model_loader_class=StableDiffusionXLModelLoader,
+    embedding_loader_class=StableDiffusionXLEmbeddingLoader,
+    lora_loader_class=StableDiffusionXLLoRALoader,
+)

--- a/modules/modelLoader/WuerstchenEmbeddingModelLoader.py
+++ b/modules/modelLoader/WuerstchenEmbeddingModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.WuerstchenModel import WuerstchenModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericEmbeddingModelLoader import make_embedding_model_loader
 from modules.modelLoader.wuerstchen.WuerstchenEmbeddingLoader import WuerstchenEmbeddingLoader
 from modules.modelLoader.wuerstchen.WuerstchenModelLoader import WuerstchenModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class WuerstchenEmbeddingModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.WUERSTCHEN_2:
-                return "resources/sd_model_spec/wuerstchen_2.0-embedding.json"
-            case ModelType.STABLE_CASCADE_1:
-                return "resources/sd_model_spec/stable_cascade_1.0-embedding.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> WuerstchenModel | None:
-        base_model_loader = WuerstchenModelLoader()
-        embedding_loader = WuerstchenEmbeddingLoader()
-
-        model = WuerstchenModel(model_type=model_type)
-        self._load_internal_data(model, model_names.embedding.model_name)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.embedding.model_name, model_names)
-
-        return model
+WuerstchenEmbeddingModelLoader = make_embedding_model_loader(
+    model_spec_map={
+        ModelType.WUERSTCHEN_2: "resources/sd_model_spec/wuerstchen_2.0-embedding.json",
+        ModelType.STABLE_CASCADE_1: "resources/sd_model_spec/stable_cascade_1.0-embedding.json",
+    },
+    model_class=WuerstchenModel,
+    model_loader_class=WuerstchenModelLoader,
+    embedding_loader_class=WuerstchenEmbeddingLoader,
+)

--- a/modules/modelLoader/WuerstchenFineTuneModelLoader.py
+++ b/modules/modelLoader/WuerstchenFineTuneModelLoader.py
@@ -1,49 +1,15 @@
 from modules.model.WuerstchenModel import WuerstchenModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericFineTuneModelLoader import make_fine_tune_model_loader
 from modules.modelLoader.wuerstchen.WuerstchenEmbeddingLoader import WuerstchenEmbeddingLoader
 from modules.modelLoader.wuerstchen.WuerstchenModelLoader import WuerstchenModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class WuerstchenFineTuneModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.WUERSTCHEN_2:
-                return "resources/sd_model_spec/wuerstchen_2.0.json"
-            case ModelType.STABLE_CASCADE_1:
-                return "resources/sd_model_spec/stable_cascade_1.0.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> WuerstchenModel | None:
-        base_model_loader = WuerstchenModelLoader()
-        embedding_loader = WuerstchenEmbeddingLoader()
-
-        model = WuerstchenModel(model_type=model_type)
-
-        self._load_internal_data(model, model_names.base_model)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        embedding_loader.load(model, model_names.base_model, model_names)
-
-        return model
+WuerstchenFineTuneModelLoader = make_fine_tune_model_loader(
+    model_spec_map={
+        ModelType.WUERSTCHEN_2: "resources/sd_model_spec/wuerstchen_2.0.json",
+        ModelType.STABLE_CASCADE_1: "resources/sd_model_spec/stable_cascade_1.0.json",
+    },
+    model_class=WuerstchenModel,
+    model_loader_class=WuerstchenModelLoader,
+    embedding_loader_class=WuerstchenEmbeddingLoader,
+)

--- a/modules/modelLoader/WuerstchenLoRAModelLoader.py
+++ b/modules/modelLoader/WuerstchenLoRAModelLoader.py
@@ -1,52 +1,17 @@
 from modules.model.WuerstchenModel import WuerstchenModel
-from modules.modelLoader.BaseModelLoader import BaseModelLoader
-from modules.modelLoader.mixin.InternalModelLoaderMixin import InternalModelLoaderMixin
-from modules.modelLoader.mixin.ModelSpecModelLoaderMixin import ModelSpecModelLoaderMixin
+from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.wuerstchen.WuerstchenEmbeddingLoader import WuerstchenEmbeddingLoader
 from modules.modelLoader.wuerstchen.WuerstchenLoRALoader import WuerstchenLoRALoader
 from modules.modelLoader.wuerstchen.WuerstchenModelLoader import WuerstchenModelLoader
 from modules.util.enum.ModelType import ModelType
-from modules.util.ModelNames import ModelNames
-from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
-
-class WuerstchenLoRAModelLoader(
-    BaseModelLoader,
-    ModelSpecModelLoaderMixin,
-    InternalModelLoaderMixin,
-):
-    def __init__(self):
-        super().__init__()
-
-    def _default_model_spec_name(
-            self,
-            model_type: ModelType,
-    ) -> str | None:
-        match model_type:
-            case ModelType.WUERSTCHEN_2:
-                return "resources/sd_model_spec/wuerstchen_2.0-lora.json"
-            case ModelType.STABLE_CASCADE_1:
-                return "resources/sd_model_spec/stable_cascade_1.0-lora.json"
-            case _:
-                return None
-
-    def load(
-            self,
-            model_type: ModelType,
-            model_names: ModelNames,
-            weight_dtypes: ModelWeightDtypes,
-    ) -> WuerstchenModel | None:
-        base_model_loader = WuerstchenModelLoader()
-        lora_model_loader = WuerstchenLoRALoader()
-        embedding_loader = WuerstchenEmbeddingLoader()
-
-        model = WuerstchenModel(model_type=model_type)
-        self._load_internal_data(model, model_names.lora)
-        model.model_spec = self._load_default_model_spec(model_type)
-
-        if model_names.base_model is not None:
-            base_model_loader.load(model, model_type, model_names, weight_dtypes)
-        lora_model_loader.load(model, model_names)
-        embedding_loader.load(model, model_names.lora, model_names)
-
-        return model
+WuerstchenLoRAModelLoader = make_lora_model_loader(
+    model_spec_map={
+        ModelType.WUERSTCHEN_2: "resources/sd_model_spec/wuerstchen_2.0-lora.json",
+        ModelType.STABLE_CASCADE_1: "resources/sd_model_spec/stable_cascade_1.0-lora.json",
+    },
+    model_class=WuerstchenModel,
+    model_loader_class=WuerstchenModelLoader,
+    embedding_loader_class=WuerstchenEmbeddingLoader,
+    lora_loader_class=WuerstchenLoRALoader,
+)


### PR DESCRIPTION
This is an attempt to de-duplicate identical code between models,
 - but keep the OneTrainer object model unchanged
 - still have the possibility to write model-specific classes if that is necessary for future models
 - this makes changes easier for future PRs. as an example, one of the existing PRs requires passing quantization settings through the model loader

This PR is only model loaders, but the principle could be applied to other parts of the object model.
This PR uses class constructors, similar to C++ templates. An alternative to this way would be to use base classes and mixins, but I feel this way is cleaner and less likely to break things. Feedback welcome

