### PR TITLE
Bump requests ver

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -56,5 +56,5 @@ fabric==3.2.2
 
 # debug
 psutil==7.0.0
-requests==2.32.3
+requests==2.32.5
 deepdiff==8.6.1 # output easy to read diff for troublshooting


### PR DESCRIPTION
Bump `requests` ver to `2.32.5` get rid of CVE alert from dependabot, tested and works fine.