### PR TITLE
Skip caching and sampling on manual abort

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -633,6 +633,7 @@ class GenericTrainer(BaseTrainer):
         epochs = range(train_progress.epoch, self.config.epochs, 1)
 
         for _epoch in tqdm(epochs, desc="epoch") if multi.is_master() else epochs:
+            multi.sync_commands(self.commands)
             if self.commands.get_stop_command():
                 return
             self.callbacks.on_update_status("Starting epoch/caching")


### PR DESCRIPTION
I just added two conditions to skip the whole caching and sampling loops, when the training is manually being stopped before it even started. Only checked the general functionality.
Would be nice if you could check and tell me if this breaks something out of my scope.

Maybe also add a debug output for "Training manually stopped" or something in the console?

- [x] Basic functionality testing
- [ ] Multi-GPU testing