### PR TITLE
Check training loss for NaN

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import json
+import math
 import os
 import shutil
 import traceback
@@ -778,6 +779,9 @@ class GenericTrainer(BaseTrainer):
                             )
 
                             accumulated_loss_cpu = accumulated_loss.item()
+                            if math.isnan(accumulated_loss_cpu):
+                                raise RuntimeError("Training loss became NaN. This may be due to invalid parameters, precision issues, or a bug in the loss computation.")
+
                             self.tensorboard.add_scalar("loss/train_step",accumulated_loss_cpu , train_progress.global_step)
                             ema_loss = ema_loss or accumulated_loss_cpu
                             ema_loss_steps += 1


### PR DESCRIPTION
Error out if NaN training loss was detected, which is non-recoverable

- it does not react to fp16 overflow. In this case, gradients become `inf` or `NaN', but not the loss (unless the forward pass produces a NaN values, but this case cannot be recovered by the scaler)
- it doesn't prevent NaN gradients to be applied to the model. In case the user has enabled backups before save, that backup will be destroyed. It might be better to avoid that, but: checking for NaN before the each optimizer step requires a CUDA synchronisation because it branches on CPU. this is either a small performance impact, or even a large performance impact if fused backpass is used. So I decided against it.
