### PR TITLE
Fix sampling for multi-GPU

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -214,8 +214,8 @@ class GenericTrainer(BaseTrainer):
             folder_postfix: str = "",
             is_custom_sample: bool = False,
     ):
-        for i, sample_config in multi.distributed_enumerate(
-            [sample_config for sample_config in sample_config_list if sample_config.enabled],
+        for i, sample_config in multi.distributed(
+            [(i, sample_config) for i, sample_config in enumerate(sample_config_list) if sample_config.enabled],
             distribute=not self.config.samples_to_tensorboard and not ema_applied
         ):
             try:

--- a/modules/util/multi_gpu_util.py
+++ b/modules/util/multi_gpu_util.py
@@ -41,6 +41,15 @@ def master_first(enabled: bool = True):
     else:
         yield()
 
+def distributed(iterable, distribute: bool=True):
+    if distribute:
+        for i, x in enumerate(iterable):
+            if i % world_size() == rank():
+                yield x
+    elif is_master():
+        for x in iterable:
+            yield x
+
 def distributed_enumerate(iterable, distribute: bool=True):
     if distribute:
         for i, x in enumerate(iterable):


### PR DESCRIPTION
Bug: even disabled samples were given to a GPU, making that GPU idle
Now: only distribute samples that are enabled
The change is only in line 217 and 218. Everything else is a change in indent