### PR TITLE
fix vast.ai user issue

### DIFF
--- a/resources/docker/RunPod-NVIDIA-CLI.Dockerfile
+++ b/resources/docker/RunPod-NVIDIA-CLI.Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update --yes \
 	  gh \
 	  iputils-ping \
 	  nano \
+	  nethogs \
  && apt-get autoremove -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/resources/docker/Vast-NVIDIA-CLI.Dockerfile
+++ b/resources/docker/Vast-NVIDIA-CLI.Dockerfile
@@ -6,6 +6,7 @@
 FROM vastai/pytorch:cuda-12.8.1-auto
 
 WORKDIR /
+USER root
 RUN git clone https://github.com/Nerogar/OneTrainer
 RUN cd OneTrainer \
  && export OT_PLATFORM_REQUIREMENTS=requirements-cuda.txt \
@@ -21,10 +22,11 @@ RUN apt-get update --yes \
 	  gh \
 	  iputils-ping \
 	  nano \
+	  nethogs \
  && apt-get autoremove -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN pip install nvitop \
  && pip cache purge \
  && rm -rf ~/.cache/pip
-RUN ln -snf /OneTrainer /workspace/OneTrainer
+RUN mkdir /workspace && ln -snf /OneTrainer /workspace/OneTrainer


### PR DESCRIPTION
fix an issue with the vast image, that caused `git` to refuse an update
before, `/workspace` was owned by `user`, but `/OneTrainer` was owned by `root`. Now, everything is owned by `root`.

