### PR TITLE
torch upgrade support

### DIFF
--- a/modules/util/triton_mm_8bit.py
+++ b/modules/util/triton_mm_8bit.py
@@ -47,7 +47,7 @@ import triton.language as tl
 )
 
 @triton.jit
-def __mm_kernel(
+def _mm_kernel(
         a_ptr, b_ptr, c_ptr,
         M, N, K,
         stride_am, stride_ak,
@@ -109,7 +109,7 @@ def mm_8bit(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
     def grid(META):
         return (triton.cdiv(N, META['BLOCK_SIZE_N']) , triton.cdiv(M, META['BLOCK_SIZE_M']), )
-    __mm_kernel[grid](
+    _mm_kernel[grid](
         a, b, c,
         M, N, K,
         a.stride(0), a.stride(1),


### PR DESCRIPTION
this PR works around https://github.com/pytorch/pytorch/issues/170398
this workaround is required for upgrading to torch 2.9 or higher
it is a part of https://github.com/Nerogar/OneTrainer/pull/1266 which cannot be merged yet because of another regression in torch 2.10
but it avoids an error if people choose to upgrade themselves