### PR TITLE
adv_optm Bump: Improve Simplified AdEMAMix stability and ease-of-use via LR scaling

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -42,7 +42,7 @@ prodigyopt==1.1.2 # prodigy optimizer
 schedulefree==1.4.1 # schedule-free optimizers
 pytorch_optimizer==3.6.0 # pytorch optimizers
 prodigy-plus-schedule-free==2.0.1 # Prodigy plus optimizer
-adv_optm==2.2.2 # advanced optimizers
+adv_optm==2.2.3 # advanced optimizers
 -e git+https://github.com/KellerJordan/Muon.git@f90a42b#egg=muon-optimizer
 
 # Profiling


### PR DESCRIPTION
Simplified AdEMAMix is a powerful momentum theory that has proven superior in all of my test cases, as well as in reports from users who have tested it.

One of its primary downsides, however, is that it requires a completely different range for learning rate and weight decay.
To address this, we can apply a simple scalar scaling that brings it into the same LR range as AdamW without altering the training dynamics (in fact, this change actually improves stability and performance).

This version update enhances the Simplified AdEMAMix optimizer/options by allowing it to use standard AdamW LR/WD values.

This will only affect:
1. Simplified AdEMAMix optimzier
2. Prodigy_adv with `Simplified AdEMAMix` option
3. Adopt_adv with `Simplified AdEMAMix` option

Beyond aligning with AdamW LR/WD, this allows for seamless testing of different `beta1` and `alpha grad`. Users can now adjust these parameters (or toggle `Simplified AdEMAMix` on/off) without needing to retune the LR.