### PR TITLE
Fix raised None exception in MUON_ADV

### DIFF
--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -248,7 +248,7 @@ class TrainOptimizerConfig(BaseConfig):
         data.append(("muon_adam_lr", None, float, True))
         data.append(("muon_te1_adam_lr", None, float, True))
         data.append(("muon_te2_adam_lr", None, float, True))
-        data.append(("muon_adam_config", None, dict, True))
+        data.append(("muon_adam_config", {}, dict, True))
         data.append(("rms_rescaling", True, bool, True))
         data.append(("normuon_variant", False, bool, False))
         data.append(("beta2_normuon", None, float, True))

--- a/modules/util/create.py
+++ b/modules/util/create.py
@@ -847,7 +847,7 @@ def create_optimizer(
             # Prepare Adam-specific keyword arguments from the config
             adam_kwargs = {}
             if MuonWithAuxAdam:
-                adam_config = optimizer_config.muon_adam_config if optimizer_config.muon_adam_config is not None else {}
+                adam_config = optimizer_config.muon_adam_config
                 adam_config_dict = adam_config if isinstance(adam_config, dict) else adam_config.to_dict()
 
                 valid_adam_keys = {k for k in inspect.signature(Muon_adv.__init__).parameters if k.startswith('adam_')}
@@ -899,7 +899,7 @@ def create_optimizer(
             # Prepare Adam-specific keyword arguments from the config
             adam_kwargs = {}
             if MuonWithAuxAdam:
-                adam_config = optimizer_config.muon_adam_config if optimizer_config.muon_adam_config is not None else {}
+                adam_config = optimizer_config.muon_adam_config
                 # Handle both dict (from JSON/Config) and Object (legacy/runtime)
                 adam_config_dict = adam_config if isinstance(adam_config, dict) else adam_config.to_dict()
 
@@ -963,9 +963,7 @@ def create_optimizer(
                     }
                 else:  # is adam
                     adam_config = optimizer_config.muon_adam_config
-                    if adam_config is None:
-                        adam_config = {}
-                    elif not isinstance(adam_config, dict):
+                    if not isinstance(adam_config, dict):
                         adam_config = adam_config.to_dict()
 
                     beta1 = adam_config.get('beta1')

--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -160,7 +160,7 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "muon_adam_lr": 3e-4,
         "muon_te1_adam_lr": None,
         "muon_te2_adam_lr": None,
-        "muon_adam_config": None,
+        "muon_adam_config": {},
     },
     Optimizer.AdEMAMix_8BIT: {
         "beta1": 0.9,
@@ -614,7 +614,7 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "normuon_eps": 1e-8,
         "orthogonal_gradient": False,
         "approx_mars": False,
-        "muon_adam_config": None,
+        "muon_adam_config": {},
     },
     Optimizer.ADAMUON_ADV: {
         "beta1": 0.95,
@@ -644,7 +644,7 @@ OPTIMIZER_DEFAULT_PARAMETERS = {
         "normuon_variant": True,
         "orthogonal_gradient": False,
         "approx_mars": False,
-        "muon_adam_config": None,
+        "muon_adam_config": {},
     },
     Optimizer.ADABELIEF: {
         "beta1": 0.9,


### PR DESCRIPTION
Added a `None` type-check for the `optimizer_config.muon_adam_config` value in the `MUON_ADV` and `ADAMUON_ADV` optimizer create/setup code, which coerces the config to an empty dict if not present. This prevents the next line from trying to call `to_dict()` on `None`.