### PR TITLE
Delta transfer learning between models (e.g. from Base to Turbo models)

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -607,6 +607,12 @@ class GenericTrainer(BaseTrainer):
             self.model.optimizer.eval()
 
     def train(self):
+
+
+        transfer_step1 = False
+        transfer_step2 = False
+        transfer_guidance = 3.0
+
         train_device = torch.device(self.config.train_device)
 
         train_progress = self.model.train_progress
@@ -739,7 +745,33 @@ class GenericTrainer(BaseTrainer):
                         model_output_data['target'][prior_pred_indices] = prior_model_prediction[prior_pred_indices]
                         model_output_data['prior_target'] = prior_model_prediction
                     else:
-                        model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
+                        transfer_filename = f"transfer-{train_progress.global_step}.pt"
+                        if transfer_step1:
+                            with torch.no_grad():
+                                with self.model_setup.prior_model(self.model, self.config):
+                                    model_output_data_without_lora = self.model_setup.predict(self.model, batch, self.config, train_progress)
+                                model_output_data_with_lora = self.model_setup.predict(self.model, batch, self.config, train_progress)
+
+                                torch.save((
+                                    model_output_data_without_lora['predicted'],
+                                    model_output_data_with_lora['predicted'],
+                                    batch['image_path'],
+                                    model_output_data_with_lora['timestep'],
+                                ), transfer_filename)
+
+                            train_progress.next_step(self.config.batch_size)
+                            self.callbacks.on_update_train_progress(train_progress, current_epoch_length, self.config.epochs)
+                            continue
+                        if transfer_step2:
+                            base_without_lora, base_with_lora, image_path, timestep = torch.load(transfer_filename, map_location=train_device)
+                            with self.model_setup.prior_model(self.model, self.config), torch.no_grad():
+                                model_output_data_prior = self.model_setup.predict(self.model, batch, self.config, train_progress)
+
+                            model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
+                            assert image_path == batch['image_path'] and model_output_data['timestep'] == timestep, "transfer step 1 data does not match"
+                            model_output_data['target'] = model_output_data_prior['predicted'] + transfer_guidance * (base_with_lora - base_without_lora)
+                        else:
+                            model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
 
                     loss = self.model_setup.calculate_loss(self.model, batch, model_output_data, self.config)
 


### PR DESCRIPTION
Experimental training method to teach a LoRA from one model (for example Flux2 Base, Z-Image non-Turbo, ...) into another model (Flux2 non-Base, Z-Image Turbo, ...). Using this method you can directly train Turbo models without affecting distillation.

It could also be used to teach the knowledge of an already existing LoRA into another LoRA, or between any two models as long they have the same latent space/VAE (untested though).

Usage for Base-to-Turbo training:

1. Train a LoRA on the Base model

2. Transfer step 1
 - keep the base model in `Base Model` on the `model` tab
 - set the trained LoRA as `LoRA base model` on the `LoRA` tab
 - set `transfer_step1` to `True`
 - start training
This step only creates training data. It does not output a model.

3. Transfer step 2
 - change `Base Model` on the `model tab` to the Turbo model
 - keep the trained LoRA as `LoRA base model` on the `LoRA` tab (removing it is also possible, but then you teach the Turbo model from scratch)
 - set `transfer_step1` to `False` and `transfer_step2` to `True`
 - start training

Validation loss is meaningless when teaching a Turbo model. Sample often! Transfer learning can go very quickly (for example 300 steps on a LoRA that took 2000 steps to train originally)
Flux2 non-Base seems to require a higher learning rate in the e-4 range than Flux2 Base  (e-5 range). Z-Image Turbo seems to learn well at the same learning rate as Z-Image non-Turbo (in the e-4 range)
Increase `transfer_guidance` to emphasize your concept, or lower it if the concept is overdone, looks like a carricature or looks like you've used too high CFG. `2.5` seems to work well for Flux2, `3.0` for Z-Image Turbo.

Do not change training data, timestep distribution, batch size, ... between transfer step 1 and transfer step 2. Other training parameters like learning rate, optimizer, ... can be changed without repeating step 1.
