### PR TITLE
Skip dot-directories in subdirectory scanning

### DIFF
--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -257,6 +257,8 @@ class ConceptWidget(ctk.CTkFrame):
         concept_path = ConceptWindow.get_concept_path(getattr(self.concept, 'path', None))
         if concept_path:
             for path in pathlib.Path(concept_path).glob(glob_pattern):
+                if any(part.startswith('.') for part in path.relative_to(concept_path).parts):
+                    continue
                 extension = os.path.splitext(path)[1]
                 if (path.is_file()
                         and path_util.is_supported_image_extension(extension)

--- a/modules/ui/ConceptTab.py
+++ b/modules/ui/ConceptTab.py
@@ -257,7 +257,7 @@ class ConceptWidget(ctk.CTkFrame):
         concept_path = ConceptWindow.get_concept_path(getattr(self.concept, 'path', None))
         if concept_path:
             for path in pathlib.Path(concept_path).glob(glob_pattern):
-                if any(part.startswith('.') for part in path.relative_to(concept_path).parts):
+                if any(part.startswith('.') for part in path.relative_to(concept_path).parent.parts):
                     continue
                 extension = os.path.splitext(path)[1]
                 if (path.is_file()

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -610,7 +610,7 @@ class ConceptWindow(ctk.CTkToplevel):
         concept_path = self.get_concept_path(self.concept.path)
         if concept_path:
             for path in pathlib.Path(concept_path).glob(glob_pattern):
-                if any(part.startswith('.') for part in path.relative_to(concept_path).parts):
+                if any(part.startswith('.') for part in path.relative_to(concept_path).parent.parts):
                     continue
                 extension = os.path.splitext(path)[1]
                 if path.is_file() and path_util.is_supported_image_extension(extension) \

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -610,6 +610,8 @@ class ConceptWindow(ctk.CTkToplevel):
         concept_path = self.get_concept_path(self.concept.path)
         if concept_path:
             for path in pathlib.Path(concept_path).glob(glob_pattern):
+                if any(part.startswith('.') for part in path.relative_to(concept_path).parts):
+                    continue
                 extension = os.path.splitext(path)[1]
                 if path.is_file() and path_util.is_supported_image_extension(extension) \
                         and not path.name.endswith("-masklabel.png") and not path.name.endswith("-condlabel.png"):
@@ -883,7 +885,7 @@ class ConceptWindow(ctk.CTkToplevel):
                 break
             stats_dict = concept_stats.folder_scan(path, stats_dict, advanced_checks, self.concept, start_time, wait_time, self.cancel_scan_flag)
             if self.concept.include_subdirectories and not self.cancel_scan_flag.is_set():     #add all subfolders of current directory to for loop
-                subfolders.extend([f for f in os.scandir(path) if f.is_dir()])
+                subfolders.extend([f for f in os.scandir(path) if f.is_dir() and not f.name.startswith('.')])
             self.concept.concept_stats = stats_dict
             #update GUI approx every half second
             if time.perf_counter() > (last_update + 0.5):

--- a/modules/util/concept_stats.py
+++ b/modules/util/concept_stats.py
@@ -285,7 +285,7 @@ def subfolder_scan(conceptconfig : ConceptConfig, advanced_checks : bool, wait_t
 
     for dir in subfolders:
         stats_dict = folder_scan(dir, stats_dict, advanced_checks, start_time, wait_time, cancel_scan_flag)
-        subfolders.extend([f for f in os.scandir(dir) if f.is_dir()])
+        subfolders.extend([f for f in os.scandir(dir) if f.is_dir() and not f.name.startswith('.')])
 
     return stats_dict
 
@@ -302,7 +302,7 @@ def subfolder_scan_threaded(conceptconfig : ConceptConfig, advanced_checks : boo
         stats_futures = []
         for dir in subfolders:
             stats_futures += [executor.submit(folder_scan, dir, init_concept_stats(advanced_checks), advanced_checks, start_time, wait_time, cancel_scan_flag)]
-            subfolders.extend([f.path for f in os.scandir(dir) if f.is_dir()])
+            subfolders.extend([f.path for f in os.scandir(dir) if f.is_dir() and not os.path.basename(f.path).startswith('.')])
         stats_results = [f.result() for f in stats_futures]
 
     final_stats = combine_stats_dicts(stats_results, conceptconfig, advanced_checks)

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -32,7 +32,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@a0c84a3#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@e4bfa65#egg=mgds
 
 # optimizers
 dadaptation==3.2 # dadaptation optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -32,7 +32,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@e4bfa65#egg=mgds
+-e git+https://github.com/Nerogar/mgds.git@@5bbafa5#egg=mgds
 
 # optimizers
 dadaptation==3.2 # dadaptation optimizers


### PR DESCRIPTION
## Summary
- Excludes directories starting with `.` (e.g. `.trash`, `.ignore`, `.git`) from recursive subdirectory scanning across all "Include Subdirectories" code paths
- Fixes image preview, concept stats, and concept list scanning in the UI
- Updates `mgds` dependency to include the same fix in `CollectPaths` for the training data loader (see https://github.com/Nerogar/mgds/pull/45)

## Files changed
- `modules/ui/ConceptWindow.py` - preview image glob + stats scan
- `modules/ui/ConceptTab.py` - concept list preview glob
- `modules/util/concept_stats.py` - legacy scan functions
- `requirements-global.txt` - points mgds at fork with CollectPaths fix

**Note:** Once https://github.com/Nerogar/mgds/pull/45 is merged, `requirements-global.txt` should be updated to point back at `Nerogar/mgds`.

Doesn't conflict with #1296.