### PR TITLE
Default file picker directory/file to current value

### DIFF
--- a/modules/util/ui/components.py
+++ b/modules/util/ui/components.py
@@ -156,6 +156,7 @@ def path_entry(
         # Determine currently selected filename and/or directory
         current_dir, current_filename = None, None
         current_path_str = ui_state.get_var(var_name).get() or None
+
         if current_path_str is not None:
             current_path = Path(current_path_str)
             if mode == "file":


### PR DESCRIPTION
## Feature
Make the file-picker open to the currently selected value.

### Previous behavior
The previous behavior was to default to the last globally selected directory (if a directory has been selected by another file-picker), or the current working directory (if the file-picker hadn't been used yet.)

### New behavior
If the value of the associated CTK UIi variable is not empty, it is parsed and the values of the current directory, (and potentially the current selected file if in file selection mode, ) are extracted and passed to the file-picker dialog functions, 

## Testing
Tested by opening the file-picker in `open-directory` mode, `open-file` mode, and `save-file` mode with empty, valid, and non-existent paths.

### Testing results
If an input box has a valid directory already set, the file-picker successfully opens to that directory.

If an input box has a valid file already set, the file-picker successfully opens into that file's parent directory, with the file pre-selected.

If an input box is empty or an invalid value, the file-picker falls-back to the previous behavior of using the last globally picked directory as the initial/current directory.

If the value in `initialdir` does not exist, the file-picker falls-back to the previous behavior of using the last globally picked directory as the initial/current directory.

If the value in `initialfile` does not exist, but `initialdir` still does exist, the file-picker opens the `initialdir` directory without selecting any file.