### PR TITLE
Flux2 Edit training

### DIFF
--- a/modules/model/Flux2Model.py
+++ b/modules/model/Flux2Model.py
@@ -239,8 +239,9 @@ class Flux2Model(BaseModel):
     @staticmethod
     def prepare_latent_image_ids(latents: torch.Tensor, index: int=0) -> torch.Tensor:
         batch_size, _, height, width = latents.shape
+        scale = 10
 
-        t = torch.arange(1, device=latents.device) + index
+        t = torch.arange(1, device=latents.device) + index * scale
         h = torch.arange(height, device=latents.device)
         w = torch.arange(width, device=latents.device)
         l_ = torch.arange(1, device=latents.device)

--- a/modules/model/Flux2Model.py
+++ b/modules/model/Flux2Model.py
@@ -237,10 +237,10 @@ class Flux2Model(BaseModel):
 
     #code adapted from https://github.com/huggingface/diffusers/blob/c8656ed73c638e51fc2e777a5fd355d69fa5220f/src/diffusers/pipelines/flux2/pipeline_flux2.py
     @staticmethod
-    def prepare_latent_image_ids(latents: torch.Tensor) -> torch.Tensor:
+    def prepare_latent_image_ids(latents: torch.Tensor, index: int=0) -> torch.Tensor:
         batch_size, _, height, width = latents.shape
 
-        t = torch.arange(1, device=latents.device)
+        t = torch.arange(1, device=latents.device) + index
         h = torch.arange(height, device=latents.device)
         w = torch.arange(width, device=latents.device)
         l_ = torch.arange(1, device=latents.device)

--- a/modules/modelSampler/BaseModelSampler.py
+++ b/modules/modelSampler/BaseModelSampler.py
@@ -74,8 +74,13 @@ class BaseModelSampler(metaclass=ABCMeta):
         pass
 
     @staticmethod
-    def quantize_resolution(resolution: int, quantization: int) -> int:
-        return round(resolution / quantization) * quantization
+    def quantize_resolution(resolution: int, quantization: int, mode: str='round') -> int:
+        if mode == 'round':
+            return round(resolution / quantization) * quantization
+        elif mode == 'floor':
+            return (resolution // quantization) * quantization
+        else:
+            raise RuntimeError
 
     @staticmethod
     def save_sampler_output(

--- a/modules/ui/SampleFrame.py
+++ b/modules/ui/SampleFrame.py
@@ -100,23 +100,23 @@ class SampleFrame(ctk.CTkFrame):
             components.label(bottom_frame, 4, 0, "steps:")
             components.entry(bottom_frame, 4, 1, self.ui_state, "diffusion_steps")
 
-            # inpainting
-            components.label(bottom_frame, 5, 0, "inpainting:",
-                             tooltip="Enables inpainting sampling. Only available when sampling from an inpainting model.")
-            components.switch(bottom_frame, 5, 1, self.ui_state, "sample_inpainting")
-
             # base image path
-            components.label(bottom_frame, 6, 0, "base image path:",
-                             tooltip="The base image used when inpainting.")
-            components.file_entry(bottom_frame, 6, 1, self.ui_state, "base_image_path",
+            components.label(bottom_frame, 5, 0, "base image path:",
+                             tooltip="The image used for inpainting and as reference image for edit models.")
+            components.file_entry(bottom_frame, 5, 1, self.ui_state, "base_image_path",
                                   allow_model_files=False,
                                   allow_image_files=True,
                                   )
 
             # mask image path
-            components.label(bottom_frame, 6, 2, "mask image path:",
+            components.label(bottom_frame, 5, 2, "mask image path:",
                              tooltip="The mask used when inpainting.")
-            components.file_entry(bottom_frame, 6, 3, self.ui_state, "mask_image_path",
+            components.file_entry(bottom_frame, 5, 3, self.ui_state, "mask_image_path",
                                   allow_model_files=False,
                                   allow_image_files=True,
                                   )
+
+            # inpainting
+            components.label(bottom_frame, 6, 0, "inpainting:",
+                             tooltip="Enables inpainting sampling. Only available when sampling from an inpainting model.")
+            components.switch(bottom_frame, 6, 1, self.ui_state, "sample_inpainting")

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -710,8 +710,8 @@ class TrainingTab:
         components.entry(frame, 4, 1, self.ui_state, "masked_prior_preservation_weight")
 
         # use custom conditioning image
-        components.label(frame, 5, 0, "Custom Conditioning Image",
-                         tooltip="When custom conditioning image is enabled, will use png postfix with -condlabel instead of automatically generated.It's suitable for special scenarios, such as object removal, allowing the model to learn a certain behavior concept")
+        components.label(frame, 5, 0, "Edit Training /\nCustom Conditioning Image",
+                         tooltip="Uses a file with -condlabel postfix as reference image for edit models. For inpainting models, the file is used as custom conditioning image instead of an automatically generated conditioning image.")
         components.switch(frame, 5, 1, self.ui_state, "custom_conditioning_image")
 
     def __create_loss_frame(self, master, row, supports_vb_loss: bool = False):

--- a/modules/util/enum/ModelType.py
+++ b/modules/util/enum/ModelType.py
@@ -117,7 +117,8 @@ class ModelType(Enum):
         return self == ModelType.STABLE_DIFFUSION_15_INPAINTING \
             or self == ModelType.STABLE_DIFFUSION_20_INPAINTING \
             or self == ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING \
-            or self == ModelType.FLUX_FILL_DEV_1
+            or self == ModelType.FLUX_FILL_DEV_1 \
+            or self == ModelType.FLUX_2
 
     def has_depth_input(self):
         return self == ModelType.STABLE_DIFFUSION_20_DEPTH


### PR DESCRIPTION
Install:
```
git branch -D pr-1301
git fetch upstream pull/1301/head:pr-1301
git switch pr-1301
```

<img width="249" height="54" alt="grafik" src="https://github.com/user-attachments/assets/5c6f5d2f-5c23-44fe-9e80-012685ee1600" />

this PR uses the existing dataloader infrastructure for inpainting models in OneTrainer. because of that, there are a few limitations:
- only 1 reference image
- reference image filename is hardcoded to `filename-condlabel.png` when your training sample is `filename.jpg`. Note the png.
- if enabled, there must be a reference image for all images
- the reference image should have the same resolution as the training sample
- edge case: don't use together with masked training when `Unmasked Probability` > 0
