### PR TITLE
move OMI code back to OneTrainer

### DIFF
--- a/modules/modelLoader/ZImageModelLoader.py
+++ b/modules/modelLoader/ZImageModelLoader.py
@@ -8,6 +8,7 @@ from modules.modelLoader.GenericLoRAModelLoader import make_lora_model_loader
 from modules.modelLoader.mixin.HFModelLoaderMixin import HFModelLoaderMixin
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
 from modules.util.config.TrainConfig import QuantizationConfig
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelType import ModelType
 from modules.util.ModelNames import ModelNames
 from modules.util.ModelWeightDtypes import ModelWeightDtypes
@@ -24,8 +25,6 @@ from transformers import (
     Qwen2Tokenizer,
     Qwen3ForCausalLM,
 )
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class ZImageModelLoader(

--- a/modules/modelLoader/chroma/ChromaLoRALoader.py
+++ b/modules/modelLoader/chroma/ChromaLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.ChromaModel import ChromaModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_chroma_lora import convert_chroma_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_chroma_lora import convert_chroma_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class ChromaLoRALoader(

--- a/modules/modelLoader/flux/FluxLoRALoader.py
+++ b/modules/modelLoader/flux/FluxLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.FluxModel import FluxModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_flux_lora import convert_flux_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_flux_lora import convert_flux_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class FluxLoRALoader(

--- a/modules/modelLoader/hiDream/HiDreamLoRALoader.py
+++ b/modules/modelLoader/hiDream/HiDreamLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.HiDreamModel import HiDreamModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_hidream_lora import convert_hidream_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_hidream_lora import convert_hidream_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class HiDreamLoRALoader(

--- a/modules/modelLoader/hunyuanVideo/HunyuanVideoLoRALoader.py
+++ b/modules/modelLoader/hunyuanVideo/HunyuanVideoLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_hunyuan_video_lora import convert_hunyuan_video_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_hunyuan_video_lora import convert_hunyuan_video_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class HunyuanVideoLoRALoader(

--- a/modules/modelLoader/mixin/LoRALoaderMixin.py
+++ b/modules/modelLoader/mixin/LoRALoaderMixin.py
@@ -3,11 +3,11 @@ import traceback
 from abc import ABCMeta, abstractmethod
 
 from modules.model.BaseModel import BaseModel
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, convert_to_diffusers
 from modules.util.ModelNames import ModelNames
 
 import torch
 
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, convert_to_diffusers
 from safetensors.torch import load_file
 
 

--- a/modules/modelLoader/pixartAlpha/PixArtAlphaLoRALoader.py
+++ b/modules/modelLoader/pixartAlpha/PixArtAlphaLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_pixart_lora import convert_pixart_lora_key_sets
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_pixart_lora import convert_pixart_lora_key_sets
 
 
 class PixArtAlphaLoRALoader(

--- a/modules/modelLoader/qwen/QwenLoRALoader.py
+++ b/modules/modelLoader/qwen/QwenLoRALoader.py
@@ -1,9 +1,8 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.QwenModel import QwenModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class QwenLoRALoader(

--- a/modules/modelLoader/sana/SanaLoRALoader.py
+++ b/modules/modelLoader/sana/SanaLoRALoader.py
@@ -1,9 +1,8 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.SanaModel import SanaModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class SanaLoRALoader(

--- a/modules/modelLoader/stableDiffusion/StableDiffusionLoRALoader.py
+++ b/modules/modelLoader/stableDiffusion/StableDiffusionLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.StableDiffusionModel import StableDiffusionModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sd_lora import convert_sd_lora_key_sets
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sd_lora import convert_sd_lora_key_sets
 
 
 class StableDiffusionLoRALoader(

--- a/modules/modelLoader/stableDiffusion3/StableDiffusion3LoRALoader.py
+++ b/modules/modelLoader/stableDiffusion3/StableDiffusion3LoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sd3_lora import convert_sd3_lora_key_sets
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sd3_lora import convert_sd3_lora_key_sets
 
 
 class StableDiffusion3LoRALoader(

--- a/modules/modelLoader/stableDiffusionXL/StableDiffusionXLLoRALoader.py
+++ b/modules/modelLoader/stableDiffusionXL/StableDiffusionXLLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sdxl_lora import convert_sdxl_lora_key_sets
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sdxl_lora import convert_sdxl_lora_key_sets
 
 
 class StableDiffusionXLLoRALoader(

--- a/modules/modelLoader/wuerstchen/WuerstchenLoRALoader.py
+++ b/modules/modelLoader/wuerstchen/WuerstchenLoRALoader.py
@@ -1,10 +1,9 @@
 from modules.model.BaseModel import BaseModel
 from modules.model.WuerstchenModel import WuerstchenModel
 from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_stable_cascade_lora import convert_stable_cascade_lora_key_sets
 from modules.util.ModelNames import ModelNames
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_stable_cascade_lora import convert_stable_cascade_lora_key_sets
 
 
 class WuerstchenLoRALoader(

--- a/modules/modelSaver/chroma/ChromaLoRASaver.py
+++ b/modules/modelSaver/chroma/ChromaLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.ChromaModel import ChromaModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_chroma_lora import convert_chroma_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_chroma_lora import convert_chroma_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class ChromaLoRASaver(

--- a/modules/modelSaver/flux/FluxLoRASaver.py
+++ b/modules/modelSaver/flux/FluxLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.FluxModel import FluxModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_flux_lora import convert_flux_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_flux_lora import convert_flux_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class FluxLoRASaver(

--- a/modules/modelSaver/hidream/HiDreamLoRASaver.py
+++ b/modules/modelSaver/hidream/HiDreamLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.HiDreamModel import HiDreamModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_hidream_lora import convert_hidream_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_hidream_lora import convert_hidream_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class HiDreamLoRASaver(

--- a/modules/modelSaver/hunyuanVideo/HunyuanVideoLoRASaver.py
+++ b/modules/modelSaver/hunyuanVideo/HunyuanVideoLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.HunyuanVideoModel import HunyuanVideoModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_hunyuan_video_lora import convert_hunyuan_video_lora_key_sets
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_hunyuan_video_lora import convert_hunyuan_video_lora_key_sets
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class HunyuanVideoLoRASaver(

--- a/modules/modelSaver/mixin/LoRASaverMixin.py
+++ b/modules/modelSaver/mixin/LoRASaverMixin.py
@@ -4,16 +4,16 @@ from pathlib import Path
 
 from modules.model.BaseModel import BaseModel
 from modules.modelSaver.mixin.DtypeModelSaverMixin import DtypeModelSaverMixin
+from modules.util.convert.lora.convert_lora_util import (
+    LoraConversionKeySet,
+    convert_to_legacy_diffusers,
+    convert_to_omi,
+)
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
 
-from omi_model_standards.convert.lora.convert_lora_util import (
-    LoraConversionKeySet,
-    convert_to_legacy_diffusers,
-    convert_to_omi,
-)
 from safetensors.torch import save_file
 
 

--- a/modules/modelSaver/pixartAlpha/PixArtAlphaLoRASaver.py
+++ b/modules/modelSaver/pixartAlpha/PixArtAlphaLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.PixArtAlphaModel import PixArtAlphaModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_pixart_lora import convert_pixart_lora_key_sets
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_pixart_lora import convert_pixart_lora_key_sets
 
 
 class PixArtAlphaLoRASaver(

--- a/modules/modelSaver/qwen/QwenLoRASaver.py
+++ b/modules/modelSaver/qwen/QwenLoRASaver.py
@@ -1,11 +1,10 @@
 from modules.model.QwenModel import QwenModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class QwenLoRASaver(

--- a/modules/modelSaver/sana/SanaLoRASaver.py
+++ b/modules/modelSaver/sana/SanaLoRASaver.py
@@ -1,11 +1,10 @@
 from modules.model.SanaModel import SanaModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class SanaLoRASaver(

--- a/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.StableDiffusionModel import StableDiffusionModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sd_lora import convert_sd_lora_key_sets
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sd_lora import convert_sd_lora_key_sets
 
 
 class StableDiffusionLoRASaver(

--- a/modules/modelSaver/stableDiffusion3/StableDiffusion3LoRASaver.py
+++ b/modules/modelSaver/stableDiffusion3/StableDiffusion3LoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.StableDiffusion3Model import StableDiffusion3Model
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sd3_lora import convert_sd3_lora_key_sets
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sd3_lora import convert_sd3_lora_key_sets
 
 
 class StableDiffusion3LoRASaver(

--- a/modules/modelSaver/stableDiffusionXL/StableDiffusionXLLoRASaver.py
+++ b/modules/modelSaver/stableDiffusionXL/StableDiffusionXLLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_sdxl_lora import convert_sdxl_lora_key_sets
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_sdxl_lora import convert_sdxl_lora_key_sets
 
 
 class StableDiffusionXLLoRASaver(

--- a/modules/modelSaver/wuerstchen/WuerstchenLoRASaver.py
+++ b/modules/modelSaver/wuerstchen/WuerstchenLoRASaver.py
@@ -1,12 +1,11 @@
 from modules.model.WuerstchenModel import WuerstchenModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+from modules.util.convert.lora.convert_stable_cascade_lora import convert_stable_cascade_lora_key_sets
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
-from omi_model_standards.convert.lora.convert_stable_cascade_lora import convert_stable_cascade_lora_key_sets
 
 
 class WuerstchenLoRASaver(

--- a/modules/modelSaver/zImage/ZImageLoRASaver.py
+++ b/modules/modelSaver/zImage/ZImageLoRASaver.py
@@ -1,11 +1,10 @@
 from modules.model.ZImageModel import ZImageModel
 from modules.modelSaver.mixin.LoRASaverMixin import LoRASaverMixin
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
 from torch import Tensor
-
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 class ZImageLoRASaver(

--- a/modules/util/convert/lora/convert_chroma_lora.py
+++ b/modules/util/convert/lora/convert_chroma_lora.py
@@ -1,0 +1,74 @@
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from modules.util.convert.lora.convert_t5 import map_t5
+
+
+def __map_double_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("img_attn.qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn.qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn.qkv.2", "attn.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn.qkv.0", "attn.add_q_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn.qkv.1", "attn.add_k_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn.qkv.2", "attn.add_v_proj", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("img_attn.proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.2", "ff.net.2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn.proj", "attn.to_add_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.0", "ff_context.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.2", "ff_context.net.2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_single_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("linear1.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.2", "attn.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.3", "proj_mlp", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("linear2", "proj_out", parent=key_prefix)]
+
+    return keys
+
+def __map_distilled_guidance_layer_layers(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("in_layer", "linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("out_layer", "linear_2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("txt_in", "context_embedder", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_in.proj", "x_embedder", parent=key_prefix)]
+
+    for k in map_prefix_range("double_blocks", "transformer_blocks", parent=key_prefix):
+        keys += __map_double_transformer_block(k)
+
+    for k in map_prefix_range("single_blocks", "single_transformer_blocks", parent=key_prefix):
+        keys += __map_single_transformer_block(k)
+
+    for k in map_prefix_range("distilled_guidance_layer.layers", "distilled_guidance_layer.layers", parent=key_prefix):
+        keys += __map_distilled_guidance_layer_layers(k)
+
+    return keys
+
+
+def convert_chroma_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te"))
+
+    return keys

--- a/modules/util/convert/lora/convert_clip.py
+++ b/modules/util/convert/lora/convert_clip.py
@@ -1,0 +1,17 @@
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_clip(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("text_projection", "text_projection", parent=key_prefix)]
+
+    for k in map_prefix_range("text_model.encoder.layers", "text_model.encoder.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.fc1", "mlp.fc1", parent=k)]
+        keys += [LoraConversionKeySet("mlp.fc2", "mlp.fc2", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.out_proj", "self_attn.out_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys

--- a/modules/util/convert/lora/convert_flux_lora.py
+++ b/modules/util/convert/lora/convert_flux_lora.py
@@ -1,0 +1,75 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from modules.util.convert.lora.convert_t5 import map_t5
+
+
+def __map_double_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("img_attn.qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn.qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn.qkv.2", "attn.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn.qkv.0", "attn.add_q_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn.qkv.1", "attn.add_k_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn.qkv.2", "attn.add_v_proj", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("img_attn.proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.2", "ff.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mod.lin", "norm1.linear", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn.proj", "attn.to_add_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.0", "ff_context.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.2", "ff_context.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mod.lin", "norm1_context.linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_single_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("linear1.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.2", "attn.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.3", "proj_mlp", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("linear2", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("modulation.lin", "norm.linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("txt_in", "context_embedder", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "norm_out.linear", parent=key_prefix, swap_chunks=True)]
+    keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.in_layer", "time_text_embed.guidance_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.out_layer", "time_text_embed.guidance_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("vector_in.in_layer", "time_text_embed.text_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("vector_in.out_layer", "time_text_embed.text_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.in_layer", "time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.out_layer", "time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_in.proj", "x_embedder", parent=key_prefix)]
+
+    for k in map_prefix_range("double_blocks", "transformer_blocks", parent=key_prefix):
+        keys += __map_double_transformer_block(k)
+
+    for k in map_prefix_range("single_blocks", "single_transformer_blocks", parent=key_prefix):
+        keys += __map_single_transformer_block(k)
+
+    return keys
+
+
+def convert_flux_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te2"))
+
+    return keys

--- a/modules/util/convert/lora/convert_hidream_lora.py
+++ b/modules/util/convert/lora/convert_hidream_lora.py
@@ -1,0 +1,109 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_llama import map_causal_llama
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from modules.util.convert.lora.convert_t5 import map_t5
+
+
+def __map_caption_projection_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("linear", "linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_double_stream_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("block.adaLN_modulation.1", "block.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k", "block.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k_t", "block.attn1.to_k_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out", "block.attn1.to_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out_t", "block.attn1.to_out_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q", "block.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q_t", "block.attn1.to_q_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v", "block.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v_t", "block.attn1.to_v_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w1", "block.ff_i.experts.0.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w2", "block.ff_i.experts.0.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w3", "block.ff_i.experts.0.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w1", "block.ff_i.experts.1.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w2", "block.ff_i.experts.1.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w3", "block.ff_i.experts.1.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w1", "block.ff_i.experts.2.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w2", "block.ff_i.experts.2.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w3", "block.ff_i.experts.2.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w1", "block.ff_i.experts.3.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w2", "block.ff_i.experts.3.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w3", "block.ff_i.experts.3.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w1", "block.ff_i.shared_experts.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w2", "block.ff_i.shared_experts.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w3", "block.ff_i.shared_experts.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w1", "block.ff_t.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w2", "block.ff_t.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w3", "block.ff_t.w3", parent=key_prefix)]
+
+    return keys
+
+
+def __map_single_stream_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("block.adaLN_modulation.1", "block.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k", "block.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out", "block.attn1.to_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q", "block.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v", "block.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w1", "block.ff_i.experts.0.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w2", "block.ff_i.experts.0.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w3", "block.ff_i.experts.0.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w1", "block.ff_i.experts.1.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w2", "block.ff_i.experts.1.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w3", "block.ff_i.experts.1.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w1", "block.ff_i.experts.2.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w2", "block.ff_i.experts.2.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w3", "block.ff_i.experts.2.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w1", "block.ff_i.experts.3.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w2", "block.ff_i.experts.3.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w3", "block.ff_i.experts.3.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w1", "block.ff_i.shared_experts.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w2", "block.ff_i.shared_experts.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w3", "block.ff_i.shared_experts.w3", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "final_layer.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.linear", "final_layer.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("p_embedder.pooled_embedder.linear_1", "p_embedder.pooled_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("p_embedder.pooled_embedder.linear_2", "p_embedder.pooled_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.timestep_embedder.linear_1", "t_embedder.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.timestep_embedder.linear_2", "t_embedder.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_embedder.proj", "x_embedder.proj", parent=key_prefix)]
+
+    for k in map_prefix_range("caption_projection", "caption_projection", parent=key_prefix):
+        keys += __map_caption_projection_block(k)
+
+    for k in map_prefix_range("double_stream_blocks", "double_stream_blocks", parent=key_prefix):
+        keys += __map_double_stream_block(k)
+
+    for k in map_prefix_range("single_stream_blocks", "single_stream_blocks", parent=key_prefix):
+        keys += __map_single_stream_block(k)
+
+    return keys
+
+
+def convert_hidream_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te3"))
+    keys += map_causal_llama(LoraConversionKeySet("llama", "lora_te4"))
+
+    return keys

--- a/modules/util/convert/lora/convert_hunyuan_video_lora.py
+++ b/modules/util/convert/lora/convert_hunyuan_video_lora.py
@@ -1,0 +1,99 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_llama import map_llama
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def __map_token_refiner_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("self_attn_qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_qkv.2", "attn.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("self_attn_proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("mlp.fc0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("mlp.fc2", "ff.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("adaLN_modulation.1", "norm_out.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("norm1", "norm1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("norm2", "norm2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_double_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("img_attn_qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_qkv.2", "attn.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn_qkv.0", "attn.add_q_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_qkv.1", "attn.add_k_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_qkv.2", "attn.add_v_proj", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("img_attn_proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.fc0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.fc2", "ff.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mod.linear", "norm1.linear", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("txt_attn_proj", "attn.to_add_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.fc0", "ff_context.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.fc2", "ff_context.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mod.linear", "norm1_context.linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_single_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("linear1.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.2", "attn.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("linear1.3", "proj_mlp", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("linear2", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("modulation.linear", "norm.linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("txt_in.c_embedder.linear_1", "context_embedder.time_text_embed.text_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.c_embedder.linear_2", "context_embedder.time_text_embed.text_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.t_embedder.linear_1", "context_embedder.time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.t_embedder.linear_2", "context_embedder.time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.input_embedder", "context_embedder.proj_in", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "norm_out.linear", parent=key_prefix, swap_chunks=True)]
+    keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.mlp.0", "time_text_embed.guidance_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.mlp.2", "time_text_embed.guidance_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("vector_in.in_layer", "time_text_embed.text_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("vector_in.out_layer", "time_text_embed.text_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.mlp.0", "time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.mlp.2", "time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_in.proj", "x_embedder.proj", parent=key_prefix)]
+
+    for k in map_prefix_range("txt_in.individual_token_refiner.blocks", "context_embedder.token_refiner.refiner_blocks", parent=key_prefix):
+        keys += __map_token_refiner_block(k)
+
+    for k in map_prefix_range("double_blocks", "transformer_blocks", parent=key_prefix):
+        keys += __map_double_transformer_block(k)
+
+    for k in map_prefix_range("single_blocks", "single_transformer_blocks", parent=key_prefix):
+        keys += __map_single_transformer_block(k)
+
+    return keys
+
+
+def convert_hunyuan_video_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_llama(LoraConversionKeySet("llama", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te2"))
+
+    return keys

--- a/modules/util/convert/lora/convert_llama.py
+++ b/modules/util/convert/lora/convert_llama.py
@@ -1,0 +1,32 @@
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_llama(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    for k in map_prefix_range("language_model.model.layers", "language_model.model.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.down_proj", "mlp.down_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.gate_proj", "mlp.gate_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.up_proj", "mlp.up_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.o_proj", "self_attn.o_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys
+
+
+def map_causal_llama(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("lm_head", "lm_head", parent=key_prefix)]
+    for k in map_prefix_range("model.layers", "model.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.down_proj", "mlp.down_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.gate_proj", "mlp.gate_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.up_proj", "mlp.up_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.o_proj", "self_attn.o_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys

--- a/modules/util/convert/lora/convert_lora_util.py
+++ b/modules/util/convert/lora/convert_lora_util.py
@@ -1,0 +1,211 @@
+import torch
+from torch import Tensor
+
+from typing_extensions import Self
+
+
+class LoraConversionKeySet:
+    def __init__(
+            self,
+            omi_prefix: str,
+            diffusers_prefix: str,
+            legacy_diffusers_prefix: str | None = None,
+            parent: Self | None = None,
+            swap_chunks: bool = False,
+            filter_is_last: bool | None = None,
+            next_omi_prefix: str | None = None,
+            next_diffusers_prefix: str | None = None,
+    ):
+        if parent is not None:
+            self.omi_prefix = combine(parent.omi_prefix, omi_prefix)
+            self.diffusers_prefix = combine(parent.diffusers_prefix, diffusers_prefix)
+        else:
+            self.omi_prefix = omi_prefix
+            self.diffusers_prefix = diffusers_prefix
+
+        if legacy_diffusers_prefix is None:
+            self.legacy_diffusers_prefix = self.diffusers_prefix.replace('.', '_')
+        elif parent is not None:
+            self.legacy_diffusers_prefix = combine(parent.legacy_diffusers_prefix, legacy_diffusers_prefix).replace('.', '_')
+        else:
+            self.legacy_diffusers_prefix = legacy_diffusers_prefix
+
+        self.parent = parent
+        self.swap_chunks = swap_chunks
+        self.filter_is_last = filter_is_last
+        self.prefix = parent
+
+        if next_omi_prefix is None and parent is not None:
+            self.next_omi_prefix = parent.next_omi_prefix
+            self.next_diffusers_prefix = parent.next_diffusers_prefix
+            self.next_legacy_diffusers_prefix = parent.next_legacy_diffusers_prefix
+        elif next_omi_prefix is not None and parent is not None:
+            self.next_omi_prefix = combine(parent.omi_prefix, next_omi_prefix)
+            self.next_diffusers_prefix = combine(parent.diffusers_prefix, next_diffusers_prefix)
+            self.next_legacy_diffusers_prefix = combine(parent.legacy_diffusers_prefix, next_diffusers_prefix).replace('.', '_')
+        elif next_omi_prefix is not None and parent is None:
+            self.next_omi_prefix = next_omi_prefix
+            self.next_diffusers_prefix = next_diffusers_prefix
+            self.next_legacy_diffusers_prefix = next_diffusers_prefix.replace('.', '_')
+        else:
+            self.next_omi_prefix = None
+            self.next_diffusers_prefix = None
+            self.next_legacy_diffusers_prefix = None
+
+    def __get_omi(self, in_prefix: str, key: str) -> str:
+        return self.omi_prefix + key.removeprefix(in_prefix)
+
+    def __get_diffusers(self, in_prefix: str, key: str) -> str:
+        return self.diffusers_prefix + key.removeprefix(in_prefix)
+
+    def __get_legacy_diffusers(self, in_prefix: str, key: str) -> str:
+        key = self.legacy_diffusers_prefix + key.removeprefix(in_prefix)
+
+        suffix = key[key.rfind('.'):]
+        if suffix not in ['.alpha', '.dora_scale']:  # some keys only have a single . in the suffix
+            suffix = key[key.removesuffix(suffix).rfind('.'):]
+        key = key.removesuffix(suffix)
+
+        return key.replace('.', '_') + suffix
+
+    def get_key(self, in_prefix: str, key: str, target: str) -> str:
+        if target == 'omi':
+            return self.__get_omi(in_prefix, key)
+        elif target == 'diffusers':
+            return self.__get_diffusers(in_prefix, key)
+        elif target == 'legacy_diffusers':
+            return self.__get_legacy_diffusers(in_prefix, key)
+        return key
+
+    def __str__(self) -> str:
+        return f"omi: {self.omi_prefix}, diffusers: {self.diffusers_prefix}, legacy: {self.legacy_diffusers_prefix}"
+
+
+def combine(left: str, right: str) -> str:
+    left = left.rstrip('.')
+    right = right.lstrip('.')
+    if left == "" or left is None:
+        return right
+    elif right == "" or right is None:
+        return left
+    else:
+        return left + "." + right
+
+
+def map_prefix_range(
+        omi_prefix: str,
+        diffusers_prefix: str,
+        parent: LoraConversionKeySet,
+) -> list[LoraConversionKeySet]:
+    # 100 should be a safe upper bound. increase if it's not enough in the future
+    return [LoraConversionKeySet(
+        omi_prefix=f"{omi_prefix}.{i}",
+        diffusers_prefix=f"{diffusers_prefix}.{i}",
+        parent=parent,
+        next_omi_prefix=f"{omi_prefix}.{i + 1}",
+        next_diffusers_prefix=f"{diffusers_prefix}.{i + 1}",
+    ) for i in range(100)]
+
+
+def __convert(
+        state_dict: dict[str, Tensor],
+        key_sets: list[LoraConversionKeySet],
+        source: str,
+        target: str,
+) -> dict[str, Tensor]:
+    out_states = {}
+
+    if source == target:
+        return dict(state_dict)
+
+    # TODO: maybe replace with a non O(n^2) algorithm
+    for key, tensor in state_dict.items():
+        for key_set in key_sets:
+            in_prefix = ''
+
+            if source == 'omi':
+                in_prefix = key_set.omi_prefix
+            elif source == 'diffusers':
+                in_prefix = key_set.diffusers_prefix
+            elif source == 'legacy_diffusers':
+                in_prefix = key_set.legacy_diffusers_prefix
+
+            if not key.startswith(in_prefix):
+                continue
+
+            if key_set.filter_is_last is not None:
+                next_prefix = None
+                if source == 'omi':
+                    next_prefix = key_set.next_omi_prefix
+                elif source == 'diffusers':
+                    next_prefix = key_set.next_diffusers_prefix
+                elif source == 'legacy_diffusers':
+                    next_prefix = key_set.next_legacy_diffusers_prefix
+
+                is_last = not any(k.startswith(next_prefix) for k in state_dict)
+                if key_set.filter_is_last != is_last:
+                    continue
+
+            name = key_set.get_key(in_prefix, key, target)
+
+            can_swap_chunks = target == 'omi' or source == 'omi'
+            if key_set.swap_chunks and name.endswith('.lora_up.weight') and can_swap_chunks:
+                chunk_0, chunk_1 = tensor.chunk(2, dim=0)
+                tensor = torch.cat([chunk_1, chunk_0], dim=0)
+
+            out_states[name] = tensor
+
+            break  # only map the first matching key set
+
+    return out_states
+
+
+def __detect_source(
+        state_dict: dict[str, Tensor],
+        key_sets: list[LoraConversionKeySet],
+) -> str:
+    omi_count = 0
+    diffusers_count = 0
+    legacy_diffusers_count = 0
+
+    for key in state_dict:
+        for key_set in key_sets:
+            if key.startswith(key_set.omi_prefix):
+                omi_count += 1
+            if key.startswith(key_set.diffusers_prefix):
+                diffusers_count += 1
+            if key.startswith(key_set.legacy_diffusers_prefix):
+                legacy_diffusers_count += 1
+
+    if omi_count > diffusers_count and omi_count > legacy_diffusers_count:
+        return 'omi'
+    if diffusers_count > omi_count and diffusers_count > legacy_diffusers_count:
+        return 'diffusers'
+    if legacy_diffusers_count > omi_count and legacy_diffusers_count > diffusers_count:
+        return 'legacy_diffusers'
+
+    return ''
+
+
+def convert_to_omi(
+        state_dict: dict[str, Tensor],
+        key_sets: list[LoraConversionKeySet],
+) -> dict[str, Tensor]:
+    source = __detect_source(state_dict, key_sets)
+    return __convert(state_dict, key_sets, source, 'omi')
+
+
+def convert_to_diffusers(
+        state_dict: dict[str, Tensor],
+        key_sets: list[LoraConversionKeySet],
+) -> dict[str, Tensor]:
+    source = __detect_source(state_dict, key_sets)
+    return __convert(state_dict, key_sets, source, 'diffusers')
+
+
+def convert_to_legacy_diffusers(
+        state_dict: dict[str, Tensor],
+        key_sets: list[LoraConversionKeySet],
+) -> dict[str, Tensor]:
+    source = __detect_source(state_dict, key_sets)
+    return __convert(state_dict, key_sets, source, 'legacy_diffusers')

--- a/modules/util/convert/lora/convert_pixart_lora.py
+++ b/modules/util/convert/lora/convert_pixart_lora.py
@@ -1,0 +1,58 @@
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from modules.util.convert.lora.convert_t5 import map_t5
+
+
+def __map_transformer_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("attn.qkv.0", "attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("attn.qkv.1", "attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("attn.qkv.2", "attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("attn.proj", "attn1.to_out.0", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("cross_attn.q_linear", "attn2.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("cross_attn.kv_linear.0", "attn2.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("cross_attn.kv_linear.1", "attn2.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("cross_attn.proj", "attn2.to_out.0", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("mlp.fc1", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("mlp.fc2", "ff.net.2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("ar_embedder.mlp.0", "adaln_single.emb.aspect_ratio_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("ar_embedder.mlp.2", "adaln_single.emb.aspect_ratio_embedder.linear_2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("csize_embedder.mlp.0", "adaln_single.emb.resolution_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("csize_embedder.mlp.2", "adaln_single.emb.resolution_embedder.linear_2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("y_embedder.y_proj.fc1", "caption_projection.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("y_embedder.y_proj.fc2", "caption_projection.linear_2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("x_embedder.proj", "pos_embed.proj", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("t_embedder.mlp.0", "adaln_single.emb.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.mlp.2", "adaln_single.emb.timestep_embedder.linear_2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("t_block.1", "adaln_single.linear", parent=key_prefix)]
+
+    for k in map_prefix_range("blocks", "transformer_blocks", parent=key_prefix):
+        keys += __map_transformer_attention_block(k)
+
+    keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
+
+    return keys
+
+
+def convert_pixart_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te"))
+
+    return keys

--- a/modules/util/convert/lora/convert_sd3_lora.py
+++ b/modules/util/convert/lora/convert_sd3_lora.py
@@ -1,0 +1,68 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from modules.util.convert.lora.convert_t5 import map_t5
+
+
+def __map_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("x_block.attn.qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_block.attn.qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_block.attn.qkv.2", "attn.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("context_block.attn.qkv.0", "attn.add_q_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("context_block.attn.qkv.1", "attn.add_k_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("context_block.attn.qkv.2", "attn.add_v_proj", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("x_block.attn.proj", "attn.to_out.0", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("context_block.attn.proj", "attn.to_add_out", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("x_block.adaLN_modulation.1", "norm1.linear", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("context_block.adaLN_modulation.1", "norm1_context.linear", parent=key_prefix, filter_is_last=False)]
+    keys += [LoraConversionKeySet("context_block.adaLN_modulation.1", "norm1_context.linear", parent=key_prefix, swap_chunks=True, filter_is_last=True)]
+
+    keys += [LoraConversionKeySet("x_block.mlp.fc1", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_block.mlp.fc2", "ff.net.2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("x_block.attn2.qkv.0", "attn2.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_block.attn2.qkv.1", "attn2.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_block.attn2.qkv.2", "attn2.to_v", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("x_block.attn2.proj", "attn2.to_out.0", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("context_block.mlp.fc1", "ff_context.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("context_block.mlp.fc2", "ff_context.net.2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("x_embedder.proj", "pos_embed.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("context_embedder", "context_embedder", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "norm_out.linear", parent=key_prefix, swap_chunks=True)]
+    keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.mlp.0", "time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.mlp.2", "time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("y_embedder.mlp.0", "time_text_embed.text_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("y_embedder.mlp.2", "time_text_embed.text_embedder.linear_2", parent=key_prefix)]
+
+    for k in map_prefix_range("joint_blocks", "transformer_blocks", parent=key_prefix):
+        keys += __map_transformer_block(k)
+
+    return keys
+
+
+def convert_sd3_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te3"))
+
+    return keys

--- a/modules/util/convert/lora/convert_sd_lora.py
+++ b/modules/util/convert/lora/convert_sd_lora.py
@@ -1,0 +1,131 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet
+
+
+def __map_unet_resnet_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("emb_layers.1", "time_emb_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("in_layers.2", "conv1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("out_layers.3", "conv2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("skip_connection", "conv_shortcut", parent=key_prefix)]
+
+    return keys
+
+
+def __map_unet_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("proj_in", "proj_in", parent=key_prefix)]
+    keys += [LoraConversionKeySet("proj_out", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_q", "transformer_blocks.0.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_k", "transformer_blocks.0.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_v", "transformer_blocks.0.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_out.0", "transformer_blocks.0.attn1.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_q", "transformer_blocks.0.attn2.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_k", "transformer_blocks.0.attn2.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_v", "transformer_blocks.0.attn2.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_out.0", "transformer_blocks.0.attn2.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.ff.net.0.proj", "transformer_blocks.0.ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.ff.net.2", "transformer_blocks.0.ff.net.2", parent=key_prefix)]
+
+    return keys
+
+
+def __map_unet_down_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("1.1", "0.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("2.1", "0.attentions.1", parent=key_prefix))
+    keys += [LoraConversionKeySet("3.0.op", "0.downsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix))
+    keys += [LoraConversionKeySet("6.0.op", "1.downsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix))
+    keys += [LoraConversionKeySet("9.0.op", "2.downsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("10.0", "3.resnets.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("11.0", "3.resnets.1", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet_mid_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("0", "resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("1", "attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2", "resnets.1", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("0.0", "0.resnets.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.2", parent=key_prefix))
+    keys += [LoraConversionKeySet("2.1.conv", "0.upsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.2", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix))
+    keys += [LoraConversionKeySet("5.2.conv", "1.upsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("6.0", "2.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("6.1", "2.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.2", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.2", parent=key_prefix))
+    keys += [LoraConversionKeySet("8.2.conv", "2.upsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("9.0", "3.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("9.1", "3.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("10.0", "3.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("10.1", "3.attentions.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("11.0", "3.resnets.2", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("11.1", "3.attentions.2", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("input_blocks.0.0", "conv_in", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("time_embed.0", "time_embedding.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_embed.2", "time_embedding.linear_2", parent=key_prefix)]
+
+    keys += __map_unet_down_blocks(LoraConversionKeySet("input_blocks", "down_blocks", parent=key_prefix))
+    keys += __map_unet_mid_block(LoraConversionKeySet("middle_block", "mid_block", parent=key_prefix))
+    keys += __map_unet_up_block(LoraConversionKeySet("output_blocks", "up_blocks", parent=key_prefix))
+
+    keys += [LoraConversionKeySet("out.0", "conv_norm_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("out.2", "conv_out", parent=key_prefix)]
+
+    return keys
+
+
+def convert_sd_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_unet(LoraConversionKeySet( "unet", "lora_unet"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te"))
+
+    return keys

--- a/modules/util/convert/lora/convert_sdxl_lora.py
+++ b/modules/util/convert/lora/convert_sdxl_lora.py
@@ -1,0 +1,122 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def __map_unet_resnet_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("emb_layers.1", "time_emb_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("in_layers.2", "conv1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("out_layers.3", "conv2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("skip_connection", "conv_shortcut", parent=key_prefix)]
+
+    return keys
+
+
+def __map_unet_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("proj_in", "proj_in", parent=key_prefix)]
+    keys += [LoraConversionKeySet("proj_out", "proj_out", parent=key_prefix)]
+    for k in map_prefix_range("transformer_blocks", "transformer_blocks", parent=key_prefix):
+        keys += [LoraConversionKeySet("attn1.to_q", "attn1.to_q", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_k", "attn1.to_k", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_v", "attn1.to_v", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_out.0", "attn1.to_out.0", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_q", "attn2.to_q", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_k", "attn2.to_k", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_v", "attn2.to_v", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_out.0", "attn2.to_out.0", parent=k)]
+        keys += [LoraConversionKeySet("ff.net.0.proj", "ff.net.0.proj", parent=k)]
+        keys += [LoraConversionKeySet("ff.net.2", "ff.net.2", parent=k)]
+
+    return keys
+
+
+def __map_unet_down_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.1", parent=key_prefix))
+    keys += [LoraConversionKeySet("3.0.op", "0.downsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix))
+    keys += [LoraConversionKeySet("6.0.op", "1.downsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet_mid_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("0", "resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("1", "attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2", "resnets.1", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("0.0", "0.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("0.1", "0.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("1.1", "0.attentions.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.2", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("2.1", "0.attentions.2", parent=key_prefix))
+    keys += [LoraConversionKeySet("2.2.conv", "0.upsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.1", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.2", parent=key_prefix))
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix))
+    keys += [LoraConversionKeySet("5.2.conv", "1.upsamplers.0.conv", parent=key_prefix)]
+
+    keys += __map_unet_resnet_block(LoraConversionKeySet("6.0", "2.resnets.0", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.1", parent=key_prefix))
+    keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.2", parent=key_prefix))
+
+    return keys
+
+
+def __map_unet(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("input_blocks.0.0", "conv_in", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("time_embed.0", "time_embedding.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_embed.2", "time_embedding.linear_2", parent=key_prefix)]
+
+    keys += [LoraConversionKeySet("label_emb.0.0", "add_embedding.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("label_emb.0.2", "add_embedding.linear_2", parent=key_prefix)]
+
+    keys += __map_unet_down_blocks(LoraConversionKeySet("input_blocks", "down_blocks", parent=key_prefix))
+    keys += __map_unet_mid_block(LoraConversionKeySet("middle_block", "mid_block", parent=key_prefix))
+    keys += __map_unet_up_block(LoraConversionKeySet("output_blocks", "up_blocks", parent=key_prefix))
+
+    keys += [LoraConversionKeySet("out.0", "conv_norm_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("out.2", "conv_out", parent=key_prefix)]
+
+    return keys
+
+
+def convert_sdxl_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_unet(LoraConversionKeySet( "unet", "lora_unet"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
+
+    return keys

--- a/modules/util/convert/lora/convert_stable_cascade_lora.py
+++ b/modules/util/convert/lora/convert_stable_cascade_lora.py
@@ -1,0 +1,57 @@
+from modules.util.convert.lora.convert_clip import map_clip
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def __map_unet_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    for k in map_prefix_range("", "", parent=key_prefix):
+        keys += [LoraConversionKeySet("0.1", "0.attentions.0", parent=k)]
+
+        # resblock
+        keys += [LoraConversionKeySet("channelwise.0", "channelwise.0", parent=k)]
+        keys += [LoraConversionKeySet("channelwise.4", "channelwise.4", parent=k)]
+        keys += [LoraConversionKeySet("depthwise", "depthwise", parent=k)]
+
+        # timestep block
+        keys += [LoraConversionKeySet("mapper", "mapper", parent=k)]
+        keys += [LoraConversionKeySet("mapper_crp", "mapper_crp", parent=k)]
+        keys += [LoraConversionKeySet("mapper_sca", "mapper_sca", parent=k)]
+
+        # attention block
+        keys += [LoraConversionKeySet("kv_mapper.1", "kv_mapper.1", parent=k)]
+        keys += [LoraConversionKeySet("attention.attn.out_proj", "attention.to_out.0", legacy_diffusers_prefix="attention_attn_out_proj", parent=k)]
+        keys += [LoraConversionKeySet("attention.attn.in_proj.0", "attention.to_q", legacy_diffusers_prefix="attention_attn_to_q", parent=k)]
+        keys += [LoraConversionKeySet("attention.attn.in_proj.1", "attention.to_k", legacy_diffusers_prefix="attention_attn_to_k", parent=k)]
+        keys += [LoraConversionKeySet("attention.attn.in_proj.2", "attention.to_v", legacy_diffusers_prefix="attention_attn_to_v", parent=k)]
+
+    return keys
+
+
+def __map_prior(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("clf.1", "clf.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("clip_img_mapper", "clip_img_mapper", parent=key_prefix)]
+    keys += [LoraConversionKeySet("clip_txt_mapper", "clip_txt_mapper", parent=key_prefix)]
+    keys += [LoraConversionKeySet("clip_txt_pooled_mapper", "clip_txt_pooled_mapper", parent=key_prefix)]
+    keys += [LoraConversionKeySet("down_downscalers.1.1.blocks.0", "down_downscalers.1.1.blocks.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("embedding.1", "embedding.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("up_upscalers.0.1.blocks.1", "up_upscalers.0.1.blocks.1", parent=key_prefix)]
+
+    keys += __map_unet_blocks(LoraConversionKeySet("down_blocks.0", "down_blocks.0", parent=key_prefix))
+    keys += __map_unet_blocks(LoraConversionKeySet("down_blocks.1", "down_blocks.1", parent=key_prefix))
+    keys += __map_unet_blocks(LoraConversionKeySet("up_blocks.0", "up_blocks.0", parent=key_prefix))
+    keys += __map_unet_blocks(LoraConversionKeySet("up_blocks.1", "up_blocks.1", parent=key_prefix))
+
+    return keys
+
+
+def convert_stable_cascade_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += __map_prior(LoraConversionKeySet( "unet", "lora_prior_unet"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_prior_te"))
+
+    return keys

--- a/modules/util/convert/lora/convert_t5.py
+++ b/modules/util/convert/lora/convert_t5.py
@@ -1,0 +1,16 @@
+from modules.util.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_t5(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    for k in map_prefix_range("encoder.block", "encoder.block", parent=key_prefix):
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.k", "layer.0.SelfAttention.k", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.o", "layer.0.SelfAttention.o", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.q", "layer.0.SelfAttention.q", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.v", "layer.0.SelfAttention.v", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wi_0", "layer.1.DenseReluDense.wi_0", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wi_1", "layer.1.DenseReluDense.wi_1", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wo", "layer.1.DenseReluDense.wo", parent=k)]
+
+    return keys

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -27,9 +27,6 @@ sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loadi
 omegaconf==2.3.0 # needed to load stable diffusion from single ckpt files
 invisible-watermark==0.2.0 # needed for the SDXL pipeline
 
-# model conversion
--e git+https://github.com/Open-Model-Initiative/OMI-Model-Standards.git@f14b1da#egg=omi_model_standards
-
 # other models
 pooch==1.8.2
 open-clip-torch==2.32.0


### PR DESCRIPTION
move this code https://github.com/Open-Model-Initiative/OMI-Model-Standards/tree/main/src/omi_model_standards/convert/lora back into the OneTrainer repo where it was before

even though OMI might live on (see recent announcement), we have to consider the attempt to standardize LoRA files as part of OMI as failed for now unfortunately

part of https://github.com/Nerogar/OneTrainer/issues/1203