### PR TITLE
Immiscible Diffusion: More aligned noise-image assignment

### DIFF
--- a/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
@@ -98,7 +98,7 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
                     dtype=source_tensor.dtype
                 )
 
-                noise = immiscible_oversampling(self, source_tensor, noise_candidates)
+                noise = immiscible_oversampling(source_tensor, noise_candidates)
         else:
             # Standard Gaussian Noise
             noise = torch.randn(

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -657,7 +657,7 @@ class TrainingTab:
 
         # Immiscible Diffusion
         components.label(frame, row, 0, "Noise Oversampling",
-                         tooltip="Instead of simply assigning a random piece of noise to a data point (the standard way diffusion models work), this parameter allows the model to 'pick' the noise that is mathematically closest to the input data. value 1 is the default. Immiscible Diffusion (Value >1) This applies oversampling noise assignment for each image in the batch size. The goal of Immiscible Diffusion is to reduce the 'mixing' or 'entanglement' of paths during the diffusion process. By pairing an image with noise that is already somewhat similar to it, leading to improved and accelerated training. Start with 64, 128, 256...")
+                         tooltip="Implements Immiscible Diffusion. Generates 'k' noise candidates for each image and selects the one mathematically closest to the original. This 'straightens' the diffusion path, leading to faster convergence and cleaner images. Recommended: 64 (higher is better but slower). Set to 1 to disable.")
         components.entry(frame, row, 1, self.ui_state, "k_noise_sampling")
         row += 1
 

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -646,12 +646,20 @@ class TrainingTab:
                          tooltip="Shift the timestep distribution. Use the preview to see more details.")
         components.entry(frame, 8, 1, self.ui_state, "timestep_shift")
 
+        row = 9
+
         if supports_dynamic_timestep_shifting:
             # dynamic timestep shifting
-            components.label(frame, 9, 0, "Dynamic Timestep Shifting",
+            components.label(frame, row, 0, "Dynamic Timestep Shifting",
                              tooltip="Dynamically shift the timestep distribution based on resolution.")
-            components.switch(frame, 9, 1, self.ui_state, "dynamic_timestep_shifting")
+            components.switch(frame, row, 1, self.ui_state, "dynamic_timestep_shifting")
+            row += 1
 
+        # Immiscible Diffusion
+        components.label(frame, row, 0, "Noise Oversampling",
+                         tooltip="Instead of simply assigning a random piece of noise to a data point (the standard way diffusion models work), this parameter allows the model to 'pick' the noise that is mathematically closest to the input data. value 1 is the default. Immiscible Diffusion (Value >1) This applies oversampling noise assignment for each image in the batch size. The goal of Immiscible Diffusion is to reduce the 'mixing' or 'entanglement' of paths during the diffusion process. By pairing an image with noise that is already somewhat similar to it, leading to improved and accelerated training. Start with 64, 128, 256...")
+        components.entry(frame, row, 1, self.ui_state, "k_noise_sampling")
+        row += 1
 
 
     def __create_masked_frame(self, master, row):

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -1027,7 +1027,7 @@ class TrainConfig(BaseConfig):
         data.append(("noising_bias", 0.0, float, False))
         data.append(("timestep_shift", 1.0, float, False))
         data.append(("dynamic_timestep_shifting", False, bool, False))
-        data.append(("k_noise_sampling", 1.0, int, False))
+        data.append(("k_noise_sampling", 1, int, False))
 
 
         # unet

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -444,6 +444,7 @@ class TrainConfig(BaseConfig):
     timestep_distribution: TimestepDistribution
     min_noising_strength: float
     max_noising_strength: float
+    k_noise_sampling: int
 
     noising_weight: float
     noising_bias: float
@@ -1026,6 +1027,7 @@ class TrainConfig(BaseConfig):
         data.append(("noising_bias", 0.0, float, False))
         data.append(("timestep_shift", 1.0, float, False))
         data.append(("dynamic_timestep_shifting", False, bool, False))
+        data.append(("k_noise_sampling", 1.0, int, False))
 
 
         # unet

--- a/modules/util/immiscible_diffusion.py
+++ b/modules/util/immiscible_diffusion.py
@@ -1,5 +1,6 @@
 import torch
 
+
 def immiscible_oversampling(self, source_tensor, noise_candidates):
     """
     Implements the noise oversampling method proposed in the paper:
@@ -9,7 +10,7 @@ def immiscible_oversampling(self, source_tensor, noise_candidates):
     https://github.com/yhli123/Immiscible-Diffusion/blob/65feadc66c7653b2644d06246fe8a424a5d76794/KNN-stable_diffusion/conditional_ft_train_sd.py#L940
     """
     # Using float16 for distance calculation to save memory/compute as per reference implementation
-    latents_points = source_tensor.flatten(start_dim=1).to(torch.float16) 
+    latents_points = source_tensor.flatten(start_dim=1).to(torch.float16)
     noise_points = noise_candidates.flatten(start_dim=2).to(torch.float16)
 
     # Calculate L2 distance between latents and the corresponding k noises

--- a/modules/util/immiscible_diffusion.py
+++ b/modules/util/immiscible_diffusion.py
@@ -1,0 +1,30 @@
+import torch
+
+def immiscible_oversampling(self, source_tensor, noise_candidates):
+    """
+    Implements the noise oversampling method proposed in the paper:
+    "Improved Immiscible Diffusion: Accelerate Diffusion Training by Reducing Its Miscibility"
+    (https://arxiv.org/abs/2505.18521)
+    Modified from:
+    https://github.com/yhli123/Immiscible-Diffusion/blob/65feadc66c7653b2644d06246fe8a424a5d76794/KNN-stable_diffusion/conditional_ft_train_sd.py#L940
+    """
+    # Using float16 for distance calculation to save memory/compute as per reference implementation
+    latents_points = source_tensor.flatten(start_dim=1).to(torch.float16) 
+    noise_points = noise_candidates.flatten(start_dim=2).to(torch.float16)
+
+    # Calculate L2 distance between latents and the corresponding k noises
+    distance_points = latents_points.unsqueeze(1) - noise_points
+
+    # Euclidean norm
+    distance = torch.linalg.vector_norm(distance_points, dim=2) # [B, k]
+
+    # Pick the nearest noise index for each data point
+    _, min_index = torch.min(distance, dim=1)
+
+    expand_shape = [-1, 1] + [source_tensor.shape[i] for i in range(1, source_tensor.ndim)]
+    gather_index = min_index.view(-1, *([1] * (source_tensor.ndim))).expand(*expand_shape)
+    selected_noise = torch.gather(noise_candidates, 1, gather_index)
+
+    # Squeeze the 'k' dimension (which is now size 1) to return to [B, C, H, W]
+    noise = selected_noise.squeeze(1)
+    return noise

--- a/modules/util/immiscible_diffusion.py
+++ b/modules/util/immiscible_diffusion.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def immiscible_oversampling(self, source_tensor, noise_candidates):
+def immiscible_oversampling(source_tensor, noise_candidates):
     """
     Implements the noise oversampling method proposed in the paper:
     "Improved Immiscible Diffusion: Accelerate Diffusion Training by Reducing Its Miscibility"
@@ -14,10 +14,7 @@ def immiscible_oversampling(self, source_tensor, noise_candidates):
     noise_points = noise_candidates.flatten(start_dim=2).to(torch.float16)
 
     # Calculate L2 distance between latents and the corresponding k noises
-    distance_points = latents_points.unsqueeze(1) - noise_points
-
-    # Euclidean norm
-    distance = torch.linalg.vector_norm(distance_points, dim=2) # [B, k]
+    distance = torch.cdist(latents_points.unsqueeze(1), noise_points, p=2).squeeze(1)
 
     # Pick the nearest noise index for each data point
     _, min_index = torch.min(distance, dim=1)


### PR DESCRIPTION
This pull request implements the **Immiscible Diffusion** strategy, proposed by the paper:
["Improved Immiscible Diffusion: Accelerate Diffusion Training by Reducing Its Miscibility"](https://arxiv.org/abs/2505.18521)

This method optimizes the pairing between training data and noise, effectively "straightening" the diffusion trajectories. By ensuring each image is paired with noise that is mathematically close to it, the model learns a more direct mapping, leading to faster convergence and better sample quality.

<img width="1393" height="606" alt="Image" src="https://github.com/user-attachments/assets/e486cc2f-7608-451f-b6f2-50cb9dce4032" />


The new "Immiscible Noise" setting (`Noise Oversampling`) is available under the noise configuration settings.
* Set `Noise Oversampling` setting to 64, 128, 254, etc. (Higher values improve performance but may increase latency at larger batch sizes).

## The Key Difference: Random vs. Optimized Noise Pairing

### Standard Diffusion (Random Pairing):

* `effective_noise = random_gaussian_noise()`
* Each data point in a batch is assigned a random piece of noise. Because the noise is chosen arbitrarily, the "path" from the clean image to the noisy state is often tangled and complex.

### Immiscible Diffusion (Optimal/Nearest Pairing):

* `effective_noise = select_best_noise(source_tensor, candidates)`
* Instead of random assignment, this method ensures that the noise  is "assigned" to an image  such that the distance between them is minimized.

<img width="1267" height="883" alt="Image" src="https://github.com/user-attachments/assets/3856321e-0d35-4aa0-a1c9-a41d4fb5ccab" />


#### Noise Oversampling Strategy

* The model generates `k` candidate noise tensors for every image in the batch.
* It calculates the Euclidean distance between the image and all `k` candidates.
* It selects the **nearest** candidate (the one with the minimum distance) and discards the rest.
* **Recommended value:** `64`.


This implementation significantly reduces the complexity of the ODE/SDE trajectories that the model must learn. By making the diffusion paths "immiscible" (non-crossing), the model can achieve higher quality results in fewer training steps and produce sharper images during inference.

## Implementation details

- Minimal changes in modules\modelSetup\mixin\ModelSetupNoiseMixin.py
- New file: modules\util\immiscible_diffusion.py with the paper logic.
- Universal support for all models, and it also works for flow-matching models. 

## Sources
v1 paper: [Immiscible Diffusion: Accelerating Diffusion Training with Noise Assignment](https://arxiv.org/abs/2406.12303)
v2 paper: [Improved Immiscible Diffusion: Accelerate Diffusion Training by Reducing Its Miscibility](https://www.arxiv.org/abs/2505.18521)
Official repo: https://github.com/yhli123/Immiscible-Diffusion