### PR TITLE
Fixing cloud sync bug which caused re-syncs of existing files.

### DIFF
--- a/modules/cloud/BaseSSHFileSync.py
+++ b/modules/cloud/BaseSSHFileSync.py
@@ -105,7 +105,7 @@ class BaseSSHFileSync(BaseFileSync):
         return (
             remote not in sync_info
             or local.stat().st_size != sync_info[remote]['size']
-            or local.stat().st_mtime > sync_info[remote]['mtime']
+            or int(local.stat().st_mtime) > sync_info[remote]['mtime']
         )
 
     @staticmethod


### PR DESCRIPTION
Fixing bug with cloud sync where existing remote files are re-uploaded. Ensuring the local timestamp is an integer resolves this.