### PR TITLE
Fix `huber loss delta` default value being significantly too low

### DIFF
--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -929,7 +929,7 @@ class TrainConfig(BaseConfig):
         data.append(("mae_strength", 0.0, float, False))
         data.append(("log_cosh_strength", 0.0, float, False))
         data.append(("huber_strength", 0.0, float, False))
-        data.append(("huber_delta", 0.1, float, False))
+        data.append(("huber_delta", 1.0, float, False))
         data.append(("vb_loss_strength", 1.0, float, False))
         data.append(("loss_weight_fn", LossWeight.CONSTANT, LossWeight, False))
         data.append(("loss_weight_strength", 5.0, float, False))


### PR DESCRIPTION
I think the OT default of `0.1`, which was attempting to match the `Kohya_SS`'s `huber loss decay` value, is a bad choice and was copied in error.

The implementation of huber loss in `Kohya_SS` uses a completely different version of huber loss, known as psuedo-huber loss, which smoothes the transition between L1 and L2 loss (see: https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function). Vanilla huber loss in comparison, is a binary decision of either L1 (MAE) or L2 (MSE) loss.

In practice, these configuration options work completely differently and values used by psuedo huber loss are not directly exchangeable to vanilla huber loss. I think `0.10` in practice is very low, and is unlikely to be a good value for vanilla huber loss.  Instead, I am proposing we use the standard `1.0` as default value instead.  This value is expected to be tweaked by users, but is likely to still be quite reasonable if left unchanged.