### PR TITLE
Explictly specify fp32 precision to avoid defaulting to 'highest'

### DIFF
--- a/modules/util/compile_util.py
+++ b/modules/util/compile_util.py
@@ -59,3 +59,4 @@ def Mod_patched_eval(cls, p, q):
 def init_compile():
     torch._dynamo.config.cache_size_limit = 8192
     torch.utils._sympy.functions.Mod.eval = Mod_patched_eval
+    torch.set_float32_matmul_precision('medium')


### PR DESCRIPTION
We just need to decide on 'high' or 'medium'. Habishi reccomended medium. Highest is exceedingly slow.

https://docs.pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html