### PR TITLE
BETA-Tuned Timestep Distribution

### DIFF
--- a/modules/util/enum/TimestepDistribution.py
+++ b/modules/util/enum/TimestepDistribution.py
@@ -8,6 +8,7 @@ class TimestepDistribution(Enum):
     HEAVY_TAIL = 'HEAVY_TAIL'
     COS_MAP = 'COS_MAP'
     INVERTED_PARABOLA = 'INVERTED_PARABOLA'
+    BETA = 'BETA'
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
This PR implements the timestep distribution proposed in the paper:
[Beta-Tuned Timestep Diffusion Model](https://www.ecva.net/papers/eccv_2024/papers_ECCV/papers/00328.pdf)

This method aims to align timestep sampling with the diffusion model's forward pass, resulting in faster convergence and improved training performance. The paper observes that the data distribution changes most significantly during the initial timesteps, rendering standard uniform sampling sub-optimal.

<img width="1396" height="639" alt="image" src="https://github.com/user-attachments/assets/1342bc2d-94cc-44e2-be86-f7b07cf8871e" />

### Usage
*   Select `BETA` timestep distribution.
*   Set `Noising bias` to `1` (corresponds to **Beta** in the paper; recommended: 1).
*   Set `Noising weight` to `< 1` (corresponds to **Alpha** in the paper; recommended: 0.8).

**Note:** This is compatible with existing loss weighting strategies (e.g., Min-SNR, Debiased, etc.).