### PR TITLE
Attention backend selection / flash attention on Windows

### DIFF
--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -81,6 +81,8 @@ class BaseChromaSetup(
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
 
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
+
     def _setup_embeddings(
             self,
             model: ChromaModel,

--- a/modules/modelSetup/BaseErnieSetup.py
+++ b/modules/modelSetup/BaseErnieSetup.py
@@ -74,6 +74,8 @@ class BaseErnieSetup(
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
 
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
+
     def predict(
             self,
             model: ErnieModel,

--- a/modules/modelSetup/BaseFlux2Setup.py
+++ b/modules/modelSetup/BaseFlux2Setup.py
@@ -79,6 +79,8 @@ class BaseFlux2Setup(
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
 
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=False)
+
     def predict(
             self,
             model: Flux2Model,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -85,6 +85,8 @@ class BaseFluxSetup(
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
 
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=False)
+
     def _setup_embeddings(
             self,
             model: FluxModel,

--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -107,6 +107,8 @@ class BaseHiDreamSetup(
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.transformer_train_dtype, config)
 
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
+
     def _setup_embeddings(
             self,
             model: HiDreamModel,

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -86,6 +86,8 @@ class BaseHunyuanVideoSetup(
         quantize_layers(model.transformer, self.train_device, model.transformer_train_dtype, config)
 
         model.vae.enable_tiling()
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
+
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -88,7 +88,6 @@ class BaseHunyuanVideoSetup(
         model.vae.enable_tiling()
         self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
 
-
     def _setup_embeddings(
             self,
             model: HunyuanVideoModel,

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from modules.model.BaseModel import BaseModel
 from modules.util.config.TrainConfig import TrainConfig, TrainEmbeddingConfig, TrainModelPartConfig
+from modules.util.enum.AttentionMechanism import AttentionMechanism
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.ModuleFilter import ModuleFilter
 from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
@@ -235,3 +236,15 @@ class BaseModelSetup(
             if unique_name in self.frozen_parameters:
                 for param in self.frozen_parameters[unique_name]:
                     param.requires_grad_(False)
+
+    @staticmethod
+    def _set_attention_backend(component, attn: AttentionMechanism, mask: bool=False, varlen: bool=False):
+        match attn:
+            case AttentionMechanism.SDP:
+                component.set_attention_backend("native")
+            case AttentionMechanism.FLASH:
+                if mask or varlen:
+                    print("Warning: FLASH attention might fail for this model, depending on other configuration (batch size > 1, etc.)")
+                component.set_attention_backend("flash")
+            case _:
+                raise NotImplementedError(f"attention mechanism {str(attn)} not implemented")

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -238,13 +238,15 @@ class BaseModelSetup(
                     param.requires_grad_(False)
 
     @staticmethod
-    def _set_attention_backend(component, attn: AttentionMechanism, mask: bool=False, varlen: bool=False):
+    def _set_attention_backend(component, attn: AttentionMechanism, mask: bool):
         match attn:
             case AttentionMechanism.SDP:
                 component.set_attention_backend("native")
             case AttentionMechanism.FLASH:
-                if mask or varlen:
+                if mask:
                     print("Warning: FLASH attention might fail for this model, depending on other configuration (batch size > 1, etc.)")
                 component.set_attention_backend("flash")
+            case AttentionMechanism.CUDNN:
+                component.set_attention_backend("_native_cudnn")
             case _:
                 raise NotImplementedError(f"attention mechanism {str(attn)} not implemented")

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -81,6 +81,7 @@ class BasePixArtAlphaSetup(
         quantize_layers(model.text_encoder, self.train_device, model.text_encoder_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -75,6 +75,7 @@ class BaseQwenSetup(
         quantize_layers(model.text_encoder, self.train_device, model.text_encoder_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
 
     def predict(
             self,

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -92,6 +92,7 @@ class BaseSanaSetup(
         quantize_layers(model.text_encoder, self.train_device, model.text_encoder_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -87,7 +87,7 @@ class BaseStableDiffusion3Setup(
         quantize_layers(model.text_encoder_3, self.train_device, model.text_encoder_3_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
-        self._set_attention_backend(model.transformer, config.attention_mechanism)
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=False)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -87,6 +87,7 @@ class BaseStableDiffusion3Setup(
         quantize_layers(model.text_encoder_3, self.train_device, model.text_encoder_3_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.transformer, config.attention_mechanism)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -74,6 +74,7 @@ class BaseStableDiffusionSetup(
         quantize_layers(model.text_encoder, self.train_device, model.train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.unet, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.unet, config.attention_mechanism)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -74,7 +74,7 @@ class BaseStableDiffusionSetup(
         quantize_layers(model.text_encoder, self.train_device, model.train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.unet, self.train_device, model.train_dtype, config)
-        self._set_attention_backend(model.unet, config.attention_mechanism)
+        self._set_attention_backend(model.unet, config.attention_mechanism, mask=False)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -83,6 +83,7 @@ class BaseStableDiffusionXLSetup(
         quantize_layers(model.text_encoder_2, self.train_device, model.train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.vae_train_dtype, config)
         quantize_layers(model.unet, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.unet, config.attention_mechanism)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -83,7 +83,7 @@ class BaseStableDiffusionXLSetup(
         quantize_layers(model.text_encoder_2, self.train_device, model.train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.vae_train_dtype, config)
         quantize_layers(model.unet, self.train_device, model.train_dtype, config)
-        self._set_attention_backend(model.unet, config.attention_mechanism)
+        self._set_attention_backend(model.unet, config.attention_mechanism, mask=False)
 
     def _setup_embeddings(
             self,

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -106,7 +106,6 @@ class BaseWuerstchenSetup(
         quantize_layers(model.effnet_encoder, self.train_device, model.effnet_encoder_train_dtype, config)
         quantize_layers(model.prior_text_encoder, self.train_device, model.train_dtype, config)
         quantize_layers(model.prior_prior, self.train_device, model.prior_train_dtype, config)
-
         self._set_attention_backend(model.prior_prior, config.attention_mechanism, mask=False)
 
     def _setup_embeddings(

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -107,6 +107,8 @@ class BaseWuerstchenSetup(
         quantize_layers(model.prior_text_encoder, self.train_device, model.train_dtype, config)
         quantize_layers(model.prior_prior, self.train_device, model.prior_train_dtype, config)
 
+        self._set_attention_backend(model.prior_prior, config.attention_mechanism, mask=False)
+
     def _setup_embeddings(
             self,
             model: WuerstchenModel,

--- a/modules/modelSetup/BaseZImageSetup.py
+++ b/modules/modelSetup/BaseZImageSetup.py
@@ -77,6 +77,7 @@ class BaseZImageSetup(
         quantize_layers(model.text_encoder, self.train_device, model.text_encoder_train_dtype, config)
         quantize_layers(model.vae, self.train_device, model.train_dtype, config)
         quantize_layers(model.transformer, self.train_device, model.train_dtype, config)
+        self._set_attention_backend(model.transformer, config.attention_mechanism, mask=True)
 
     def predict(
             self,

--- a/modules/ui/BaseTrainingTabView.py
+++ b/modules/ui/BaseTrainingTabView.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from modules.util.enum.AttentionMechanism import AttentionMechanism
 from modules.util.enum.DataType import DataType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
@@ -328,6 +329,13 @@ class BaseTrainingTabView(ABC):
                               supports_circular_padding: bool = False):
         frame = self.components.section_frame(master, row)
         row = 0
+
+        # attention mechanism
+        self.components.label(frame, row, 0, "Attention",
+                              tooltip="The attention mechanism used during training. Use `SDP` on linux. On windows, `FLASH` can be faster but you have to install it, and it does not support all models.")
+        self.components.options(frame, row, 1, [str(x) for x in list(AttentionMechanism)], ui_state,
+                                "attention_mechanism")
+        row += 1
 
         # ema
         self.components.label(frame, row, 0, "EMA",

--- a/modules/ui/BaseTrainingTabView.py
+++ b/modules/ui/BaseTrainingTabView.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 
-from modules.util.enum.AttentionMechanism import AttentionMechanism
 from modules.util.enum.DataType import DataType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
@@ -71,7 +70,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_frame(column_0, 1, ui_state)
         self.__create_embedding_frame(column_0, 2, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state, supports_circular_padding=True)
+        self.__create_base2_frame(column_1, 0, controller, ui_state, supports_circular_padding=True)
         self.__create_unet_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state, supports_generalized_offset_noise=True)
 
@@ -86,7 +85,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_n_frame(column_0, 3, ui_state, i=3, supports_include=True)
         self.__create_embedding_frame(column_0, 4, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -100,7 +99,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_n_frame(column_0, 2, ui_state, i=2)
         self.__create_embedding_frame(column_0, 3, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state, supports_circular_padding=True)
+        self.__create_base2_frame(column_1, 0, controller, ui_state, supports_circular_padding=True)
         self.__create_unet_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state, supports_generalized_offset_noise=True)
 
@@ -113,7 +112,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_frame(column_0, 1, ui_state)
         self.__create_embedding_frame(column_0, 2, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state, supports_circular_padding=True)
+        self.__create_base2_frame(column_1, 0, controller, ui_state, supports_circular_padding=True)
         self.__create_prior_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -126,7 +125,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_frame(column_0, 1, ui_state)
         self.__create_embedding_frame(column_0, 2, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -140,7 +139,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_n_frame(column_0, 2, ui_state, i=2, supports_include=True, supports_sequence_length=True)
         self.__create_embedding_frame(column_0, 4, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=True)
         self.__create_noise_frame(column_1, 2, ui_state, supports_dynamic_timestep_shifting=True)
 
@@ -152,7 +151,7 @@ class BaseTrainingTabView(ABC):
         self.__create_base_frame(column_0, 0, controller, ui_state)
         self.__create_text_encoder_frame(column_0, 1, ui_state, supports_clip_skip=False, supports_training=False, supports_sequence_length=True)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=True, supports_force_attention_mask=False)
         self.__create_noise_frame(column_1, 2, ui_state, supports_dynamic_timestep_shifting=True)
 
@@ -165,7 +164,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_frame(column_0, 1, ui_state)
         self.__create_embedding_frame(column_0, 4, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=False, supports_force_attention_mask=False)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -177,7 +176,7 @@ class BaseTrainingTabView(ABC):
         self.__create_base_frame(column_0, 0, controller, ui_state)
         self.__create_text_encoder_frame(column_0, 1, ui_state, supports_clip_skip=False)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=False, supports_force_attention_mask=False)
         self.__create_noise_frame(column_1, 2, ui_state, supports_dynamic_timestep_shifting=True)
 
@@ -189,7 +188,7 @@ class BaseTrainingTabView(ABC):
         self.__create_base_frame(column_0, 0, controller, ui_state)
         self.__create_text_encoder_frame(column_0, 1, ui_state, supports_clip_skip=False, supports_training=False)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=False, supports_force_attention_mask=False)
         self.__create_noise_frame(column_1, 2, ui_state, supports_dynamic_timestep_shifting=True)
 
@@ -201,7 +200,7 @@ class BaseTrainingTabView(ABC):
         self.__create_base_frame(column_0, 0, controller, ui_state)
         self.__create_text_encoder_frame(column_0, 1, ui_state, supports_clip_skip=False, supports_training=False)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=False, supports_force_attention_mask=False)
         self.__create_noise_frame(column_1, 2, ui_state, supports_dynamic_timestep_shifting=True)
 
@@ -214,7 +213,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_frame(column_0, 1, ui_state)
         self.__create_embedding_frame(column_0, 2, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state)
+        self.__create_base2_frame(column_1, 0, controller, ui_state)
         self.__create_transformer_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -228,7 +227,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_n_frame(column_0, 2, ui_state, i=2, supports_include=True)
         self.__create_embedding_frame(column_0, 4, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state, video_training_enabled=True)
+        self.__create_base2_frame(column_1, 0, controller, ui_state, video_training_enabled=True)
         self.__create_transformer_frame(column_1, 1, ui_state, supports_guidance_scale=True)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -244,7 +243,7 @@ class BaseTrainingTabView(ABC):
         self.__create_text_encoder_n_frame(column_0, 4, ui_state, i=4, supports_include=True, supports_layer_skip=False)
         self.__create_embedding_frame(column_0, 5, ui_state)
 
-        self.__create_base2_frame(column_1, 0, ui_state, video_training_enabled=True)
+        self.__create_base2_frame(column_1, 0, controller, ui_state, video_training_enabled=True)
         self.__create_transformer_frame(column_1, 1, ui_state)
         self.__create_noise_frame(column_1, 2, ui_state)
 
@@ -325,16 +324,16 @@ class BaseTrainingTabView(ABC):
                               tooltip="Clips the gradient norm. Leave empty to disable gradient clipping.")
         self.components.entry(frame, 10, 1, ui_state, "clip_grad_norm")
 
-    def __create_base2_frame(self, master, row, ui_state, video_training_enabled: bool = False,
+    def __create_base2_frame(self, master, row, controller, ui_state, video_training_enabled: bool = False,
                               supports_circular_padding: bool = False):
         frame = self.components.section_frame(master, row)
         row = 0
 
         # attention mechanism
         self.components.label(frame, row, 0, "Attention",
-                              tooltip="The attention mechanism used during training. Use `SDP` on linux. On windows, `FLASH` can be faster but you have to install it, and it does not support all models.")
-        self.components.options(frame, row, 1, [str(x) for x in list(AttentionMechanism)], ui_state,
-                                "attention_mechanism")
+                              tooltip="The attention mechanism used during training. Use `torch SDPA` on linux. On windows, `flash-attn` can be faster, but it has to be installed manually and does not support all models. `torch cuDNN` is an alternative backend some models require or benefit from.")
+        self.components.options_kv(frame, row, 1, controller.get_attention_mechanisms(), ui_state,
+                                   "attention_mechanism")
         row += 1
 
         # ema

--- a/modules/ui/TrainingTabController.py
+++ b/modules/ui/TrainingTabController.py
@@ -5,6 +5,7 @@ from modules.ui.SchedulerParamsWindowController import SchedulerParamsWindowCont
 from modules.ui.TimestepDistributionWindowController import TimestepDistributionWindowController
 from modules.util import create
 from modules.util.config.TrainConfig import TrainConfig
+from modules.util.enum.AttentionMechanism import AttentionMechanism
 from modules.util.optimizer_util import change_optimizer
 
 
@@ -15,6 +16,13 @@ class TrainingTabController:
     def restore_optimizer_config(self, ui_state):
         optimizer_config = change_optimizer(self.config)
         ui_state.get_var("optimizer").update(optimizer_config)
+
+    def get_attention_mechanisms(self) -> list[tuple[str, AttentionMechanism]]:
+        return [
+            ("torch SDPA", AttentionMechanism.SDP),
+            ("flash-attn", AttentionMechanism.FLASH),
+            ("torch cuDNN", AttentionMechanism.CUDNN),
+        ]
 
     def get_layer_presets(self) -> dict:
         cls = create.get_model_setup_class(self.config.model_type, self.config.training_method)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -9,6 +9,7 @@ from modules.util.config.CloudConfig import CloudConfig
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.SampleConfig import SampleConfig
 from modules.util.config.SecretsConfig import SecretsConfig
+from modules.util.enum.AttentionMechanism import AttentionMechanism
 from modules.util.enum.AudioFormat import AudioFormat
 from modules.util.enum.ConfigPart import ConfigPart
 from modules.util.enum.DataType import DataType
@@ -413,6 +414,7 @@ class TrainConfig(BaseConfig):
     only_cache: bool
     resolution: str
     frames: str
+    attention_mechanism: AttentionMechanism
     mse_strength: float
     mae_strength: float
     log_cosh_strength: float
@@ -1006,6 +1008,7 @@ class TrainConfig(BaseConfig):
         data.append(("only_cache", False, bool, False))
         data.append(("resolution", "512", str, False))
         data.append(("frames", "25", str, False))
+        data.append(("attention_mechanism", AttentionMechanism.SDP, AttentionMechanism, False))
         data.append(("mse_strength", 1.0, float, False))
         data.append(("mae_strength", 0.0, float, False))
         data.append(("log_cosh_strength", 0.0, float, False))

--- a/modules/util/enum/AttentionMechanism.py
+++ b/modules/util/enum/AttentionMechanism.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AttentionMechanism(Enum):
+    SDP = 'SDP'
+    FLASH = 'FLASH'
+
+    def __str__(self):
+        return self.value

--- a/modules/util/enum/AttentionMechanism.py
+++ b/modules/util/enum/AttentionMechanism.py
@@ -4,6 +4,7 @@ from enum import Enum
 class AttentionMechanism(Enum):
     SDP = 'SDP'
     FLASH = 'FLASH'
+    CUDNN = 'CUDNN'
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
brings back attention selection, that was removed in 482333fc90eaac856784252f0bef996c45ec500b when xformers wasn't used anymore

Can be used to select flash attention, which is faster on windows because torch SDP doesn't support flash internally on Windows

<img width="341" height="71" alt="grafik" src="https://github.com/user-attachments/assets/9477268a-3b3c-41dd-8b76-f4960fe37656" />

It can be selected, but it must be manually installed from here: https://github.com/zzlol63/flash-attention-prebuild-wheels/releases

thank you to @zzlol63 for the investigation: https://github.com/Nerogar/OneTrainer/issues/1090

Uses https://github.com/huggingface/diffusers/pull/12892 to raise an error if flash attention cannot be used because of attention masks.