### PR TITLE
Enable persistent cache for incremental dataset caching

### DIFF
--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -190,7 +190,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         def before_cache_fun():
             self._setup_cache_device(model, self.train_device, self.temp_device, config)
 
-        disk_cache = DiskCache(cache_dir=config.cache_dir, split_names=split_names, aggregate_names=aggregate_names, variations_in_name='concept.image_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
+        disk_cache = DiskCache(cache_dir=config.cache_dir, persistent_key_in_name='image_path', split_names=split_names, aggregate_names=aggregate_names, variations_in_name='concept.image_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
                                variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_fun)
         variation_sorting = VariationSorting(names=sort_names, balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'],
                                group_enabled_in_name='concept.enabled')

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -349,11 +349,11 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
         def before_cache_text_fun():
             model_setup.prepare_text_caching(model, config)
 
-        image_disk_cache = DiskCache(cache_dir=image_cache_dir, split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
+        image_disk_cache = DiskCache(cache_dir=image_cache_dir, persistent_key_in_name='image_path', split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
                                      balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'],
                                      group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun)
 
-        text_disk_cache = DiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
+        text_disk_cache = DiskCache(cache_dir=text_cache_dir, persistent_key_in_name='image_path', split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
                                     variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun)
 
         modules = []


### PR DESCRIPTION
Passes `persistent_key_in_name='image_path'` to all `DiskCache` constructors so that mgds can track which cache files belong to which images. Without this, changing even a single image in your dataset causes the entire cache to be rebuilt from scratch.

With this change, only new or modified files get re-cached.

Based on https://github.com/Nerogar/mgds/pull/44 by @maedtb.

**Files changed:**
- `modules/dataLoader/mixin/DataLoaderText2ImageMixin.py` - both image and text DiskCache calls
- `modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py` - VAE fine-tune DiskCache call