### PR TITLE
Check for active gradients before offloading a layer

### DIFF
--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -873,7 +873,8 @@ class LayerOffloadConductor:
                         #In Multi-GPU training, when the gradient reduction has been started during the fused back pass, but
                         #has not finished yet. The gradients are then set to None during the backward of one of the next layers.
                         #Record which layers were ready to be offloaded, and offload them later:
-                        if not self.__config.multi_gpu or not self.__config.optimizer.fused_back_pass:
+                        if (not self.__config.multi_gpu or not self.__config.optimizer.fused_back_pass
+                            or not self.__config.fused_gradient_reduce or not self.__config.async_gradient_reduce):
                             raise RuntimeError("Gradients are still active while attempting to offload a layer")
 
                         #TODO deferring layer offloading appears to work for multi-GPU training, but there might be edge cases because offloading depends on the exact same order of layer execution. It's possible that when communication between GPU lags, more layers are deferred and this fails silently.


### PR DESCRIPTION
Before offloading a layer, check that there are no gradients that still exist
Currently, it detects this bug https://github.com/Nerogar/OneTrainer/issues/1241 but it's a good check to have anyway, because it silently corrupts memory if this goes undetected.
