### PR TITLE
Support for cloud hosts that use pyenv

### DIFF
--- a/modules/cloud/LinuxCloud.py
+++ b/modules/cloud/LinuxCloud.py
@@ -88,7 +88,7 @@ class LinuxCloud(BaseCloud):
         #for interactive shells. On RunPod, cuda is missing from $PATH; on vast.ai, python is missing.
         #We cannot pretend to be interactive either, because then vast.ai starts a tmux screen.
         #Add these paths manually:
-        cmd_env = f"export PATH=$PATH:/usr/local/cuda/bin:/venv/main/bin:~/.pyenv/shims/python\
+        cmd_env = f"export PATH=$PATH:/usr/local/cuda/bin:/venv/main/bin:~/.pyenv/shims/python \
                    && export OT_LAZY_UPDATES=true \
                    && cd {shlex.quote(config.onetrainer_dir)}"
 


### PR DESCRIPTION
See this comment https://github.com/dxqb/OneTrainer/blob/2c32d2f4ba86fbfd211b6d23b26efb152690753b/modules/cloud/LinuxCloud.py#L87 for why this has to be, unfortunately, maintained manually