### PR TITLE
Change Flux2 presets LR

### DIFF
--- a/training_presets/#flux2 LoRA 16GB.json
+++ b/training_presets/#flux2 LoRA 16GB.json
@@ -1,7 +1,7 @@
 {
     "base_model_name": "black-forest-labs/FLUX.2-klein-base-9B",
     "batch_size": 2,
-    "learning_rate": 0.0003,
+    "learning_rate": 3e-5,
     "model_type": "FLUX_2",
     "resolution": "512",
     "compile": true,

--- a/training_presets/#flux2 LoRA 8GB.json
+++ b/training_presets/#flux2 LoRA 8GB.json
@@ -1,7 +1,7 @@
 {
     "base_model_name": "black-forest-labs/FLUX.2-klein-base-9B",
     "batch_size": 2,
-    "learning_rate": 0.0003,
+    "learning_rate": 3e-5,
     "model_type": "FLUX_2",
     "resolution": "512",
     "compile": true,


### PR DESCRIPTION
presets aren't meant to have perfectly tuned LRs, but the Flux2 LoRA preset seems to be off by an order of magnitude.

this PR changes the preset from 3e-4 to 3e-5
opinions?