### PR TITLE
Draft: Add LoRA weight scaling and CFG distillation functionality

### DIFF
--- a/modules/modelLoader/mixin/LoRALoaderMixin.py
+++ b/modules/modelLoader/mixin/LoRALoaderMixin.py
@@ -19,6 +19,48 @@ class LoRALoaderMixin(metaclass=ABCMeta):
     def _get_convert_key_sets(self, model: BaseModel) -> list[LoraConversionKeySet] | None:
         pass
 
+    @staticmethod
+    def scale_lora_state_dict(
+            state_dict: dict,
+            te_scale: float = 1.0,
+            unet_scale: float = 1.0,
+    ) -> dict:
+        """
+        Scales LoRA weights for Text Encoder and main component (UNet/Transformer) separately.
+        
+        Args:
+            state_dict: The LoRA state dict to scale
+            te_scale: Scale factor for Text Encoder LoRA weights (default 1.0, applies to lora_te*)
+            unet_scale: Scale factor for main component LoRA weights (default 1.0, applies to everything else)
+            
+        Returns:
+            The scaled state dict
+        """
+        scaled_dict = {}
+        
+        weight_suffixes = (
+            ".weight",
+            "hada_w1_a",
+            "hada_w1_b",
+            "hada_w2_a",
+            "hada_w2_b",
+            "lokr_w1",
+            "lokr_w2",
+            "lokr_t1",
+            "lokr_t2",
+        )
+
+        for key, value in state_dict.items():
+            is_weight = isinstance(value, torch.Tensor) and key.endswith(weight_suffixes)
+            if key.startswith("lora_te"):
+                # Text Encoder LoRA (matches lora_te, lora_te1, lora_te2, etc.)
+                scaled_dict[key] = value * te_scale if is_weight else value
+            else:
+                # Other components: unet, transformer, prior, decoder, etc.
+                scaled_dict[key] = value * unet_scale if is_weight else value
+        
+        return scaled_dict
+
     def __load_safetensors(
             self,
             model: BaseModel,

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -75,6 +75,7 @@ class BaseModelSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            generate_distillation_empty: bool = False,
     ) -> dict:
         pass
 

--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -2,11 +2,13 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 
 from modules.model.BaseModel import BaseModel
+from modules.module.ParentModelWrapper import ParentModelWrapper
 from modules.util.config.TrainConfig import TrainConfig, TrainEmbeddingConfig, TrainModelPartConfig
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.ModuleFilter import ModuleFilter
 from modules.util.NamedParameterGroup import NamedParameterGroup, NamedParameterGroupCollection
 from modules.util.TimedActionMixin import TimedActionMixin
+from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -177,6 +179,62 @@ class BaseModelSetup(
             for adapter in model.adapters():
                 adapter.hook_to_module()
 
+    @contextmanager
+    def distillation_parent_model(
+        self,
+        model: BaseModel,
+        config: TrainConfig,
+        parent_wrapper: ParentModelWrapper | None,
+    ):
+        """
+        Context manager for distillation with external parent model.
+        
+        If parent_wrapper is provided and distillation is enabled, loads the parent
+        model temporarily to train_device for inference. Otherwise falls back to
+        prior_model behavior (unhooking LoRA adapters).
+        
+        Args:
+            model: Student model being trained
+            config: Training configuration
+            parent_wrapper: Optional wrapper containing parent model
+            
+        Yields:
+            Parent model if available, otherwise the student model with adapters unhooked
+        """
+        if parent_wrapper is None or not config.distillation.enabled:
+            # Fallback to prior_model behavior
+            with self.prior_model(model, config):
+                yield model
+            return
+        
+        # Load parent model if not already loaded
+        if not parent_wrapper.is_loaded():
+            parent_wrapper.load_parent_model()
+        
+        # Memory optimization: Swap models if keeping parent on CPU
+        # Move student model to CPU before loading parent to GPU to reduce peak VRAM
+        student_was_moved = False
+        if config.distillation.keep_parent_on_cpu:
+            model.to(self.temp_device)
+            student_was_moved = True
+            torch_gc()
+        
+        # Move parent to train_device temporarily
+        parent_wrapper.to_device(self.train_device)
+        
+        try:
+            yield parent_wrapper.parent_model
+        finally:
+            # Move parent back to temp_device (CPU)
+            if config.distillation.keep_parent_on_cpu:
+                parent_wrapper.to_device(self.temp_device)
+                torch_gc()
+                
+                # Move student model back to train_device
+                if student_was_moved:
+                    model.to(self.train_device)
+                    torch_gc()
+
     def _create_model_part_parameters(
         self,
         parameter_group_collection: NamedParameterGroupCollection,
@@ -186,7 +244,7 @@ class BaseModelSetup(
         freeze: list[ModuleFilter] | None = None,
         debug: bool = False,
     ):
-        if not config.train:
+        if not config.train or model is None:
             return
 
         if freeze is not None and len(freeze) > 0:

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -382,9 +382,9 @@ class BaseStableDiffusionXLSetup(
                         train_device=self.train_device,
                         batch_size=batch['latent_image'].shape[0],
                         rand=rand,
-                        # Pass empty tokens (all padding tokens)
-                        tokens_1=torch.zeros_like(batch['tokens_1']),
-                        tokens_2=torch.zeros_like(batch['tokens_2']),
+                        text="",
+                        tokens_1=None,
+                        tokens_2=None,
                         text_encoder_1_layer_skip=config.text_encoder_layer_skip,
                         text_encoder_2_layer_skip=config.text_encoder_2_layer_skip,
                         text_encoder_1_output=None,

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -193,6 +193,7 @@ class BaseStableDiffusionXLSetup(
             train_progress: TrainProgress,
             *,
             deterministic: bool = False,
+            generate_distillation_empty: bool = False,
     ) -> dict:
         with model.autocast_context:
             batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
@@ -370,6 +371,49 @@ class BaseStableDiffusionXLSetup(
                     )
 
         model_output_data['prediction_type'] = model.noise_scheduler.config.prediction_type
+        
+        # For CFG_DISTILL: Generate empty prompt prediction
+        if generate_distillation_empty and config.distillation.enabled \
+            and config.distillation.target_mode.value == 'CFG_DISTILL':
+            with torch.no_grad():
+                # Create empty text embeddings (as unconditional guidance)
+                empty_text_encoder_output, empty_pooled_text_encoder_2_output = model.combine_text_encoder_output(
+                    *model.encode_text(
+                        train_device=self.train_device,
+                        batch_size=batch['latent_image'].shape[0],
+                        rand=rand,
+                        # Pass empty tokens (all padding tokens)
+                        tokens_1=torch.zeros_like(batch['tokens_1']),
+                        tokens_2=torch.zeros_like(batch['tokens_2']),
+                        text_encoder_1_layer_skip=config.text_encoder_layer_skip,
+                        text_encoder_2_layer_skip=config.text_encoder_2_layer_skip,
+                        text_encoder_1_output=None,
+                        text_encoder_2_output=None,
+                        pooled_text_encoder_2_output=None,
+                        text_encoder_1_dropout_probability=0.0,
+                        text_encoder_2_dropout_probability=0.0,
+                    )
+                )
+                
+                # Create latent input (same structure, but with empty conditioning)
+                if config.model_type.has_mask_input() and config.model_type.has_conditioning_image_input():
+                    empty_latent_input = torch.concat(
+                        [scaled_noisy_latent_image, batch['latent_mask'], scaled_latent_conditioning_image], 1
+                    )
+                else:
+                    empty_latent_input = scaled_noisy_latent_image
+                
+                # Run UNet with empty conditioning
+                empty_added_cond_kwargs = {"text_embeds": empty_pooled_text_encoder_2_output, "time_ids": add_time_ids}
+                predicted_latent_noise_empty = model.unet(
+                    sample=empty_latent_input.to(dtype=model.train_dtype.torch_dtype()),
+                    timestep=timestep,
+                    encoder_hidden_states=empty_text_encoder_output.to(dtype=model.train_dtype.torch_dtype()),
+                    added_cond_kwargs=empty_added_cond_kwargs,
+                ).sample
+                
+                model_output_data['predicted_empty'] = predicted_latent_noise_empty
+        
         return model_output_data
 
     def calculate_loss(

--- a/modules/modelSetup/StableDiffusionLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionLoRASetup.py
@@ -1,6 +1,7 @@
 from modules.model.StableDiffusionModel import StableDiffusionModel
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.BaseStableDiffusionSetup import BaseStableDiffusionSetup
+from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
@@ -69,7 +70,7 @@ class StableDiffusionLoRASetup(
         if config.train_any_embedding():
             model.text_encoder.get_input_embeddings().to(dtype=config.embedding_weight_dtype.torch_dtype())
 
-        create_te = config.text_encoder.train or state_dict_has_prefix(model.lora_state_dict, "lora_te")
+        create_te = config.text_encoder.train
         model.text_encoder_lora = LoRAModuleWrapper(
             model.text_encoder, "lora_te", config
         ) if create_te else None
@@ -79,6 +80,13 @@ class StableDiffusionLoRASetup(
         )
 
         if model.lora_state_dict:
+            # Apply scaling factors to LoRA weights before loading
+            model.lora_state_dict = LoRALoaderMixin.scale_lora_state_dict(
+                model.lora_state_dict,
+                te_scale=config.lora_te_scale,
+                unet_scale=config.lora_unet_scale,
+            )
+            
             if create_te:
                 model.text_encoder_lora.load_state_dict(model.lora_state_dict)
             model.unet_lora.load_state_dict(model.lora_state_dict)

--- a/modules/modelSetup/StableDiffusionXLLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionXLLoRASetup.py
@@ -1,6 +1,7 @@
 from modules.model.StableDiffusionXLModel import StableDiffusionXLModel
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.modelSetup.BaseStableDiffusionXLSetup import BaseStableDiffusionXLSetup
+from modules.modelLoader.mixin.LoRALoaderMixin import LoRALoaderMixin
 from modules.module.LoRAModule import LoRAModuleWrapper
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
@@ -76,8 +77,8 @@ class StableDiffusionXLLoRASetup(
             model: StableDiffusionXLModel,
             config: TrainConfig,
     ):
-        create_te1 = config.text_encoder.train or state_dict_has_prefix(model.lora_state_dict, "lora_te1")
-        create_te2 = config.text_encoder_2.train or state_dict_has_prefix(model.lora_state_dict, "lora_te2")
+        create_te1 = config.text_encoder.train
+        create_te2 = config.text_encoder_2.train
 
         model.text_encoder_1_lora = LoRAModuleWrapper(
             model.text_encoder_1, "lora_te1", config
@@ -92,6 +93,13 @@ class StableDiffusionXLLoRASetup(
         )
 
         if model.lora_state_dict:
+            # Apply scaling factors to LoRA weights before loading
+            model.lora_state_dict = LoRALoaderMixin.scale_lora_state_dict(
+                model.lora_state_dict,
+                te_scale=config.lora_te_scale,
+                unet_scale=config.lora_unet_scale,
+            )
+            
             if create_te1:
                 model.text_encoder_1_lora.load_state_dict(model.lora_state_dict)
             if create_te2:

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -135,13 +135,13 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
             ).mean(mean_dim) * config.vb_loss_strength
 
         # Distillation loss
-        if config.distillation.enabled and 'parent_target' in data and 'distillation_indices' in data:
+        if config.distillation.enabled and 'prior_target' in data and 'distillation_indices' in data:
             distillation_indices = data['distillation_indices']
             if len(distillation_indices) > 0:
                 # Calculate distillation loss only for samples marked as DISTILLATION
                 dist_loss = distillation_loss(
                     student_prediction=data['predicted'][distillation_indices].to(dtype=torch.float32),
-                    parent_prediction=data['parent_target'][distillation_indices].to(dtype=torch.float32),
+                    parent_prediction=data['prior_target'][distillation_indices].to(dtype=torch.float32),
                     loss_type=config.distillation.loss_type,
                     temperature=config.distillation.kl_temperature,
                     mask=batch['latent_mask'][distillation_indices].to(dtype=torch.float32) if config.masked_training else None,

--- a/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupDiffusionLossMixin.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.DiffusionScheduleCoefficients import DiffusionScheduleCoefficients
 from modules.util.enum.LossWeight import LossWeight
-from modules.util.loss.masked_loss import masked_losses, masked_losses_with_prior
+from modules.util.loss.masked_loss import masked_losses, masked_losses_with_prior, distillation_loss
 from modules.util.loss.vb_loss import vb_losses
 
 import torch
@@ -133,6 +133,21 @@ class ModelSetupDiffusionLossMixin(metaclass=ABCMeta):
                 unmasked_weight=config.unmasked_weight,
                 normalize_masked_area_loss=config.normalize_masked_area_loss,
             ).mean(mean_dim) * config.vb_loss_strength
+
+        # Distillation loss
+        if config.distillation.enabled and 'parent_target' in data and 'distillation_indices' in data:
+            distillation_indices = data['distillation_indices']
+            if len(distillation_indices) > 0:
+                # Calculate distillation loss only for samples marked as DISTILLATION
+                dist_loss = distillation_loss(
+                    student_prediction=data['predicted'][distillation_indices].to(dtype=torch.float32),
+                    parent_prediction=data['parent_target'][distillation_indices].to(dtype=torch.float32),
+                    loss_type=config.distillation.loss_type,
+                    temperature=config.distillation.kl_temperature,
+                    mask=batch['latent_mask'][distillation_indices].to(dtype=torch.float32) if config.masked_training else None,
+                    reduction='mean',
+                )
+                losses += dist_loss * config.distillation.loss_weight
 
         return losses
 

--- a/modules/module/DistillationCacheManager.py
+++ b/modules/module/DistillationCacheManager.py
@@ -1,0 +1,230 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import Tensor
+
+
+class DistillationCacheManager:
+    """
+    Manages caching of parent model predictions for distillation training.
+    
+    This allows a two-step distillation workflow:
+    1. Generate cache: Run parent model inference and save predictions to disk
+    2. Use cache: Load cached predictions instead of running parent model
+    
+    Benefits:
+    - Reduces VRAM usage during training (no need to load parent model)
+    - Faster training when using same dataset for multiple epochs
+    - Avoids model swapping overhead on low-VRAM systems
+    """
+    
+    def __init__(self, cache_dir: str, parent_model_path: str, parent_model_type: str):
+        """
+        Initialize the distillation cache manager.
+        
+        Args:
+            cache_dir: Directory to store cache files
+            parent_model_path: Path to parent model (for validation)
+            parent_model_type: Type of parent model (for validation)
+        """
+        self.cache_dir = Path(cache_dir)
+        self.parent_model_path = parent_model_path
+        self.parent_model_type = parent_model_type
+        
+        # Create cache directory if it doesn't exist
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        print(f"[DistillationCacheManager] Initialized cache directory: {self.cache_dir.absolute()}")
+        print(f"[DistillationCacheManager] Directory exists: {self.cache_dir.exists()}")
+        print(f"[DistillationCacheManager] Directory writable: {os.access(self.cache_dir, os.W_OK)}")
+        
+        # Metadata file for cache validation
+        self.metadata_file = self.cache_dir / "cache_metadata.json"
+        
+        # Statistics
+        self.cache_hits = 0
+        self.cache_misses = 0
+    
+    def _generate_cache_key(self, image_path: str, timestep: int) -> str:
+        """
+        Generate a unique cache key from image path and timestep.
+        
+        Uses hash to avoid filesystem path issues (special chars, length limits).
+        
+        Args:
+            image_path: Path to the training image
+            timestep: The timestep used for this prediction
+            
+        Returns:
+            Hash-based cache key
+        """
+        # Combine image path and timestep for uniqueness
+        key_string = f"{image_path}_{timestep}"
+        # Use SHA256 hash (first 16 chars should be sufficient for uniqueness)
+        hash_object = hashlib.sha256(key_string.encode())
+        return hash_object.hexdigest()[:16]
+    
+    def _get_cache_filepath(self, cache_key: str) -> Path:
+        """
+        Get the full filepath for a cache entry.
+        
+        Args:
+            cache_key: The cache key
+            
+        Returns:
+            Path to cache file
+        """
+        return self.cache_dir / f"{cache_key}.pt"
+    
+    def save_prediction(
+        self,
+        image_path: str,
+        timestep: int,
+        prediction_dict: dict[str, Tensor],
+        global_step: int = 0,
+    ) -> None:
+        """
+        Save a parent model prediction to cache.
+        
+        Args:
+            image_path: Path to the training image
+            timestep: The timestep used for this prediction
+            prediction_dict: Dictionary containing prediction tensors
+                            Should include: 'predicted', 'target', 'prediction_type'
+            global_step: Current training step (for debugging)
+        """
+        cache_key = self._generate_cache_key(image_path, timestep)
+        cache_file = self._get_cache_filepath(cache_key)
+        
+        # Prepare cache data
+        cache_data = {
+            'predicted': prediction_dict.get('predicted').cpu() if prediction_dict.get('predicted') is not None else None,
+            'target': prediction_dict.get('target').cpu() if prediction_dict.get('target') is not None else None,
+            'prediction_type': prediction_dict.get('prediction_type'),
+            'timestep': timestep,
+            'image_path': image_path,
+            'global_step': global_step,
+            'parent_model_path': self.parent_model_path,
+            'parent_model_type': self.parent_model_type,
+        }
+        
+        try:
+            # Save to disk
+            torch.save(cache_data, cache_file)
+        except Exception as e:
+            print(f"[DistillationCacheManager] ERROR saving cache file {cache_file}: {str(e)}")
+            raise
+    
+    def load_prediction(self, image_path: str, timestep: int) -> dict[str, Any] | None:
+        """
+        Load a cached parent model prediction.
+        
+        Args:
+            image_path: Path to the training image
+            timestep: The timestep to load
+            
+        Returns:
+            Dictionary with cached prediction data, or None if not found
+        """
+        cache_key = self._generate_cache_key(image_path, timestep)
+        cache_file = self._get_cache_filepath(cache_key)
+        
+        if not cache_file.exists():
+            self.cache_misses += 1
+            return None
+        
+        try:
+            cache_data = torch.load(cache_file, map_location='cpu')
+            
+            # Validate metadata
+            if cache_data.get('parent_model_path') != self.parent_model_path:
+                raise ValueError(
+                    f"Cache metadata mismatch: parent_model_path\n"
+                    f"  Expected: {self.parent_model_path}\n"
+                    f"  Got: {cache_data.get('parent_model_path')}"
+                )
+            
+            if cache_data.get('parent_model_type') != self.parent_model_type:
+                raise ValueError(
+                    f"Cache metadata mismatch: parent_model_type\n"
+                    f"  Expected: {self.parent_model_type}\n"
+                    f"  Got: {cache_data.get('parent_model_type')}"
+                )
+            
+            self.cache_hits += 1
+            return cache_data
+            
+        except Exception as e:
+            raise RuntimeError(f"Failed to load cache file {cache_file}: {str(e)}")
+    
+    def cache_exists(self, image_path: str, timestep: int) -> bool:
+        """
+        Check if a cache entry exists for the given image and timestep.
+        
+        Args:
+            image_path: Path to the training image
+            timestep: The timestep
+            
+        Returns:
+            True if cache exists
+        """
+        cache_key = self._generate_cache_key(image_path, timestep)
+        cache_file = self._get_cache_filepath(cache_key)
+        return cache_file.exists()
+    
+    def get_cache_stats(self) -> dict[str, int]:
+        """
+        Get cache statistics.
+        
+        Returns:
+            Dictionary with cache_hits and cache_misses
+        """
+        return {
+            'cache_hits': self.cache_hits,
+            'cache_misses': self.cache_misses,
+        }
+    
+    def clear_cache(self) -> int:
+        """
+        Delete all cache files in the cache directory.
+        
+        Returns:
+            Number of files deleted
+        """
+        count = 0
+        for cache_file in self.cache_dir.glob("*.pt"):
+            cache_file.unlink()
+            count += 1
+        
+        # Also remove metadata file if it exists
+        if self.metadata_file.exists():
+            self.metadata_file.unlink()
+            count += 1
+        
+        return count
+    
+    def save_metadata(self, metadata: dict[str, Any]) -> None:
+        """
+        Save cache metadata to disk.
+        
+        Args:
+            metadata: Metadata dictionary to save
+        """
+        with open(self.metadata_file, 'w') as f:
+            json.dump(metadata, f, indent=2)
+    
+    def load_metadata(self) -> dict[str, Any] | None:
+        """
+        Load cache metadata from disk.
+        
+        Returns:
+            Metadata dictionary or None if file doesn't exist
+        """
+        if not self.metadata_file.exists():
+            return None
+        
+        with open(self.metadata_file, 'r') as f:
+            return json.load(f)

--- a/modules/module/DistillationCacheManager.py
+++ b/modules/module/DistillationCacheManager.py
@@ -116,6 +116,7 @@ class DistillationCacheManager:
         cache_data = {
             'predicted': prediction_dict.get('predicted').cpu() if prediction_dict.get('predicted') is not None else None,
             'target': prediction_dict.get('target').cpu() if prediction_dict.get('target') is not None else None,
+            'predicted_empty': prediction_dict.get('predicted_empty').cpu() if prediction_dict.get('predicted_empty') is not None else None,
             'prediction_type': prediction_dict.get('prediction_type'),
             'timestep': timestep,
             'image_path': image_path,
@@ -198,6 +199,15 @@ class DistillationCacheManager:
                     f"  Expected: {self.rollout_blend}\n"
                     f"  Got: {cache_data.get('rollout_blend')}"
                 )
+            
+            # Validate predicted_empty for CFG_DISTILL mode
+            if self.target_mode == 'CFG_DISTILL':
+                if cache_data.get('predicted_empty') is None:
+                    raise ValueError(
+                        f"Cache data for CFG_DISTILL mode missing predicted_empty.\n"
+                        f"This cache was likely generated with a different target_mode.\n"
+                        f"Please regenerate the cache with target_mode='CFG_DISTILL'."
+                    )
             
             self.cache_hits += 1
             return cache_data

--- a/modules/module/DistillationCacheManager.py
+++ b/modules/module/DistillationCacheManager.py
@@ -22,7 +22,16 @@ class DistillationCacheManager:
     - Avoids model swapping overhead on low-VRAM systems
     """
     
-    def __init__(self, cache_dir: str, parent_model_path: str, parent_model_type: str):
+    def __init__(
+        self,
+        cache_dir: str,
+        parent_model_path: str,
+        parent_model_type: str,
+        target_mode: str,
+        cfg_scale: float,
+        rollout_steps: int,
+        rollout_blend: float,
+    ):
         """
         Initialize the distillation cache manager.
         
@@ -34,6 +43,10 @@ class DistillationCacheManager:
         self.cache_dir = Path(cache_dir)
         self.parent_model_path = parent_model_path
         self.parent_model_type = parent_model_type
+        self.target_mode = target_mode
+        self.cfg_scale = cfg_scale
+        self.rollout_steps = rollout_steps
+        self.rollout_blend = rollout_blend
         
         # Create cache directory if it doesn't exist
         self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -109,6 +122,10 @@ class DistillationCacheManager:
             'global_step': global_step,
             'parent_model_path': self.parent_model_path,
             'parent_model_type': self.parent_model_type,
+            'target_mode': self.target_mode,
+            'cfg_scale': self.cfg_scale,
+            'rollout_steps': self.rollout_steps,
+            'rollout_blend': self.rollout_blend,
         }
         
         try:
@@ -152,6 +169,34 @@ class DistillationCacheManager:
                     f"Cache metadata mismatch: parent_model_type\n"
                     f"  Expected: {self.parent_model_type}\n"
                     f"  Got: {cache_data.get('parent_model_type')}"
+                )
+
+            if cache_data.get('target_mode') != self.target_mode:
+                raise ValueError(
+                    f"Cache metadata mismatch: target_mode\n"
+                    f"  Expected: {self.target_mode}\n"
+                    f"  Got: {cache_data.get('target_mode')}"
+                )
+
+            if float(cache_data.get('cfg_scale', 1.0)) != float(self.cfg_scale):
+                raise ValueError(
+                    f"Cache metadata mismatch: cfg_scale\n"
+                    f"  Expected: {self.cfg_scale}\n"
+                    f"  Got: {cache_data.get('cfg_scale')}"
+                )
+
+            if int(cache_data.get('rollout_steps', 1)) != int(self.rollout_steps):
+                raise ValueError(
+                    f"Cache metadata mismatch: rollout_steps\n"
+                    f"  Expected: {self.rollout_steps}\n"
+                    f"  Got: {cache_data.get('rollout_steps')}"
+                )
+
+            if float(cache_data.get('rollout_blend', 0.5)) != float(self.rollout_blend):
+                raise ValueError(
+                    f"Cache metadata mismatch: rollout_blend\n"
+                    f"  Expected: {self.rollout_blend}\n"
+                    f"  Got: {cache_data.get('rollout_blend')}"
                 )
             
             self.cache_hits += 1

--- a/modules/module/ParentModelWrapper.py
+++ b/modules/module/ParentModelWrapper.py
@@ -1,0 +1,188 @@
+import torch
+from abc import ABCMeta
+
+from modules.model.BaseModel import BaseModel
+from modules.modelLoader.BaseModelLoader import BaseModelLoader
+from modules.module.quantized.mixin.QuantizedModuleMixin import QuantizedModuleMixin
+from modules.util.config.TrainConfig import DistillationConfig, QuantizationConfig
+from modules.util.enum.DataType import DataType
+from modules.util.ModelNames import ModelNames
+from modules.util.ModelWeightDtypes import ModelWeightDtypes
+from modules.util.quantization_util import replace_linear_with_quantized_layers
+from modules.util.torch_util import torch_gc
+
+
+class ParentModelWrapper:
+    """
+    Wrapper for managing a parent model used in distillation training.
+    Handles loading, quantization, and device management for memory-efficient distillation.
+    
+    Similar to EMAModuleWrapper pattern, but loads an external model instead of
+    copying parameters. Supports CPU offloading and quantization to reduce VRAM usage.
+    """
+    
+    def __init__(
+            self,
+            config: DistillationConfig,
+            model_loader: BaseModelLoader,
+            train_device: str = "cuda",
+            temp_device: str = "cpu",
+    ):
+        """
+        Initialize the parent model wrapper.
+        
+        Args:
+            config: Distillation configuration
+            model_loader: Model loader for the parent model type
+            train_device: Device for training (GPU)
+            temp_device: Device for storage (typically CPU)
+        """
+        self.config = config
+        self.model_loader = model_loader
+        self.train_device = torch.device(train_device)
+        self.temp_device = torch.device(temp_device)
+        
+        self.parent_model: BaseModel | None = None
+        self._is_loaded = False
+        self._is_on_train_device = False
+        
+    def load_parent_model(self) -> BaseModel:
+        """
+        Lazy-load the parent model from the configured path.
+        Applies quantization if enabled. Model is loaded to temp_device (CPU) by default.
+        
+        Returns:
+            The loaded parent model
+        """
+        if self._is_loaded:
+            return self.parent_model
+            
+        if not self.config.enabled or not self.config.parent_model_path:
+            raise ValueError("Distillation not enabled or parent model path not set")
+        
+        # Create model names for loading
+        model_names = ModelNames(
+            base_model=self.config.parent_model_path,
+        )
+        
+        # Determine weight dtypes - use float32 for parent to avoid precision issues
+        # Parent model inference doesn't need fp16
+        weight_dtypes = ModelWeightDtypes.from_single_dtype(DataType.FLOAT_32)
+        
+        # Create a default quantization config (no SVD quantization for parent model)
+        # Parent model uses its own quantization via distillation config
+        quantization_config = QuantizationConfig.default_values()
+        
+        # Load the model
+        # Initially load to temp_device (CPU) to save VRAM
+        self.parent_model = self.model_loader.load(
+            model_type=self.config.parent_model_type,
+            model_names=model_names,
+            weight_dtypes=weight_dtypes,
+            quantization=quantization_config,
+        )
+        
+        # Move to temp device initially
+        if hasattr(self.parent_model, 'to'):
+            self.parent_model.to(self.temp_device)
+        
+        # Apply quantization if enabled
+        if self.config.quantize_parent and self.config.parent_quantization_dtype != DataType.NONE:
+            self._quantize_parent_model()
+        
+        self._is_loaded = True
+        self._is_on_train_device = False
+        
+        return self.parent_model
+    
+    def _quantize_parent_model(self):
+        """
+        Apply quantization to the parent model to reduce memory footprint.
+        Uses existing quantization infrastructure from OneTrainer.
+        Iterates through all nn.Module attributes of the parent model.
+        """
+        if not hasattr(self.parent_model, '__dict__'):
+            return
+        
+        quantized_modules = []
+            
+        # Step 1: Replace linear layers with quantized versions
+        for attr_name in dir(self.parent_model):
+            # Skip private/protected attributes and methods
+            if attr_name.startswith('_'):
+                continue
+                
+            try:
+                attr = getattr(self.parent_model, attr_name)
+                
+                # Check if this attribute is a PyTorch module (like unet, text_encoder, etc.)
+                if isinstance(attr, torch.nn.Module):
+                    # Apply quantization to this module
+                    # No layer filtering for parent model - quantize all linear layers
+                    replace_linear_with_quantized_layers(
+                        parent_module=attr,
+                        dtype=self.config.parent_quantization_dtype,
+                        keep_in_fp32_modules=None,
+                        quantization=None,  # Don't use SVD quantization for parent
+                        copy_parameters=True,  # Copy parameters to quantized layers
+                    )
+                    quantized_modules.append(attr)
+            except (AttributeError, RuntimeError):
+                # Some attributes might not be accessible or quantizable
+                # Continue with other attributes
+                pass
+        
+        # Step 2: Initialize quantized layers by calling .quantize()
+        # This is critical for QuantizedModuleMixin types (LinearNf4, LinearFp8, etc.)
+        # They need .quantize() called to initialize internal state (e.g., quant_state)
+        for module in quantized_modules:
+            for child_module in module.modules():
+                if isinstance(child_module, QuantizedModuleMixin):
+                    # Set compute dtype to float32 (parent model doesn't need mixed precision)
+                    child_module.compute_dtype = DataType.FLOAT_32.torch_dtype()
+                    # Initialize quantization state
+                    child_module.quantize(device=self.temp_device)
+    
+    def to_device(self, device: torch.device):
+        """
+        Move the parent model to a specific device.
+        Used for temporarily moving to GPU for inference, then back to CPU.
+        
+        Args:
+            device: Target device
+        """
+        if not self._is_loaded:
+            raise RuntimeError("Parent model not loaded. Call load_parent_model() first.")
+        
+        current_device = device
+        
+        # Only move if device is different
+        if current_device == self.train_device and not self._is_on_train_device:
+            self.parent_model.to(device)
+            self._is_on_train_device = True
+        elif current_device == self.temp_device and self._is_on_train_device:
+            self.parent_model.to(device)
+            self._is_on_train_device = False
+            # Critical: Force VRAM cleanup after moving quantized model back to CPU
+            # Quantized layers have additional state buffers that need explicit cleanup
+            torch_gc()
+    
+    def unload(self):
+        """
+        Explicitly unload the parent model and free memory.
+        Should be called when training is complete.
+        """
+        if self._is_loaded:
+            del self.parent_model
+            self.parent_model = None
+            self._is_loaded = False
+            self._is_on_train_device = False
+            torch_gc()
+    
+    def is_loaded(self) -> bool:
+        """Check if parent model is loaded."""
+        return self._is_loaded
+    
+    def is_on_train_device(self) -> bool:
+        """Check if parent model is currently on the training device (GPU)."""
+        return self._is_on_train_device

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -15,6 +15,7 @@ from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelSampler.BaseModelSampler import BaseModelSampler, ModelSamplerOutput
 from modules.modelSaver.BaseModelSaver import BaseModelSaver
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
+from modules.module.ParentModelWrapper import ParentModelWrapper
 from modules.trainer.BaseTrainer import BaseTrainer
 from modules.util import create, path_util
 from modules.util.bf16_stochastic_rounding import set_seed as bf16_stochastic_rounding_set_seed
@@ -54,6 +55,7 @@ class GenericTrainer(BaseTrainer):
     model_sampler: BaseModelSampler
     model: BaseModel | None
     validation_data_loader: BaseDataLoader
+    parent_model_wrapper: ParentModelWrapper | None
 
     previous_sample_time: float
     sample_queue: list[Callable]
@@ -75,6 +77,7 @@ class GenericTrainer(BaseTrainer):
                 super()._start_tensorboard()
 
         self.model = None
+        self.parent_model_wrapper = None
         self.one_step_trained = False
         self.grad_hook_handles = []
 
@@ -155,6 +158,20 @@ class GenericTrainer(BaseTrainer):
         self.sample_queue = []
 
         self.parameters = self.model.parameters.parameters()
+
+        # Initialize parent model wrapper for distillation if enabled
+        if self.config.distillation.enabled:
+            self.callbacks.on_update_status("loading parent model for distillation")
+            parent_model_loader = create.create_model_loader(
+                self.config.distillation.parent_model_type,
+                TrainingMethod.FINE_TUNE  # Load parent as full model
+            )
+            self.parent_model_wrapper = ParentModelWrapper(
+                config=self.config.distillation,
+                model_loader=parent_model_loader,
+                train_device=self.config.train_device,
+                temp_device=self.config.temp_device,
+            )
 
         if self.config.validation:
             self.validation_data_loader = self.create_data_loader(
@@ -726,20 +743,49 @@ class GenericTrainer(BaseTrainer):
                     step_seed = train_progress.global_step
                     bf16_stochastic_rounding_set_seed(step_seed, train_device)
 
+                    # Identify prior prediction samples
                     prior_pred_indices = [i for i in range(self.config.batch_size)
                                           if ConceptType(batch['concept_type'][i]) == ConceptType.PRIOR_PREDICTION]
-                    if len(prior_pred_indices) > 0 \
+                    
+                    # Identify distillation samples
+                    distillation_indices = [i for i in range(self.config.batch_size)
+                                           if ConceptType(batch['concept_type'][i]) == ConceptType.DISTILLATION]
+                    
+                    # Run parent/prior model if needed for either prior prediction or distillation
+                    if len(prior_pred_indices) > 0 or len(distillation_indices) > 0 \
                             or (self.config.masked_training
                                 and self.config.masked_prior_preservation_weight > 0
                                 and self.config.training_method == TrainingMethod.LORA):
-                        with self.model_setup.prior_model(self.model, self.config), torch.no_grad():
-                            #do NOT create a subbatch using the indices, even though it would be more efficient:
-                            #different timesteps are used for a smaller subbatch by predict(), but the conditioning must match exactly:
-                            prior_model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
+                        with self.model_setup.distillation_parent_model(
+                            self.model, 
+                            self.config, 
+                            self.parent_model_wrapper
+                        ) as parent_model, torch.no_grad():
+                            # Do NOT create a subbatch using the indices, even though it would be more efficient:
+                            # Different timesteps are used for a smaller subbatch by predict(), but the conditioning must match exactly
+                            parent_model_output_data = self.model_setup.predict(
+                                parent_model if parent_model != self.model else self.model,
+                                batch, 
+                                self.config, 
+                                train_progress
+                            )
+                        
+                        # Run student model
                         model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
-                        prior_model_prediction = prior_model_output_data['predicted'].to(dtype=model_output_data['target'].dtype)
-                        model_output_data['target'][prior_pred_indices] = prior_model_prediction[prior_pred_indices]
+                        
+                        # Get parent predictions
+                        prior_model_prediction = parent_model_output_data['predicted'].to(dtype=model_output_data['target'].dtype)
+                        
+                        # For prior_prediction: Replace target (legacy behavior)
+                        if len(prior_pred_indices) > 0:
+                            model_output_data['target'][prior_pred_indices] = prior_model_prediction[prior_pred_indices]
+                        
+                        # Store parent prediction for masked prior preservation and distillation
                         model_output_data['prior_target'] = prior_model_prediction
+                        
+                        # For distillation: Store indices for loss calculation
+                        if len(distillation_indices) > 0:
+                            model_output_data['distillation_indices'] = distillation_indices
                     else:
                         model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
 
@@ -869,6 +915,11 @@ class GenericTrainer(BaseTrainer):
 
         if self.model is not None:
             self.model.to(self.temp_device)
+
+        # Cleanup parent model wrapper if used for distillation
+        if self.parent_model_wrapper is not None:
+            self.parent_model_wrapper.unload()
+            self.parent_model_wrapper = None
 
         if multi.is_master():
             self.tensorboard.close()

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -166,6 +166,18 @@ class GenericTrainer(BaseTrainer):
 
         # Initialize parent model wrapper for distillation if enabled
         if self.config.distillation.enabled:
+            # Validate distillation target_mode (breaking change from CFG_SCALE)
+            valid_modes = {
+                DistillationTargetMode.RAW,
+                DistillationTargetMode.SCALED_LOSS_WEIGHT,
+                DistillationTargetMode.CFG_DISTILL,
+                DistillationTargetMode.STEP_ROLLOUT,
+            }
+            if self.config.distillation.target_mode not in valid_modes:
+                raise ValueError(
+                    f"Invalid distillation target_mode: {self.config.distillation.target_mode}\n"
+                )
+            
             # Initialize cache manager if cache mode is enabled
             if self.config.distillation.cache_mode != DistillationCacheMode.DISABLED:
                 # Resolve cache_dir path relative to workspace
@@ -232,23 +244,47 @@ class GenericTrainer(BaseTrainer):
             batch: dict,
             train_progress: TrainProgress,
             parent_model: BaseModel,
-            base_parent_prediction: Tensor,
-            target: Tensor | None,
+            parent_model_output_data: dict,
     ) -> Tensor:
+        """
+        Build distillation target based on target_mode.
+        
+        Modes:
+        - RAW: Use parent prediction directly
+        - SCALED_LOSS_WEIGHT: Use parent prediction (scaled only via loss_weight in loss calculation)
+        - CFG_DISTILL: p_cfg = predicted_empty + cfg_scale * (predicted - predicted_empty)
+        - STEP_ROLLOUT: Blend multiple parent predictions
+        """
         target_mode = self.config.distillation.target_mode
+        base_parent_prediction = parent_model_output_data['predicted']
 
         if target_mode == DistillationTargetMode.RAW:
             return base_parent_prediction
 
-        if target_mode == DistillationTargetMode.CFG_SCALE:
-            if target is None:
-                if multi.is_master() and train_progress.global_step == 0:
-                    print("[Distillation] CFG_SCALE requested but no target available, falling back to RAW.")
-                return base_parent_prediction
+        if target_mode == DistillationTargetMode.SCALED_LOSS_WEIGHT:
+            # Pure scaling via distillation.loss_weight in loss calculation
+            # No target transformation
+            return base_parent_prediction
 
+        if target_mode == DistillationTargetMode.CFG_DISTILL:
+            # CFG distillation: p_cfg = predicted_empty + cfg_scale * (predicted_pos - predicted_empty)
+            predicted_empty = parent_model_output_data.get('predicted_empty')
+            if predicted_empty is None:
+                raise ValueError(
+                    f"CFG_DISTILL target_mode requires predicted_empty from parent model, but it is None.\n"
+                    f"This typically happens when:\n"
+                    f"  1. Using cache mode without CFG_DISTILL enabled when cache was generated\n"
+                    f"  2. Model setup does not support CFG_DISTILL (only SDXL currently supported)\n"
+                    f"\nSolution: Regenerate cache with CFG_DISTILL target_mode, or use a different target_mode."
+                )
+            
             cfg_scale = float(self.config.distillation.cfg_scale)
-            target_for_blend = target.to(dtype=base_parent_prediction.dtype)
-            return target_for_blend + cfg_scale * (base_parent_prediction - target_for_blend)
+            predicted_empty_typed = predicted_empty.to(dtype=base_parent_prediction.dtype)
+            base_parent_typed = base_parent_prediction.to(dtype=base_parent_prediction.dtype)
+            
+            # p_cfg = empty + cfg_scale * (positive - empty)
+            p_cfg = predicted_empty_typed + cfg_scale * (base_parent_typed - predicted_empty_typed)
+            return p_cfg
 
         if target_mode == DistillationTargetMode.STEP_ROLLOUT:
             rollout_steps = max(1, int(self.config.distillation.rollout_steps))
@@ -896,15 +932,15 @@ class GenericTrainer(BaseTrainer):
                                 parent_model if parent_model != self.model else self.model,
                                 batch, 
                                 self.config, 
-                                train_progress
+                                train_progress,
+                                generate_distillation_empty=self.config.distillation.target_mode == DistillationTargetMode.CFG_DISTILL,
                             )
 
                             transformed_parent_prediction = self.__build_distillation_target(
                                 batch=batch,
                                 train_progress=train_progress,
                                 parent_model=parent_model if parent_model != self.model else self.model,
-                                base_parent_prediction=parent_model_output_data['predicted'],
-                                target=parent_model_output_data.get('target'),
+                                parent_model_output_data=parent_model_output_data,
                             )
                         
                         # Save predictions to cache for each distillation sample
@@ -929,6 +965,8 @@ class GenericTrainer(BaseTrainer):
                                 prediction_dict = {
                                     'predicted': transformed_parent_prediction[idx:idx+1].detach().cpu(),
                                     'target': parent_model_output_data.get('target', None),
+                                    'predicted_empty': parent_model_output_data.get('predicted_empty')[idx:idx+1].detach().cpu()
+                                        if parent_model_output_data.get('predicted_empty') is not None else None,
                                     'prediction_type': parent_model_output_data.get('prediction_type'),
                                 }
                                 
@@ -1032,7 +1070,8 @@ class GenericTrainer(BaseTrainer):
                                 parent_model if parent_model != self.model else self.model,
                                 batch, 
                                 self.config, 
-                                train_progress
+                                train_progress,
+                                generate_distillation_empty=self.config.distillation.target_mode == DistillationTargetMode.CFG_DISTILL,
                             )
                         
                         # Run student model
@@ -1046,8 +1085,7 @@ class GenericTrainer(BaseTrainer):
                             batch=batch,
                             train_progress=train_progress,
                             parent_model=parent_model if parent_model != self.model else self.model,
-                            base_parent_prediction=prior_model_prediction,
-                            target=model_output_data.get('target'),
+                            parent_model_output_data=parent_model_output_data,
                         )
                         
                         # For prior_prediction: Replace target (legacy behavior)

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -28,6 +28,7 @@ from modules.util.dtype_util import create_grad_scaler, enable_grad_scaling
 from modules.util.enum.ConceptType import ConceptType
 from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.EMAMode import EMAMode
+from modules.util.enum.DistillationTargetMode import DistillationTargetMode
 from modules.util.enum.FileType import FileType
 from modules.util.enum.ModelFormat import ModelFormat
 from modules.util.enum.TimeUnit import TimeUnit
@@ -171,13 +172,17 @@ class GenericTrainer(BaseTrainer):
                 cache_dir = self.config.distillation.cache_dir
                 if not os.path.isabs(cache_dir):
                     cache_dir = os.path.join(self.config.workspace_dir, cache_dir)
-                
+
                 self.distillation_cache_manager = DistillationCacheManager(
                     cache_dir=cache_dir,
                     parent_model_path=self.config.distillation.parent_model_path,
                     parent_model_type=str(self.config.distillation.parent_model_type),
+                    target_mode=str(self.config.distillation.target_mode),
+                    cfg_scale=float(self.config.distillation.cfg_scale),
+                    rollout_steps=int(self.config.distillation.rollout_steps),
+                    rollout_blend=float(self.config.distillation.rollout_blend),
                 )
-                
+
                 if multi.is_master():
                     if self.config.distillation.cache_mode == DistillationCacheMode.GENERATE_CACHE:
                         print(f"\n{'='*80}")
@@ -186,6 +191,10 @@ class GenericTrainer(BaseTrainer):
                         print(f"Cache directory: {cache_dir}")
                         print(f"Parent model: {self.config.distillation.parent_model_path}")
                         print(f"Parent model type: {self.config.distillation.parent_model_type}")
+                        print(f"Target mode: {self.config.distillation.target_mode}")
+                        print(f"CFG scale: {self.config.distillation.cfg_scale}")
+                        print(f"Rollout steps: {self.config.distillation.rollout_steps}")
+                        print(f"Rollout blend: {self.config.distillation.rollout_blend}")
                         print(f"All samples with concept_type 'DISTILLATION' will have their parent")
                         print(f"model predictions cached to disk during this training run.")
                         print(f"This cache will be reused in subsequent training runs with USE_CACHE mode.")
@@ -198,7 +207,7 @@ class GenericTrainer(BaseTrainer):
                         print(f"Parent model will NOT be loaded - using cached predictions only.")
                         print(f"{'='*80}\n")
                 self.callbacks.on_update_status("initializing distillation cache")
-            
+
             # Only load parent model if not using cached predictions
             if self.config.distillation.cache_mode != DistillationCacheMode.USE_CACHE:
                 self.callbacks.on_update_status("loading parent model for distillation")
@@ -217,6 +226,60 @@ class GenericTrainer(BaseTrainer):
             self.validation_data_loader = self.create_data_loader(
                 self.model, self.model_setup, self.model.train_progress, is_validation=True
             )
+
+    def __build_distillation_target(
+            self,
+            batch: dict,
+            train_progress: TrainProgress,
+            parent_model: BaseModel,
+            base_parent_prediction: Tensor,
+            target: Tensor | None,
+    ) -> Tensor:
+        target_mode = self.config.distillation.target_mode
+
+        if target_mode == DistillationTargetMode.RAW:
+            return base_parent_prediction
+
+        if target_mode == DistillationTargetMode.CFG_SCALE:
+            if target is None:
+                if multi.is_master() and train_progress.global_step == 0:
+                    print("[Distillation] CFG_SCALE requested but no target available, falling back to RAW.")
+                return base_parent_prediction
+
+            cfg_scale = float(self.config.distillation.cfg_scale)
+            target_for_blend = target.to(dtype=base_parent_prediction.dtype)
+            return target_for_blend + cfg_scale * (base_parent_prediction - target_for_blend)
+
+        if target_mode == DistillationTargetMode.STEP_ROLLOUT:
+            rollout_steps = max(1, int(self.config.distillation.rollout_steps))
+            rollout_blend = float(self.config.distillation.rollout_blend)
+            rollout_blend = min(1.0, max(0.0, rollout_blend))
+
+            if rollout_steps == 1:
+                return base_parent_prediction
+
+            rolled_prediction = base_parent_prediction
+            for rollout_idx in range(rollout_steps - 1):
+                # Use a shifted global_step so each rollout pass gets a distinct but reproducible seed.
+                rollout_progress = TrainProgress(
+                    epoch=train_progress.epoch,
+                    epoch_step=train_progress.epoch_step,
+                    epoch_sample=train_progress.epoch_sample,
+                    global_step=train_progress.global_step + rollout_idx + 1,
+                )
+                rollout_output_data = self.model_setup.predict(
+                    parent_model,
+                    batch,
+                    self.config,
+                    rollout_progress,
+                    deterministic=False,
+                )
+                rollout_prediction = rollout_output_data['predicted'].to(dtype=rolled_prediction.dtype)
+                rolled_prediction = torch.lerp(rolled_prediction, rollout_prediction, rollout_blend)
+
+            return rolled_prediction
+
+        return base_parent_prediction
 
     def __save_config_to_workspace(self):
         path = path_util.canonical_join(self.config.workspace_dir, "config")
@@ -835,6 +898,14 @@ class GenericTrainer(BaseTrainer):
                                 self.config, 
                                 train_progress
                             )
+
+                            transformed_parent_prediction = self.__build_distillation_target(
+                                batch=batch,
+                                train_progress=train_progress,
+                                parent_model=parent_model if parent_model != self.model else self.model,
+                                base_parent_prediction=parent_model_output_data['predicted'],
+                                target=parent_model_output_data.get('target'),
+                            )
                         
                         # Save predictions to cache for each distillation sample
                         saved_count = 0
@@ -856,7 +927,7 @@ class GenericTrainer(BaseTrainer):
                                     timestep = train_progress.global_step
                                 
                                 prediction_dict = {
-                                    'predicted': parent_model_output_data['predicted'][idx:idx+1].detach().cpu(),
+                                    'predicted': transformed_parent_prediction[idx:idx+1].detach().cpu(),
                                     'target': parent_model_output_data.get('target', None),
                                     'prediction_type': parent_model_output_data.get('prediction_type'),
                                 }
@@ -969,13 +1040,22 @@ class GenericTrainer(BaseTrainer):
                         
                         # Get parent predictions
                         prior_model_prediction = parent_model_output_data['predicted'].to(dtype=model_output_data['target'].dtype)
+
+                        # Apply distillation target transformation before loss routing.
+                        transformed_parent_prediction = self.__build_distillation_target(
+                            batch=batch,
+                            train_progress=train_progress,
+                            parent_model=parent_model if parent_model != self.model else self.model,
+                            base_parent_prediction=prior_model_prediction,
+                            target=model_output_data.get('target'),
+                        )
                         
                         # For prior_prediction: Replace target (legacy behavior)
                         if len(prior_pred_indices) > 0:
                             model_output_data['target'][prior_pred_indices] = prior_model_prediction[prior_pred_indices]
                         
                         # Store parent prediction for masked prior preservation and distillation
-                        model_output_data['prior_target'] = prior_model_prediction
+                        model_output_data['prior_target'] = transformed_parent_prediction
                         
                         # For distillation: Store indices for loss calculation
                         if len(distillation_indices) > 0:

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -15,6 +15,7 @@ from modules.modelLoader.BaseModelLoader import BaseModelLoader
 from modules.modelSampler.BaseModelSampler import BaseModelSampler, ModelSamplerOutput
 from modules.modelSaver.BaseModelSaver import BaseModelSaver
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
+from modules.module.DistillationCacheManager import DistillationCacheManager
 from modules.module.ParentModelWrapper import ParentModelWrapper
 from modules.trainer.BaseTrainer import BaseTrainer
 from modules.util import create, path_util
@@ -25,6 +26,7 @@ from modules.util.config.SampleConfig import SampleConfig
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_grad_scaler, enable_grad_scaling
 from modules.util.enum.ConceptType import ConceptType
+from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.FileType import FileType
 from modules.util.enum.ModelFormat import ModelFormat
@@ -56,6 +58,7 @@ class GenericTrainer(BaseTrainer):
     model: BaseModel | None
     validation_data_loader: BaseDataLoader
     parent_model_wrapper: ParentModelWrapper | None
+    distillation_cache_manager: DistillationCacheManager | None
 
     previous_sample_time: float
     sample_queue: list[Callable]
@@ -78,6 +81,7 @@ class GenericTrainer(BaseTrainer):
 
         self.model = None
         self.parent_model_wrapper = None
+        self.distillation_cache_manager = None
         self.one_step_trained = False
         self.grad_hook_handles = []
 
@@ -161,17 +165,53 @@ class GenericTrainer(BaseTrainer):
 
         # Initialize parent model wrapper for distillation if enabled
         if self.config.distillation.enabled:
-            self.callbacks.on_update_status("loading parent model for distillation")
-            parent_model_loader = create.create_model_loader(
-                self.config.distillation.parent_model_type,
-                TrainingMethod.FINE_TUNE  # Load parent as full model
-            )
-            self.parent_model_wrapper = ParentModelWrapper(
-                config=self.config.distillation,
-                model_loader=parent_model_loader,
-                train_device=self.config.train_device,
-                temp_device=self.config.temp_device,
-            )
+            # Initialize cache manager if cache mode is enabled
+            if self.config.distillation.cache_mode != DistillationCacheMode.DISABLED:
+                # Resolve cache_dir path relative to workspace
+                cache_dir = self.config.distillation.cache_dir
+                if not os.path.isabs(cache_dir):
+                    cache_dir = os.path.join(self.config.workspace_dir, cache_dir)
+                
+                self.distillation_cache_manager = DistillationCacheManager(
+                    cache_dir=cache_dir,
+                    parent_model_path=self.config.distillation.parent_model_path,
+                    parent_model_type=str(self.config.distillation.parent_model_type),
+                )
+                
+                if multi.is_master():
+                    if self.config.distillation.cache_mode == DistillationCacheMode.GENERATE_CACHE:
+                        print(f"\n{'='*80}")
+                        print(f"DISTILLATION CACHE GENERATION MODE")
+                        print(f"{'='*80}")
+                        print(f"Cache directory: {cache_dir}")
+                        print(f"Parent model: {self.config.distillation.parent_model_path}")
+                        print(f"Parent model type: {self.config.distillation.parent_model_type}")
+                        print(f"All samples with concept_type 'DISTILLATION' will have their parent")
+                        print(f"model predictions cached to disk during this training run.")
+                        print(f"This cache will be reused in subsequent training runs with USE_CACHE mode.")
+                        print(f"{'='*80}\n")
+                    elif self.config.distillation.cache_mode == DistillationCacheMode.USE_CACHE:
+                        print(f"\n{'='*80}")
+                        print(f"DISTILLATION CACHE USAGE MODE")
+                        print(f"{'='*80}")
+                        print(f"Loading cached predictions from: {cache_dir}")
+                        print(f"Parent model will NOT be loaded - using cached predictions only.")
+                        print(f"{'='*80}\n")
+                self.callbacks.on_update_status("initializing distillation cache")
+            
+            # Only load parent model if not using cached predictions
+            if self.config.distillation.cache_mode != DistillationCacheMode.USE_CACHE:
+                self.callbacks.on_update_status("loading parent model for distillation")
+                parent_model_loader = create.create_model_loader(
+                    self.config.distillation.parent_model_type,
+                    TrainingMethod.FINE_TUNE  # Load parent as full model
+                )
+                self.parent_model_wrapper = ParentModelWrapper(
+                    config=self.config.distillation,
+                    model_loader=parent_model_loader,
+                    train_device=self.config.train_device,
+                    temp_device=self.config.temp_device,
+                )
 
         if self.config.validation:
             self.validation_data_loader = self.create_data_loader(
@@ -750,6 +790,159 @@ class GenericTrainer(BaseTrainer):
                     # Identify distillation samples
                     distillation_indices = [i for i in range(self.config.batch_size)
                                            if ConceptType(batch['concept_type'][i]) == ConceptType.DISTILLATION]
+                    
+                    # Debug logging for cache generation mode
+                    if (self.config.distillation.enabled and 
+                        self.config.distillation.cache_mode == DistillationCacheMode.GENERATE_CACHE and
+                        train_progress.global_step == 0 and multi.is_master()):
+                        # Log batch composition on first step
+                        concept_types = [ConceptType(batch['concept_type'][i]) for i in range(self.config.batch_size)]
+                        print(f"[Cache Generation] Batch concept types: {concept_types}")
+                        print(f"[Cache Generation] Distillation samples found: {len(distillation_indices)}")
+                        if len(distillation_indices) == 0:
+                            print(f"[Cache Generation] WARNING: No DISTILLATION concept_type samples found!")
+                            print(f"[Cache Generation] Please mark your training samples with 'concept_type': 'DISTILLATION'")
+                    
+                    # === CACHE GENERATION MODE ===
+                    if (self.config.distillation.enabled and 
+                        self.config.distillation.cache_mode == DistillationCacheMode.GENERATE_CACHE):
+                        
+                        if len(distillation_indices) == 0:
+                            # No distillation samples in this batch, skip
+                            train_progress.next_step(self.config.batch_size)
+                            continue
+                        
+                        if self.distillation_cache_manager is None:
+                            raise RuntimeError("Cache manager not initialized for GENERATE_CACHE mode")
+                        
+                        if multi.is_master():
+                            print(f"[Cache Generation] Processing {len(distillation_indices)} distillation samples, step {train_progress.global_step}")
+                        
+                        # Move student model to CPU to free VRAM for parent model
+                        self.model.to('cpu')
+                        torch_gc()
+                        
+                        # Run parent model inference to generate cache
+                        with self.model_setup.distillation_parent_model(
+                            self.model, 
+                            self.config, 
+                            self.parent_model_wrapper
+                        ) as parent_model, torch.no_grad():
+                            parent_model_output_data = self.model_setup.predict(
+                                parent_model if parent_model != self.model else self.model,
+                                batch, 
+                                self.config, 
+                                train_progress
+                            )
+                        
+                        # Save predictions to cache for each distillation sample
+                        saved_count = 0
+                        for idx in distillation_indices:
+                            try:
+                                image_path = batch['image_path'][idx]
+                                timestep_value = parent_model_output_data.get('timestep')
+                                
+                                if timestep_value is not None:
+                                    if isinstance(timestep_value, torch.Tensor):
+                                        if timestep_value.dim() > 0:
+                                            timestep = int(timestep_value[idx].item())
+                                        else:
+                                            timestep = int(timestep_value.item())
+                                    else:
+                                        timestep = int(timestep_value)
+                                else:
+                                    # If timestep not in output, use global step as fallback
+                                    timestep = train_progress.global_step
+                                
+                                prediction_dict = {
+                                    'predicted': parent_model_output_data['predicted'][idx:idx+1].detach().cpu(),
+                                    'target': parent_model_output_data.get('target', None),
+                                    'prediction_type': parent_model_output_data.get('prediction_type'),
+                                }
+                                
+                                self.distillation_cache_manager.save_prediction(
+                                    image_path=image_path,
+                                    timestep=timestep,
+                                    prediction_dict=prediction_dict,
+                                    global_step=train_progress.global_step,
+                                )
+                                saved_count += 1
+                            except Exception as e:
+                                if multi.is_master():
+                                    print(f"[Cache Generation] Error saving prediction for {batch['image_path'][idx]}: {str(e)}")
+                                raise
+                        
+                        if multi.is_master():
+                            cache_stats = self.distillation_cache_manager.get_cache_stats()
+                            print(f"[Cache Generation] Saved {saved_count} predictions (Total hits: {cache_stats['cache_hits']}, misses: {cache_stats['cache_misses']})")
+                            step_tqdm.set_postfix({
+                                'cache_gen': f"{saved_count} samples saved",
+                            })
+                        
+                        # Skip training step in cache generation mode
+                        train_progress.next_step(self.config.batch_size)
+                        continue
+                    
+                    # === USE CACHE MODE ===
+                    elif (self.config.distillation.enabled and 
+                          self.config.distillation.cache_mode == DistillationCacheMode.USE_CACHE):
+                        
+                        # Ensure student model is on training device (may have been moved to CPU during cache generation)
+                        self.model_setup.setup_train_device(self.model, self.config)
+                        
+                        # Run student model normally
+                        model_output_data = self.model_setup.predict(self.model, batch, self.config, train_progress)
+                        
+                        # Load cached predictions for distillation samples
+                        if len(distillation_indices) > 0:
+                            # Create tensor to store cached predictions
+                            prior_model_prediction = torch.zeros_like(model_output_data['predicted'])
+                            
+                            for idx in distillation_indices:
+                                image_path = batch['image_path'][idx]
+                                timestep_value = model_output_data.get('timestep')
+                                
+                                if timestep_value is not None:
+                                    if isinstance(timestep_value, torch.Tensor):
+                                        if timestep_value.dim() > 0:
+                                            timestep = int(timestep_value[idx].item())
+                                        else:
+                                            timestep = int(timestep_value.item())
+                                    else:
+                                        timestep = int(timestep_value)
+                                else:
+                                    timestep = train_progress.global_step
+                                
+                                # Load from cache
+                                cached_data = self.distillation_cache_manager.load_prediction(image_path, timestep)
+                                
+                                if cached_data is None:
+                                    raise RuntimeError(
+                                        f"Cache miss for distillation sample:\n"
+                                        f"  Image: {image_path}\n"
+                                        f"  Timestep: {timestep}\n"
+                                        f"  This may happen if cache was generated with different training parameters.\n"
+                                        f"  Please regenerate cache with GENERATE_CACHE mode."
+                                    )
+                                
+                                # Move cached prediction to correct device and dtype
+                                cached_pred = cached_data['predicted'].to(
+                                    device=model_output_data['predicted'].device,
+                                    dtype=model_output_data['target'].dtype
+                                )
+                                prior_model_prediction[idx:idx+1] = cached_pred
+                            
+                            # Store for distillation loss calculation
+                            model_output_data['prior_target'] = prior_model_prediction
+                            model_output_data['distillation_indices'] = distillation_indices
+                            
+                            if multi.is_master() and train_progress.global_step % 10 == 0:
+                                cache_stats = self.distillation_cache_manager.get_cache_stats()
+                                print(f"Cache stats - Hits: {cache_stats['cache_hits']}, Misses: {cache_stats['cache_misses']}")
+                    
+                    # === NORMAL MODE (DISABLED or live inference) ===
+                    # Ensure student model is on training device (may have been moved to CPU during cache generation)
+                    self.model_setup.setup_train_device(self.model, self.config)
                     
                     # Run parent/prior model if needed for either prior prediction or distillation
                     if len(prior_pred_indices) > 0 or len(distillation_indices) > 0 \

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -799,6 +799,11 @@ class GenericTrainer(BaseTrainer):
                         concept_types = [ConceptType(batch['concept_type'][i]) for i in range(self.config.batch_size)]
                         print(f"[Cache Generation] Batch concept types: {concept_types}")
                         print(f"[Cache Generation] Distillation samples found: {len(distillation_indices)}")
+                        
+                        # Move student model to CPU to free VRAM for parent model
+                        self.model.to('cpu')
+                        torch_gc()
+                        
                         if len(distillation_indices) == 0:
                             print(f"[Cache Generation] WARNING: No DISTILLATION concept_type samples found!")
                             print(f"[Cache Generation] Please mark your training samples with 'concept_type': 'DISTILLATION'")
@@ -817,10 +822,6 @@ class GenericTrainer(BaseTrainer):
                         
                         if multi.is_master():
                             print(f"[Cache Generation] Processing {len(distillation_indices)} distillation samples, step {train_progress.global_step}")
-                        
-                        # Move student model to CPU to free VRAM for parent model
-                        self.model.to('cpu')
-                        torch_gc()
                         
                         # Run parent model inference to generate cache
                         with self.model_setup.distillation_parent_model(

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -96,23 +96,33 @@ class LoraTab:
                             tooltip=f"The alpha parameter used when creating a new {name}")
             components.entry(master, 2, 1, self.ui_state, "lora_alpha")
 
+            # TE Scale
+            components.label(master, 3, 0, f"{name} TE Scale",
+                            tooltip=f"Scale factor for Text Encoder {name} weights on load. 1.0 = no scaling. Use 0.5 to halve weights, 2.0 to double.")
+            components.entry(master, 3, 1, self.ui_state, "lora_te_scale")
+
+            # UNet Scale
+            components.label(master, 4, 0, f"{name} UNet Scale",
+                            tooltip=f"Scale factor for UNet {name} weights on load. 1.0 = no scaling. Use 0.5 to halve weights, 2.0 to double.")
+            components.entry(master, 4, 1, self.ui_state, "lora_unet_scale")
+
             # Dropout Percentage
-            components.label(master, 3, 0, "Dropout Probability",
+            components.label(master, 5, 0, "Dropout Probability",
                             tooltip="Dropout probability. This percentage of model nodes will be randomly ignored at each training step. Helps with overfitting. 0 disables, 1 maximum.")
-            components.entry(master, 3, 1, self.ui_state, "dropout_probability")
+            components.entry(master, 5, 1, self.ui_state, "dropout_probability")
 
             # weight dtype
-            components.label(master, 4, 0, f"{name} Weight Data Type",
+            components.label(master, 6, 0, f"{name} Weight Data Type",
                             tooltip=f"The {name} weight data type used for training. This can reduce memory consumption, but reduces precision")
-            components.options_kv(master, 4, 1, [
+            components.options_kv(master, 6, 1, [
                 ("float32", DataType.FLOAT_32),
                 ("bfloat16", DataType.BFLOAT_16),
             ], self.ui_state, "lora_weight_dtype")
 
             # For use with additional embeddings.
-            components.label(master, 5, 0, "Bundle Embeddings",
+            components.label(master, 7, 0, "Bundle Embeddings",
                             tooltip=f"Bundles any additional embeddings into the {name} output file, rather than as separate files")
-            components.switch(master, 5, 1, self.ui_state, "bundle_additional_embeddings")
+            components.switch(master, 7, 1, self.ui_state, "bundle_additional_embeddings")
 
         # OFTv2
         elif peft_type == PeftType.OFT_2:

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -5,12 +5,14 @@ from modules.ui.TimestepDistributionWindow import TimestepDistributionWindow
 from modules.util import create
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.DataType import DataType
+from modules.util.enum.DistillationLossType import DistillationLossType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
 from modules.util.enum.LearningRateScaler import LearningRateScaler
 from modules.util.enum.LearningRateScheduler import LearningRateScheduler
 from modules.util.enum.LossScaler import LossScaler
 from modules.util.enum.LossWeight import LossWeight
+from modules.util.enum.ModelType import ModelType
 from modules.util.enum.Optimizer import Optimizer
 from modules.util.enum.TimestepDistribution import TimestepDistribution
 from modules.util.optimizer_util import change_optimizer
@@ -96,6 +98,7 @@ class TrainingTab:
         self.__create_unet_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2, supports_generalized_offset_noise=True)
 
+        self.__create_distillation_frame(column_2, 0)
         self.__create_masked_frame(column_2, 1)
         self.__create_loss_frame(column_2, 2)
         self.__create_layer_frame(column_2, 3)
@@ -111,6 +114,7 @@ class TrainingTab:
         self.__create_transformer_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2)
 
+        self.__create_distillation_frame(column_2, 0)
         self.__create_masked_frame(column_2, 1)
         self.__create_loss_frame(column_2, 2)
         self.__create_layer_frame(column_2, 3)
@@ -125,6 +129,7 @@ class TrainingTab:
         self.__create_unet_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2, supports_generalized_offset_noise=True)
 
+        self.__create_distillation_frame(column_2, 0)
         self.__create_masked_frame(column_2, 1)
         self.__create_loss_frame(column_2, 2)
         self.__create_layer_frame(column_2, 3)
@@ -713,6 +718,77 @@ class TrainingTab:
         components.label(frame, 5, 0, "Custom Conditioning Image",
                          tooltip="When custom conditioning image is enabled, will use png postfix with -condlabel instead of automatically generated.It's suitable for special scenarios, such as object removal, allowing the model to learn a certain behavior concept")
         components.switch(frame, 5, 1, self.ui_state, "custom_conditioning_image")
+
+    def __create_distillation_frame(self, master, row):
+        frame = ctk.CTkFrame(master=master, corner_radius=5)
+        frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
+        frame.grid_columnconfigure(0, weight=1)
+        frame.grid_columnconfigure(1, weight=2)
+
+        # Enable Distillation
+        components.label(frame, 0, 0, "Enable Distillation",
+                         tooltip="Enables distillation training where the student model learns from a parent model. Use DISTILLATION concept type in training data to trigger distillation per-sample.")
+        components.switch(frame, 0, 1, self.ui_state, "distillation.enabled")
+
+        # Parent Model Path
+        components.label(frame, 1, 0, "Parent Model Path",
+                         tooltip="Path to the parent model checkpoint to learn from. The parent model should be trained or a base model that produces better outputs than your student model.")
+        components.file_entry(frame, 1, 1, self.ui_state, "distillation.parent_model_path")
+
+        # Parent Model Type
+        # Filter only Stable Diffusion family models
+        sd_model_types = [
+            ("SD 1.5", ModelType.STABLE_DIFFUSION_15),
+            ("SD 1.5 Inpainting", ModelType.STABLE_DIFFUSION_15_INPAINTING),
+            ("SD 2.0", ModelType.STABLE_DIFFUSION_20),
+            ("SD 2.0 Base", ModelType.STABLE_DIFFUSION_20_BASE),
+            ("SD 2.0 Inpainting", ModelType.STABLE_DIFFUSION_20_INPAINTING),
+            ("SD 2.0 Depth", ModelType.STABLE_DIFFUSION_20_DEPTH),
+            ("SD 2.1", ModelType.STABLE_DIFFUSION_21),
+            ("SD 2.1 Base", ModelType.STABLE_DIFFUSION_21_BASE),
+            ("SDXL 1.0 Base", ModelType.STABLE_DIFFUSION_XL_10_BASE),
+            ("SDXL 1.0 Inpainting", ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING),
+            ("SD 3", ModelType.STABLE_DIFFUSION_3),
+            ("SD 3.5", ModelType.STABLE_DIFFUSION_35),
+        ]
+        components.label(frame, 2, 0, "Parent Model Type",
+                         tooltip="The model type of the parent model. Must match the architecture of the parent checkpoint.")
+        components.options_kv(frame, 2, 1, sd_model_types, self.ui_state, "distillation.parent_model_type")
+
+        # Quantize Parent
+        components.label(frame, 3, 0, "Quantize Parent Model",
+                         tooltip="Enables quantization of the parent model to reduce VRAM usage. Recommended for large models or limited VRAM.")
+        components.switch(frame, 3, 1, self.ui_state, "distillation.quantize_parent")
+
+        # Parent Quantization Dtype
+        components.label(frame, 4, 0, "Parent Quantization Type",
+                         tooltip="Quantization precision for parent model. NFLOAT_4 saves most VRAM (75%), INT_8 is balanced (50%), FLOAT_8 is highest quality (50%).")
+        components.options_kv(frame, 4, 1, [
+            ("None", DataType.NONE),
+            #("NFloat4", DataType.NFLOAT_4),
+            #("Int8", DataType.INT_8),
+            ("Float8", DataType.FLOAT_8),
+        ], self.ui_state, "distillation.parent_quantization_dtype")
+
+        # Keep Parent on CPU
+        components.label(frame, 5, 0, "Keep Parent on CPU",
+                         tooltip="Keeps parent model on CPU between forward passes to save VRAM. Increases training time but dramatically reduces memory usage. Recommended for very large models.")
+        components.switch(frame, 5, 1, self.ui_state, "distillation.keep_parent_on_cpu")
+
+        # Loss Type
+        components.label(frame, 6, 0, "Distillation Loss Type",
+                         tooltip="Loss function for distillation: MSE (L2), MAE (L1), HUBER (robust), KL_DIVERGENCE (distribution matching, requires kl_temperature).")
+        components.options(frame, 6, 1, [str(x) for x in list(DistillationLossType)], self.ui_state, "distillation.loss_type")
+
+        # Loss Weight
+        components.label(frame, 7, 0, "Distillation Loss Weight",
+                         tooltip="Weight multiplier for distillation loss. Higher values increase the influence of the parent model. Typical range: 0.1-1.0.")
+        components.entry(frame, 7, 1, self.ui_state, "distillation.loss_weight")
+
+        # KL Temperature
+        components.label(frame, 8, 0, "KL Temperature",
+                         tooltip="Temperature parameter for KL divergence loss. Only used when loss_type is KL_DIVERGENCE. Higher values (2.0+) make the distribution matching softer. Typical range: 1.0-5.0.")
+        components.entry(frame, 8, 1, self.ui_state, "distillation.kl_temperature")
 
     def __create_loss_frame(self, master, row, supports_vb_loss: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -5,6 +5,7 @@ from modules.ui.TimestepDistributionWindow import TimestepDistributionWindow
 from modules.util import create
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.DataType import DataType
+from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.DistillationLossType import DistillationLossType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
@@ -789,6 +790,20 @@ class TrainingTab:
         components.label(frame, 8, 0, "KL Temperature",
                          tooltip="Temperature parameter for KL divergence loss. Only used when loss_type is KL_DIVERGENCE. Higher values (2.0+) make the distribution matching softer. Typical range: 1.0-5.0.")
         components.entry(frame, 8, 1, self.ui_state, "distillation.kl_temperature")
+
+        # Cache Mode
+        components.label(frame, 9, 0, "Cache Mode",
+                         tooltip="Cache mode for distillation training:\n" +
+                                 "  • DISABLED: Live parent model inference (default)\n" +
+                                 "  • GENERATE_CACHE: Run parent model and save predictions to cache\n" +
+                                 "  • USE_CACHE: Load cached predictions instead of running parent model\n" +
+                                 "Two-step workflow: First run with GENERATE_CACHE, then train with USE_CACHE to save VRAM.")
+        components.options(frame, 9, 1, [str(x) for x in list(DistillationCacheMode)], self.ui_state, "distillation.cache_mode")
+
+        # Cache Directory
+        components.label(frame, 10, 0, "Cache Directory",
+                         tooltip="Directory to store/load distillation cache files. Path is relative to workspace directory. Cache files contain parent model predictions for each training sample.")
+        components.entry(frame, 10, 1, self.ui_state, "distillation.cache_dir")
 
     def __create_loss_frame(self, master, row, supports_vb_loss: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -7,6 +7,7 @@ from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.DataType import DataType
 from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.DistillationLossType import DistillationLossType
+from modules.util.enum.DistillationTargetMode import DistillationTargetMode
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
 from modules.util.enum.LearningRateScaler import LearningRateScaler
@@ -791,19 +792,42 @@ class TrainingTab:
                          tooltip="Temperature parameter for KL divergence loss. Only used when loss_type is KL_DIVERGENCE. Higher values (2.0+) make the distribution matching softer. Typical range: 1.0-5.0.")
         components.entry(frame, 8, 1, self.ui_state, "distillation.kl_temperature")
 
+        # Target Mode
+        components.label(frame, 9, 0, "Distillation Target Mode",
+                 tooltip="How parent predictions are transformed for DISTILLATION samples:\n" +
+                     "  • RAW: Use parent prediction directly (legacy behavior)\n" +
+                     "  • CFG_SCALE: Push prediction away from base target using cfg_scale\n" +
+                     "  • STEP_ROLLOUT: Blend multiple parent predictions to create a rollout target")
+        components.options(frame, 9, 1, [str(x) for x in list(DistillationTargetMode)], self.ui_state, "distillation.target_mode")
+
+        # CFG Scale
+        components.label(frame, 10, 0, "Distillation CFG Scale",
+                 tooltip="Used when target_mode is CFG_SCALE. Formula: target + cfg_scale * (parent - target). 1.0 keeps parent unchanged.")
+        components.entry(frame, 10, 1, self.ui_state, "distillation.cfg_scale")
+
+        # Rollout Steps
+        components.label(frame, 11, 0, "Distillation Rollout Steps",
+                 tooltip="Used when target_mode is STEP_ROLLOUT. Number of parent predictions to blend. Minimum is 1.")
+        components.entry(frame, 11, 1, self.ui_state, "distillation.rollout_steps")
+
+        # Rollout Blend
+        components.label(frame, 12, 0, "Distillation Rollout Blend",
+                 tooltip="Used when target_mode is STEP_ROLLOUT. Blend factor in [0,1] for each rollout update.")
+        components.entry(frame, 12, 1, self.ui_state, "distillation.rollout_blend")
+
         # Cache Mode
-        components.label(frame, 9, 0, "Cache Mode",
+        components.label(frame, 13, 0, "Cache Mode",
                          tooltip="Cache mode for distillation training:\n" +
                                  "  • DISABLED: Live parent model inference (default)\n" +
                                  "  • GENERATE_CACHE: Run parent model and save predictions to cache\n" +
                                  "  • USE_CACHE: Load cached predictions instead of running parent model\n" +
                                  "Two-step workflow: First run with GENERATE_CACHE, then train with USE_CACHE to save VRAM.")
-        components.options(frame, 9, 1, [str(x) for x in list(DistillationCacheMode)], self.ui_state, "distillation.cache_mode")
+        components.options(frame, 13, 1, [str(x) for x in list(DistillationCacheMode)], self.ui_state, "distillation.cache_mode")
 
         # Cache Directory
-        components.label(frame, 10, 0, "Cache Directory",
+        components.label(frame, 14, 0, "Cache Directory",
                          tooltip="Directory to store/load distillation cache files. Path is relative to workspace directory. Cache files contain parent model predictions for each training sample.")
-        components.entry(frame, 10, 1, self.ui_state, "distillation.cache_dir")
+        components.entry(frame, 14, 1, self.ui_state, "distillation.cache_dir")
 
     def __create_loss_frame(self, master, row, supports_vb_loss: bool = False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -796,13 +796,14 @@ class TrainingTab:
         components.label(frame, 9, 0, "Distillation Target Mode",
                  tooltip="How parent predictions are transformed for DISTILLATION samples:\n" +
                      "  • RAW: Use parent prediction directly (legacy behavior)\n" +
-                     "  • CFG_SCALE: Push prediction away from base target using cfg_scale\n" +
+                     "  • SCALED_LOSS_WEIGHT: Apply only distillation.loss_weight scaling (no target transformation)\n" +
+                     "  • CFG_DISTILL: CFG distillation: p_cfg = empty + cfg_scale * (positive - empty)\n" +
                      "  • STEP_ROLLOUT: Blend multiple parent predictions to create a rollout target")
         components.options(frame, 9, 1, [str(x) for x in list(DistillationTargetMode)], self.ui_state, "distillation.target_mode")
 
         # CFG Scale
-        components.label(frame, 10, 0, "Distillation CFG Scale",
-                 tooltip="Used when target_mode is CFG_SCALE. Formula: target + cfg_scale * (parent - target). 1.0 keeps parent unchanged.")
+        components.label(frame, 10, 0, "CFG Factor (for CFG_DISTILL)",
+                 tooltip="Used when target_mode is CFG_DISTILL. Formula: p_cfg = empty + cfg_scale * (positive - empty). Controls the strength of classifier-free guidance.")
         components.entry(frame, 10, 1, self.ui_state, "distillation.cfg_scale")
 
         # Rollout Steps

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -14,6 +14,7 @@ from modules.util.enum.ConfigPart import ConfigPart
 from modules.util.enum.DataType import DataType
 from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.DistillationLossType import DistillationLossType
+from modules.util.enum.DistillationTargetMode import DistillationTargetMode
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
 from modules.util.enum.GradientReducePrecision import GradientReducePrecision
@@ -371,6 +372,12 @@ class DistillationConfig(BaseConfig):
     
     # KL-specific
     kl_temperature: float
+
+    # Target transformation
+    target_mode: DistillationTargetMode
+    cfg_scale: float
+    rollout_steps: int
+    rollout_blend: float
     
     # Cache configuration
     cache_mode: DistillationCacheMode
@@ -390,6 +397,10 @@ class DistillationConfig(BaseConfig):
         data.append(("loss_type", DistillationLossType.MSE, DistillationLossType, False))
         data.append(("loss_weight", 1.0, float, False))
         data.append(("kl_temperature", 1.0, float, False))
+        data.append(("target_mode", DistillationTargetMode.RAW, DistillationTargetMode, False))
+        data.append(("cfg_scale", 1.0, float, False))
+        data.append(("rollout_steps", 2, int, False))
+        data.append(("rollout_blend", 0.5, float, False))
         data.append(("cache_mode", DistillationCacheMode.DISABLED, DistillationCacheMode, False))
         data.append(("cache_dir", "workspace-cache/distillation", str, False))
         return DistillationConfig(data)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -397,7 +397,7 @@ class DistillationConfig(BaseConfig):
         data.append(("loss_type", DistillationLossType.MSE, DistillationLossType, False))
         data.append(("loss_weight", 1.0, float, False))
         data.append(("kl_temperature", 1.0, float, False))
-        data.append(("target_mode", DistillationTargetMode.RAW, DistillationTargetMode, False))
+        data.append(("target_mode", DistillationTargetMode.SCALED_LOSS_WEIGHT, DistillationTargetMode, False))
         data.append(("cfg_scale", 1.0, float, False))
         data.append(("rollout_steps", 2, int, False))
         data.append(("rollout_blend", 0.5, float, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -12,6 +12,7 @@ from modules.util.config.SecretsConfig import SecretsConfig
 from modules.util.enum.AudioFormat import AudioFormat
 from modules.util.enum.ConfigPart import ConfigPart
 from modules.util.enum.DataType import DataType
+from modules.util.enum.DistillationLossType import DistillationLossType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
 from modules.util.enum.GradientReducePrecision import GradientReducePrecision
@@ -353,6 +354,39 @@ class QuantizationConfig(BaseConfig):
         data.append(("cache_dir", None, str, True))
         return QuantizationConfig(data)
 
+class DistillationConfig(BaseConfig):
+    enabled: bool
+    parent_model_path: str
+    parent_model_type: ModelType
+    
+    # Memory management
+    quantize_parent: bool
+    parent_quantization_dtype: DataType
+    keep_parent_on_cpu: bool
+    
+    # Loss configuration
+    loss_type: DistillationLossType
+    loss_weight: float
+    
+    # KL-specific
+    kl_temperature: float
+
+    @staticmethod
+    def default_values():
+        data = []
+
+        # name, default value, data type, nullable
+        data.append(("enabled", False, bool, False))
+        data.append(("parent_model_path", "", str, False))
+        data.append(("parent_model_type", ModelType.STABLE_DIFFUSION_15, ModelType, False))
+        data.append(("quantize_parent", True, bool, False))
+        data.append(("parent_quantization_dtype", DataType.NFLOAT_4, DataType, False))
+        data.append(("keep_parent_on_cpu", True, bool, False))
+        data.append(("loss_type", DistillationLossType.MSE, DistillationLossType, False))
+        data.append(("loss_weight", 1.0, float, False))
+        data.append(("kl_temperature", 1.0, float, False))
+        return DistillationConfig(data)
+
 class TrainConfig(BaseConfig):
     training_method: TrainingMethod
     model_type: ModelType
@@ -506,6 +540,9 @@ class TrainConfig(BaseConfig):
     normalize_masked_area_loss: bool
     masked_prior_preservation_weight: float
 
+    # distillation
+    distillation: DistillationConfig
+
     # custom conditioning image
     custom_conditioning_image: bool
 
@@ -525,6 +562,8 @@ class TrainConfig(BaseConfig):
     lora_decompose_norm_epsilon: bool
     lora_decompose_output_axis: bool
     lora_weight_dtype: DataType
+    lora_te_scale: float  # Scale factor for Text Encoder LoRA weights on load (default 1.0)
+    lora_unet_scale: float  # Scale factor for UNet LoRA weights on load (default 1.0)
     bundle_additional_embeddings: bool
 
     # oft
@@ -569,7 +608,7 @@ class TrainConfig(BaseConfig):
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(
             data,
-            config_version=10,
+            config_version=12,
             config_migrations={
                 0: self.__migration_0,
                 1: self.__migration_1,
@@ -581,6 +620,8 @@ class TrainConfig(BaseConfig):
                 7: self.__migration_7,
                 8: self.__migration_8,
                 9: self.__migration_9,
+                10: self.__migration_10,
+                11: self.__migration_11,
             }
         )
 
@@ -797,6 +838,23 @@ class TrainConfig(BaseConfig):
         replace_dtype("decoder_text_encoder")
         replace_dtype("decoder_vqgan")
         migrated_data.pop("weight_dtype")
+
+        return migrated_data
+
+    def __migration_10(self, data: dict) -> dict:
+        migrated_data = data.copy()
+
+        # Add LoRA weight scaling factors with default value 1.0 (no scaling)
+        migrated_data.setdefault("lora_te_scale", 1.0)
+        migrated_data.setdefault("lora_unet_scale", 1.0)
+
+        return migrated_data
+
+    def __migration_11(self, data: dict) -> dict:
+        migrated_data = data.copy()
+
+        # Add distillation config with default values
+        migrated_data.setdefault("distillation", DistillationConfig.default_values().to_dict())
 
         return migrated_data
 
@@ -1128,6 +1186,10 @@ class TrainConfig(BaseConfig):
         data.append(("unmasked_weight", 0.1, float, False))
         data.append(("normalize_masked_area_loss", False, bool, False))
         data.append(("masked_prior_preservation_weight", 0.0, float, False))
+
+        # distillation
+        data.append(("distillation", DistillationConfig.default_values(), DistillationConfig, False))
+
         data.append(("custom_conditioning_image", False, bool, False))
 
         #layer filter
@@ -1154,6 +1216,8 @@ class TrainConfig(BaseConfig):
         data.append(("lora_decompose_norm_epsilon", True, bool, False))
         data.append(("lora_decompose_output_axis", False, bool, False))
         data.append(("lora_weight_dtype", DataType.FLOAT_32, DataType, False))
+        data.append(("lora_te_scale", 1.0, float, False))
+        data.append(("lora_unet_scale", 1.0, float, False))
         data.append(("bundle_additional_embeddings", True, bool, False))
 
         # oft

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -12,6 +12,7 @@ from modules.util.config.SecretsConfig import SecretsConfig
 from modules.util.enum.AudioFormat import AudioFormat
 from modules.util.enum.ConfigPart import ConfigPart
 from modules.util.enum.DataType import DataType
+from modules.util.enum.DistillationCacheMode import DistillationCacheMode
 from modules.util.enum.DistillationLossType import DistillationLossType
 from modules.util.enum.EMAMode import EMAMode
 from modules.util.enum.GradientCheckpointingMethod import GradientCheckpointingMethod
@@ -370,6 +371,10 @@ class DistillationConfig(BaseConfig):
     
     # KL-specific
     kl_temperature: float
+    
+    # Cache configuration
+    cache_mode: DistillationCacheMode
+    cache_dir: str
 
     @staticmethod
     def default_values():
@@ -385,6 +390,8 @@ class DistillationConfig(BaseConfig):
         data.append(("loss_type", DistillationLossType.MSE, DistillationLossType, False))
         data.append(("loss_weight", 1.0, float, False))
         data.append(("kl_temperature", 1.0, float, False))
+        data.append(("cache_mode", DistillationCacheMode.DISABLED, DistillationCacheMode, False))
+        data.append(("cache_dir", "workspace-cache/distillation", str, False))
         return DistillationConfig(data)
 
 class TrainConfig(BaseConfig):

--- a/modules/util/enum/ConceptType.py
+++ b/modules/util/enum/ConceptType.py
@@ -5,6 +5,7 @@ class ConceptType(Enum):
     STANDARD = 'STANDARD'
     VALIDATION = 'VALIDATION'
     PRIOR_PREDICTION = 'PRIOR_PREDICTION'
+    DISTILLATION = 'DISTILLATION'
 
     def __str__(self):
         return self.value

--- a/modules/util/enum/DistillationCacheMode.py
+++ b/modules/util/enum/DistillationCacheMode.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class DistillationCacheMode(Enum):
+    DISABLED = 'DISABLED'
+    GENERATE_CACHE = 'GENERATE_CACHE'
+    USE_CACHE = 'USE_CACHE'
+
+    def __str__(self):
+        return self.value

--- a/modules/util/enum/DistillationLossType.py
+++ b/modules/util/enum/DistillationLossType.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class DistillationLossType(Enum):
+    MSE = 'MSE'
+    MAE = 'MAE'
+    HUBER = 'HUBER'
+    KL_DIVERGENCE = 'KL_DIVERGENCE'
+
+    def __str__(self):
+        return self.value

--- a/modules/util/enum/DistillationTargetMode.py
+++ b/modules/util/enum/DistillationTargetMode.py
@@ -3,7 +3,8 @@ from enum import Enum
 
 class DistillationTargetMode(Enum):
     RAW = 'RAW'
-    CFG_SCALE = 'CFG_SCALE'
+    SCALED_LOSS_WEIGHT = 'SCALED_LOSS_WEIGHT'
+    CFG_DISTILL = 'CFG_DISTILL'
     STEP_ROLLOUT = 'STEP_ROLLOUT'
 
     def __str__(self):

--- a/modules/util/enum/DistillationTargetMode.py
+++ b/modules/util/enum/DistillationTargetMode.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class DistillationTargetMode(Enum):
+    RAW = 'RAW'
+    CFG_SCALE = 'CFG_SCALE'
+    STEP_ROLLOUT = 'STEP_ROLLOUT'
+
+    def __str__(self):
+        return self.value

--- a/modules/util/loss/masked_loss.py
+++ b/modules/util/loss/masked_loss.py
@@ -1,5 +1,8 @@
 import torch
+import torch.nn.functional as F
 from torch import Tensor
+
+from modules.util.enum.DistillationLossType import DistillationLossType
 
 
 def masked_losses(
@@ -43,3 +46,61 @@ def masked_losses_with_prior(
         prior_losses = prior_losses / clamped_mask.mean(dim=(1, 2, 3), keepdim=True)
 
     return losses + prior_losses
+
+
+def distillation_loss(
+        student_prediction: Tensor,
+        parent_prediction: Tensor,
+        loss_type: DistillationLossType,
+        temperature: float = 1.0,
+        mask: Tensor | None = None,
+        reduction: str = 'mean',
+) -> Tensor:
+    """
+    Calculate distillation loss between student and parent predictions.
+    
+    Args:
+        student_prediction: Student model output
+        parent_prediction: Parent model output (should be detached)
+        loss_type: Type of loss (MSE, MAE, Huber, KL)
+        temperature: Temperature scaling for KL divergence
+        mask: Optional mask for masked training
+        reduction: 'mean' or 'none'
+        
+    Returns:
+        Distillation loss tensor
+    """
+    # Ensure parent prediction is detached (no gradients through parent)
+    parent_prediction = parent_prediction.detach()
+    
+    if loss_type == DistillationLossType.MSE:
+        loss = F.mse_loss(student_prediction, parent_prediction, reduction='none')
+    elif loss_type == DistillationLossType.MAE:
+        loss = F.l1_loss(student_prediction, parent_prediction, reduction='none')
+    elif loss_type == DistillationLossType.HUBER:
+        loss = F.huber_loss(student_prediction, parent_prediction, reduction='none', delta=1.0)
+    elif loss_type == DistillationLossType.KL_DIVERGENCE:
+        # For KL divergence on continuous predictions (e.g., latents)
+        # We use a log-normal approximation:
+        # Treat predictions as means of distributions, compute KL between Gaussians
+        # KL(P||Q) = 0.5 * (||mu_p - mu_q||^2 / sigma^2)
+        # For simplicity, assume unit variance (sigma=1)
+        # Temperature scaling: divide by temperature before computing
+        student_scaled = student_prediction / temperature
+        parent_scaled = parent_prediction / temperature
+        
+        # MSE-based KL approximation with temperature scaling
+        loss = F.mse_loss(student_scaled, parent_scaled, reduction='none') * (temperature ** 2)
+    else:
+        raise ValueError(f"Unknown distillation loss type: {loss_type}")
+    
+    # Apply mask if provided
+    if mask is not None:
+        # Use same masking logic as other losses
+        clamped_mask = torch.clamp(mask, 0.1, 1.0)  # Use default unmasked_weight
+        loss = loss * clamped_mask
+    
+    if reduction == 'mean':
+        return loss.mean()
+    else:
+        return loss


### PR DESCRIPTION
#### What’s working
- Lower CFG during inference now looks significantly better.  
  - Training was done at CFG Distillation Scale 7 (and then 3), and inference at CFG 1 now looks roughly like prior CFG 7 quality.
- Overall quality gains are already noticeable after 5-10 steps, especially on trained concepts.
- Style transfer performance is very strong.
- For concept-focused use cases, results at low CFG are excellent.
- Inference speed improved substantially at CFG 1:
  - From ~21-24s (CFG 7) to ~11.5-11.7s (CFG 1), close to 2x faster.
- Compared against the base checkpoint, this setup gives both a quality boost and a speed boost.

#### Observed behavior / limitations
- Tested SDXL to SDXL only
- Trained concepts improve strongly at earlier CFG, but non-trained content improves less consistently.
- In refiner workflows, behavior is somewhat unstable/funky but very good after later training.
- There appears to be a drop in baseline activations without additional regularization/diversification.
- The model strongly biases toward trained concepts even with generic prompts (offset by lower CFG at inference)

#### Practical takeaway
So far, this is a success for targeted training:
- Very high quality at CFG 1
- Strong style transfer
- Better ability to learn concepts that the parent model previously resisted

This could be a path toward practical “poor man’s turbo checkpoints” once stabilized.

#### Additional note
- Rank compression/back-merge experiments (e.g., train rank 32 -> apply -> diff to rank 16) seem promising:
  - Styles can be preserved
  - CFG-scale shifts can be partially reduced in some merges

#### Known bug
- Cache generation can fail on low VRAM after the first epoch.
- Current workaround:
  1. Press stop after cache generation starts
  2. Wait for cache generation to finish
  3. Ensure sampling and backups are disabled during the cache run


---
Initial Draft:
This pull request introduces support for distillation training by adding infrastructure for managing a parent model (teacher) during training, including memory-efficient loading and quantization, as well as integrating distillation loss computation into the training loop. Additionally, it improves LoRA weight handling by allowing separate scaling for text encoder and UNet/transformer components, and simplifies logic for LoRA module creation.

**Distillation training support:**

* Added a new `ParentModelWrapper` class to handle loading, quantization, device management, and unloading of the parent (teacher) model for distillation. This enables efficient memory usage by supporting CPU offloading and quantized inference for the parent model.
* Integrated the parent model wrapper into the trainer (`GenericTrainer`) and model setup (`BaseModelSetup`). Added a context manager `distillation_parent_model` to temporarily load and move the parent model during distillation steps, with VRAM optimization. 
* Added distillation loss calculation to the diffusion loss mixin, applying the configured loss type and temperature only to relevant samples during training. 

**LoRA handling improvements:**

* Introduced a static method `scale_lora_state_dict` in `LoRALoaderMixin` to allow separate scaling of LoRA weights for text encoder and UNet/transformer components, and applied this scaling before loading LoRA weights in both SD and SDXL LoRA setups.
* Simplified logic for creating LoRA modules for text encoders in SD and SDXL setups by removing checks for state dict prefixes and relying only on the training config.

As Discussed in https://github.com/Nerogar/OneTrainer/pull/1353 , Implementing a 2 Step pipeline and precomputing the predictions may allow us to hit almost prior-prediction level performance without the high (V)RAM requirements.

--

As a last note, I kinda rushed this because I was kinda just playing around and I was not actually planning to PR it, so I am not sure it has upstreams quality standard.