### PR TITLE
Fix multi-threaded dataloader for Qwen3/Mistral text encoders

### DIFF
--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -9,6 +9,7 @@ from modules.modelSetup.BaseZImageSetup import BaseZImageSetup
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
+from modules.util.thread_safety import apply_thread_safe_forward
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.pipelineModules.DecodeTokens import DecodeTokens
@@ -36,7 +37,7 @@ class ZImageBaseDataLoader(
                                     apply_chat_template = lambda caption: format_input(caption), apply_chat_template_kwargs = {'add_generation_prompt': True, 'enable_thinking': True}
                                   )
         if config.dataloader_threads > 1:
-            raise NotImplementedError("Multiple data loader threads are not supported due to an issue with the transformers library: https://github.com/huggingface/transformers/issues/42673")
+            apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
         encode_prompt = EncodeQwenText(tokens_name='tokens', tokens_attention_mask_in_name='tokens_mask', hidden_state_out_name='text_encoder_hidden_state', tokens_attention_mask_out_name='tokens_mask',
                                        text_encoder=model.text_encoder, hidden_state_output_index=-2, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
 

--- a/modules/util/thread_safety.py
+++ b/modules/util/thread_safety.py
@@ -1,0 +1,43 @@
+import functools
+import threading
+
+import torch
+
+_THREAD_SAFE_FORWARD_ATTR = "_thread_safe_forward_lock"
+
+
+def apply_thread_safe_forward(model: torch.nn.Module) -> None:
+    """
+    Wrap ``model.forward()`` with a per-instance ``threading.Lock`` to
+    serialize concurrent calls.
+
+    This is a workaround for a thread-safety bug in the transformers library's
+    ``check_model_inputs`` decorator, which monkey-patches child module
+    ``.forward()`` methods during execution and is not safe for concurrent use
+    from multiple dataloader threads.
+
+    See: https://github.com/huggingface/transformers/issues/42673
+    Fix: https://github.com/huggingface/transformers/pull/43765 (v5 only)
+
+    This patch can be removed when upgrading to transformers v5+.
+
+    The lock is per-model-instance so different model instances do not block
+    each other. The function is idempotent: calling it twice on the same model
+    is a no-op.
+
+    Args:
+        model: The ``nn.Module`` whose ``forward()`` should be made thread-safe.
+    """
+    if hasattr(model, _THREAD_SAFE_FORWARD_ATTR):
+        return
+
+    lock = threading.Lock()
+    original_forward = model.forward
+
+    @functools.wraps(original_forward)
+    def locked_forward(*args, **kwargs):
+        with lock:
+            return original_forward(*args, **kwargs)
+
+    model.forward = locked_forward
+    setattr(model, _THREAD_SAFE_FORWARD_ATTR, lock)


### PR DESCRIPTION
## Description

Enables `dataloader_threads > 1` for Z-Image and Flux2.Klein models by working around a thread-safety bug in the transformers library's `check_model_inputs` decorator ([huggingface/transformers#42673](https://github.com/huggingface/transformers/issues/42673)).

Closes #1291

## Problem

The `check_model_inputs` decorator in transformers v4 monkey-patches child module `.forward()` methods on every call to capture `output_hidden_states`, then restores them after. When two dataloader threads call the same text encoder concurrently, they race on patching/restoring these methods, causing hidden states from different threads to bleed into each other.

## Fix

Wraps the text encoder's `.forward()` with a per-instance `threading.Lock` to serialize concurrent calls, preventing the race condition. The lock is applied conditionally only when `dataloader_threads > 1` and is idempotent (safe if called multiple times).

Performance impact is negligible since GPU computation is already serialized on a single device. The benefit of multiple dataloader threads (pipelining CPU image loading/preprocessing against GPU encoding) is preserved.

Also proactively applies the same fix to the Flux2.Dev (Mistral) path, which has the same underlying vulnerability via `MistralModel.forward()`.

The upstream fix ([huggingface/transformers#43765](https://github.com/huggingface/transformers/pull/43765)) shipped in transformers v5 only. This workaround can be removed when upgrading to v5+.

## Changes

- `modules/util/thread_safety.py`: New utility — `apply_thread_safe_forward()` wraps a model's forward with a per-instance lock
- `modules/dataLoader/ZImageBaseDataLoader.py`: Replace `NotImplementedError` with thread-safe forward patch
- `modules/dataLoader/Flux2BaseDataLoader.py`: Replace `NotImplementedError` (Klein) and add proactive fix (Dev)

## Testing Notes

Verified the bug and fix with a tiny Qwen3ForCausalLM (CPU, random weights, 280K params):
- **Without lock**: 4 threads x 100 iterations — hidden states corrupt immediately (expected 3 layers, got 6-9)
- **With lock**: 4 threads x 100 iterations — 400/400 calls correct, zero errors

Tested on Windows 11, Python 3.10.11.

Will run a full test on Z-Image either today or tomorrow.