### PR TITLE
Fix and Enhance LoRA-Muon Setup: Orthogonalize B, Adam A

### DIFF
--- a/modules/util/optimizer/muon_util.py
+++ b/modules/util/optimizer/muon_util.py
@@ -76,7 +76,13 @@ def build_muon_adam_key_fn(
                 for param_name, p in lora_module.named_parameters():
                     if p.requires_grad:
                         full_param_name = f"{full_prefix}.{param_name}"
-                        param_map[id(p)] = get_optim_type(full_param_name, p)
+                        # B (Up) -> Muon, A (Down) -> Adam
+                        if "lora_up.weight" in param_name and p.ndim > 1:
+                            param_map[id(p)] = 'muon'
+                        elif "lora_down.weight" in param_name:
+                            param_map[id(p)] = 'adam'
+                        else:
+                            param_map[id(p)] = get_optim_type(full_param_name, p)
                         all_processed_params.append(p)
         elif isinstance(module, torch.nn.Module) and any(p.requires_grad for p in module.parameters()):
             for param_name, p in module.named_parameters():


### PR DESCRIPTION
Muon wasn't originally designed for LoRAs, and as a result, the existing documentations and implementations are quite lacking.

In my initial implementation of Muon (within OT), I applied Muon to all LoRA layers based on hidden layer mapping. However, this is sub-optimal. Muon should only be applied to the **B matrix**. Because the **A matrix** typically has an extreme aspect ratio, Muon’s orthogonalization process tends to produce noise (garbage outputs) rather than meaningful updates.

This PR addresses this by:

* Applying **Muon** exclusively to the **B matrix**.
* Assigning **AuxAdam** to the **A matrix**.

This setup makes LoRA significantly more robust; theoretically, we can achieve DoRA-like effects on standard LoRA using this configuration.

### Technical Context

I identified this issue while testing https://github.com/Nerogar/OneTrainer/pull/1263#issuecomment-3830755795. After applying the scaling to both the A and B matrices, I observed that spectral normalization severely cripples the orthogonalization of the A matrix when using Muon.

This approach is supported by recent research (see: [arXiv:2508.17901](https://arxiv.org/pdf/2508.17901)), which proposes orthogonalizing the B matrix to achieve superior results. The paper notes that if the B matrix contains redundant (correlated) columns, the "effective rank" of the update falls below the actual rank. Orthogonalization resolves this by ensuring the update remains full-rank and efficient.

### Potential Benefits

* **Enhanced Robustness:** Prevents the "garbage" noise generation caused by applying orthogonalization to the extreme aspect ratios of the A matrix.
* **Improved Effective Rank:** By orthogonalizing the B matrix, we eliminate column correlation, ensuring the update maintains its full actual rank .
* **DoRA-like Performance:** Theoretically allows standard LoRA to achieve effects similar (or superior) to Weight-Decomposed Low-Rank Adaptation (DoRA) without the extra overhead.
* **Optimization Efficiency:** Uses the strengths of Muon where it excels (B matrix) and relies on AuxAdam where Muon struggles (A matrix).

**❕ Tests, comparisons, and feedback are always welcome.**