### PR TITLE
Z-Image presets for non-Turbo

### DIFF
--- a/training_presets/#z-image DeTurbo LoRA 16GB.json
+++ b/training_presets/#z-image DeTurbo LoRA 16GB.json
@@ -1,0 +1,33 @@
+{
+    "base_model_name": "Tongyi-MAI/Z-Image-Turbo",
+    "batch_size": 2,
+    "learning_rate": 0.0003,
+    "model_type": "Z_IMAGE",
+    "resolution": "512",
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "INT_W8A8",
+        "model_name": "https://huggingface.co/ostris/Z-Image-De-Turbo/blob/main/z_image_de_turbo_v1_bf16.safetensors"
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "LORA",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "weight_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "layer_filter": "^(?=.*attention)(?!.*refiner).*,^(?=.*feed_forward)(?!.*refiner).*",
+    "layer_filter_preset": "attn-mlp",
+    "layer_filter_regex": true,
+    "quantization": {
+        "layer_filter": "layers",
+        "layer_filter_preset": "blocks"
+    },
+    "dataloader_threads": 1,
+    "timestep_distribution": "LOGIT_NORMAL"
+}

--- a/training_presets/#z-image DeTurbo LoRA 8GB.json
+++ b/training_presets/#z-image DeTurbo LoRA 8GB.json
@@ -1,0 +1,35 @@
+{
+    "base_model_name": "Tongyi-MAI/Z-Image-Turbo",
+    "batch_size": 2,
+    "learning_rate": 0.0003,
+    "model_type": "Z_IMAGE",
+    "resolution": "512",
+    "gradient_checkpointing": "CPU_OFFLOADED",
+    "layer_offload_fraction": 0.6,
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "INT_W8A8",
+        "model_name": "https://huggingface.co/ostris/Z-Image-De-Turbo/blob/main/z_image_de_turbo_v1_bf16.safetensors"
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "LORA",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "weight_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "layer_filter": "^(?=.*attention)(?!.*refiner).*,^(?=.*feed_forward)(?!.*refiner).*",
+    "layer_filter_preset": "attn-mlp",
+    "layer_filter_regex": true,
+    "quantization": {
+        "layer_filter": "layers",
+        "layer_filter_preset": "blocks"
+    },
+    "dataloader_threads": 1,
+    "timestep_distribution": "LOGIT_NORMAL"
+}

--- a/training_presets/#z-image Finetune 16GB.json
+++ b/training_presets/#z-image Finetune 16GB.json
@@ -1,0 +1,45 @@
+{
+    "base_model_name": "Tongyi-MAI/Z-Image",
+    "batch_size": 2,
+    "learning_rate": 1e-5,
+    "model_type": "Z_IMAGE",
+    "resolution": "512",
+    "gradient_checkpointing": "CPU_OFFLOADED",
+    "layer_offload_fraction": 0.1,
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "BFLOAT_16"
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "FINE_TUNE",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "dataloader_threads": 1,
+    "timestep_distribution": "LOGIT_NORMAL",
+    "optimizer": {
+        "optimizer": "ADAFACTOR"
+    },
+    "optimizer_defaults": {
+        "ADAFACTOR": {
+            "optimizer": "ADAFACTOR",
+            "fused_back_pass": true,
+            "beta1": null,
+            "clip_threshold": 1.0,
+            "decay_rate": -0.8,
+            "eps": 1e-30,
+            "eps2": 0.001,
+            "relative_step": false,
+            "scale_parameter": false,
+            "stochastic_rounding": true,
+            "warmup_init": false,
+            "weight_decay": 0.0
+        }
+    }
+}

--- a/training_presets/#z-image Finetune 24GB.json
+++ b/training_presets/#z-image Finetune 24GB.json
@@ -1,0 +1,43 @@
+{
+    "base_model_name": "Tongyi-MAI/Z-Image",
+    "batch_size": 2,
+    "learning_rate": 1e-5,
+    "model_type": "Z_IMAGE",
+    "resolution": "512",
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "BFLOAT_16"
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "FINE_TUNE",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "dataloader_threads": 1,
+    "timestep_distribution": "LOGIT_NORMAL",
+    "optimizer": {
+        "optimizer": "ADAFACTOR"
+    },
+    "optimizer_defaults": {
+        "ADAFACTOR": {
+            "optimizer": "ADAFACTOR",
+            "fused_back_pass": true,
+            "beta1": null,
+            "clip_threshold": 1.0,
+            "decay_rate": -0.8,
+            "eps": 1e-30,
+            "eps2": 0.001,
+            "relative_step": false,
+            "scale_parameter": false,
+            "stochastic_rounding": true,
+            "warmup_init": false,
+            "weight_decay": 0.0
+        }
+    }
+}

--- a/training_presets/#z-image LoRA 16GB.json
+++ b/training_presets/#z-image LoRA 16GB.json
@@ -1,5 +1,5 @@
 {
-    "base_model_name": "Tongyi-MAI/Z-Image-Turbo",
+    "base_model_name": "Tongyi-MAI/Z-Image",
     "batch_size": 2,
     "learning_rate": 0.0003,
     "model_type": "Z_IMAGE",
@@ -7,8 +7,7 @@
     "compile": true,
     "transformer": {
         "train": true,
-        "weight_dtype": "INT_W8A8",
-        "model_name": "https://huggingface.co/ostris/Z-Image-De-Turbo/blob/main/z_image_de_turbo_v1_bf16.safetensors"
+        "weight_dtype": "FLOAT_8"
     },
     "text_encoder": {
         "train": false,

--- a/training_presets/#z-image LoRA 8GB.json
+++ b/training_presets/#z-image LoRA 8GB.json
@@ -1,5 +1,5 @@
 {
-    "base_model_name": "Tongyi-MAI/Z-Image-Turbo",
+    "base_model_name": "Tongyi-MAI/Z-Image",
     "batch_size": 2,
     "learning_rate": 0.0003,
     "model_type": "Z_IMAGE",
@@ -9,8 +9,7 @@
     "compile": true,
     "transformer": {
         "train": true,
-        "weight_dtype": "INT_W8A8",
-        "model_name": "https://huggingface.co/ostris/Z-Image-De-Turbo/blob/main/z_image_de_turbo_v1_bf16.safetensors"
+        "weight_dtype": "FLOAT_8"
     },
     "text_encoder": {
         "train": false,


### PR DESCRIPTION
- using float8 (W8) because z-image is hard to quantize
- you might want to switch to `float W8A8` if you have an RTX 40xx, or to `int W8A8` with a high svd rank if you want to wait for SVD
