### PR TITLE
Fix leaking pyplot figure handle in ConceptsWindow

### DIFF
--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -516,9 +516,7 @@ class ConceptWindow(ctk.CTkToplevel):
 
         plt.set_loglevel('WARNING')     #suppress errors about data type in bar chart
 
-        # Store previous figure to release once we're no longer using it
-        prev_bucket_fig = self.bucket_fig
-
+        assert self.bucket_fig is None
         self.bucket_fig, self.bucket_ax = plt.subplots(figsize=(7,3))
         self.canvas = FigureCanvasTkAgg(self.bucket_fig, master=frame)
         self.canvas.get_tk_widget().grid(row=19, column=0, columnspan=4, rowspan=2)
@@ -535,11 +533,6 @@ class ConceptWindow(ctk.CTkToplevel):
         self.bucket_ax.tick_params(axis='y', colors=self.text_color, which="both")
         self.bucket_ax.xaxis.label.set_color(self.text_color)
         self.bucket_ax.yaxis.label.set_color(self.text_color)
-
-        # Close any previous figure handle (if we had one)
-        if prev_bucket_fig is not None:
-            plt.close(prev_bucket_fig)
-            prev_bucket_fig = None
 
         #refresh stats - must be after all labels are defined or will give error
         self.refresh_basic_stats_button = components.button(master=frame, row=0, column=0, text="Refresh Basic", command=lambda: self.__get_concept_stats_threaded(False, 9999),


### PR DESCRIPTION
The documentation does not say this very prominently, but under the documentation for `pyplot.close()` (https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.close.html), it states that this needs to happen if figures are not displayed using `pyplot.show()`, which we, nor the TK wrappers, appear to be doing.

This fixes a warning message about a potential leak that is printed to the console once you have opened quite a few figures.

Steps to reproduce:
1. Create a concept.
2. Repeat 20 times: Open the concept's window, open the statistics tab, and then close the concept window.
3. Look at the OneTrainer console output for a warning message related to this:
> RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.