### PR TITLE
fix SDXL and pixart presets

### DIFF
--- a/training_presets/#pixart sigma 1.0 LoRA.json
+++ b/training_presets/#pixart sigma 1.0 LoRA.json
@@ -7,9 +7,6 @@
     "output_model_destination": "models/lora.safetensors",
     "output_model_format": "SAFETENSORS",
     "resolution": "1024",
-    "text_encoder": {
-        "train": false
-    },
     "training_method": "LORA",
     "lora_rank": 16,
 	"lora_alpha": 1.0,
@@ -17,6 +14,7 @@
         "weight_dtype": "BFLOAT_16"
     },
     "text_encoder": {
+        "train": false,
         "weight_dtype": "BFLOAT_16"
     },
     "vae": {

--- a/training_presets/#pixart sigma 1.0.json
+++ b/training_presets/#pixart sigma 1.0.json
@@ -7,14 +7,12 @@
     "output_model_destination": "models/model",
     "output_model_format": "SAFETENSORS",
     "resolution": "1024",
-    "text_encoder": {
-        "train": false
-    },
     "training_method": "FINE_TUNE",
     "transformer": {
         "weight_dtype": "BFLOAT_16"
     },
     "text_encoder": {
+        "train": false,
         "weight_dtype": "BFLOAT_16"
     },
     "vae": {

--- a/training_presets/#sdxl 1.0 LoRA.json
+++ b/training_presets/#sdxl 1.0 LoRA.json
@@ -8,20 +8,16 @@
     "output_model_destination": "models/lora.safetensors",
     "output_model_format": "SAFETENSORS",
     "resolution": "1024",
-    "text_encoder": {
-        "train": false
-    },
-    "text_encoder_2": {
-        "train": false
-    },
     "training_method": "LORA",
     "unet": {
         "weight_dtype": "FLOAT_16"
     },
     "text_encoder": {
+        "train": false,
         "weight_dtype": "FLOAT_16"
     },
     "text_encoder_2": {
+        "train": false,
         "weight_dtype": "FLOAT_16"
     },
     "vae": {

--- a/training_presets/#sdxl 1.0.json
+++ b/training_presets/#sdxl 1.0.json
@@ -4,12 +4,6 @@
     "output_model_destination": "models/model.safetensors",
     "output_model_format": "SAFETENSORS",
     "resolution": "1024",
-    "text_encoder": {
-        "train": false
-    },
-    "text_encoder_2": {
-        "train": false
-    },
     "training_method": "FINE_TUNE",
     "vae": {
         "weight_dtype": "FLOAT_32"
@@ -18,9 +12,11 @@
         "weight_dtype": "BFLOAT_16"
     },
     "text_encoder": {
+        "train": false,
         "weight_dtype": "BFLOAT_16"
     },
     "text_encoder_2": {
+        "train": false,
         "weight_dtype": "BFLOAT_16"
     }
 }


### PR DESCRIPTION
duplicate "text_encoder" sections are silently ignored by json loader