### PR TITLE
remove circular padding for transformer models

### DIFF
--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_t5_encoder_layers,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -56,12 +55,6 @@ class BaseChromaSetup(
             if model.text_encoder is not None:
                 model.text_encoder_offload_conductor = \
                     enable_checkpointing_for_t5_encoder_layers(model.text_encoder, config)
-
-        if config.force_circular_padding: #TODO useful for Chroma?
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseFlux2Setup.py
+++ b/modules/modelSetup/BaseFlux2Setup.py
@@ -56,13 +56,6 @@ class BaseFlux2Setup(
                     model.text_encoder_offload_conductor = \
                         enable_checkpointing_for_qwen3_encoder_layers(model.text_encoder, config)
 
-        if config.force_circular_padding:
-            raise NotImplementedError #TODO applies to Flux2?
-#            apply_circular_padding_to_conv2d(model.vae)
-#            apply_circular_padding_to_conv2d(model.transformer)
-#            if model.transformer_lora is not None:
-#                apply_circular_padding_to_conv2d(model.transformer_lora)
-
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -17,7 +17,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_t5_encoder_layers,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -58,12 +57,6 @@ class BaseFluxSetup(
             if model.text_encoder_2 is not None:
                 model.text_encoder_2_offload_conductor = \
                     enable_checkpointing_for_t5_encoder_layers(model.text_encoder_2, config)
-
-        if config.force_circular_padding:
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -17,7 +17,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_llama_encoder_layers,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -58,12 +57,6 @@ class BaseHunyuanVideoSetup(
                     enable_checkpointing_for_llama_encoder_layers(model.text_encoder_1, config)
             if model.text_encoder_2 is not None:
                 enable_checkpointing_for_clip_encoder_layers(model.text_encoder_2, config)
-
-        if config.force_circular_padding:
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_t5_encoder_layers,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -58,12 +57,6 @@ class BasePixArtAlphaSetup(
                 enable_checkpointing_for_basic_transformer_blocks(model.transformer, config, offload_enabled=True)
             model.text_encoder_offload_conductor = \
                 enable_checkpointing_for_t5_encoder_layers(model.text_encoder, config)
-
-        if config.force_circular_padding:
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -14,7 +14,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_qwen_transformer,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -53,12 +52,6 @@ class BaseQwenSetup(
             if model.text_encoder is not None:
                 model.text_encoder_offload_conductor = \
                     enable_checkpointing_for_qwen25vl_encoder_layers(model.text_encoder, config)
-
-        if config.force_circular_padding: #TODO useful for Qwen?
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_sana_transformer,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -59,12 +58,6 @@ class BaseSanaSetup(
                 enable_checkpointing_for_sana_transformer(model.transformer, config)
             model.text_encoder_offload_conductor = \
                 enable_checkpointing_for_gemma_layers(model.text_encoder, config)
-
-        if config.force_circular_padding:
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -17,7 +17,6 @@ from modules.util.checkpointing_util import (
     enable_checkpointing_for_t5_encoder_layers,
 )
 from modules.util.config.TrainConfig import TrainConfig
-from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.quantization_util import quantize_layers
@@ -59,12 +58,6 @@ class BaseStableDiffusion3Setup(
             if model.text_encoder_3 is not None:
                 model.text_encoder_3_offload_conductor = \
                     enable_checkpointing_for_t5_encoder_layers(model.text_encoder_3, config)
-
-        if config.force_circular_padding:
-            apply_circular_padding_to_conv2d(model.vae)
-            apply_circular_padding_to_conv2d(model.transformer)
-            if model.transformer_lora is not None:
-                apply_circular_padding_to_conv2d(model.transformer_lora)
 
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,

--- a/modules/modelSetup/BaseZImageSetup.py
+++ b/modules/modelSetup/BaseZImageSetup.py
@@ -54,13 +54,6 @@ class BaseZImageSetup(
                 model.text_encoder_offload_conductor = \
                     enable_checkpointing_for_qwen3_encoder_layers(model.text_encoder, config)
 
-        if config.force_circular_padding:
-            raise NotImplementedError #TODO applies to Z-Image?
-#            apply_circular_padding_to_conv2d(model.vae)
-#            apply_circular_padding_to_conv2d(model.transformer)
-#            if model.transformer_lora is not None:
-#                apply_circular_padding_to_conv2d(model.transformer_lora)
-
         model.autocast_context, model.train_dtype = create_autocast_context(self.train_device, config.train_dtype, [
             config.weight_dtypes().transformer,
             config.weight_dtypes().text_encoder,

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -93,7 +93,7 @@ class TrainingTab:
         self.__create_text_encoder_frame(column_0, 1)
         self.__create_embedding_frame(column_0, 2)
 
-        self.__create_base2_frame(column_1, 0)
+        self.__create_base2_frame(column_1, 0, supports_circular_padding=True)
         self.__create_unet_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2, supports_generalized_offset_noise=True)
 
@@ -122,7 +122,7 @@ class TrainingTab:
         self.__create_text_encoder_n_frame(column_0, 2, i=2)
         self.__create_embedding_frame(column_0, 3)
 
-        self.__create_base2_frame(column_1, 0)
+        self.__create_base2_frame(column_1, 0, supports_circular_padding=True)
         self.__create_unet_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2, supports_generalized_offset_noise=True)
 
@@ -135,7 +135,7 @@ class TrainingTab:
         self.__create_text_encoder_frame(column_0, 1)
         self.__create_embedding_frame(column_0, 2)
 
-        self.__create_base2_frame(column_1, 0)
+        self.__create_base2_frame(column_1, 0, supports_circular_padding=True)
         self.__create_prior_frame(column_1, 1)
         self.__create_noise_frame(column_1, 2)
 
@@ -335,7 +335,7 @@ class TrainingTab:
                          tooltip="Clips the gradient norm. Leave empty to disable gradient clipping.")
         components.entry(frame, 10, 1, self.ui_state, "clip_grad_norm")
 
-    def __create_base2_frame(self, master, row, video_training_enabled: bool = False):
+    def __create_base2_frame(self, master, row, video_training_enabled: bool=False, supports_circular_padding: bool=False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)
         frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
         frame.grid_columnconfigure(0, weight=1)
@@ -415,9 +415,10 @@ class TrainingTab:
             row += 1
 
         # force circular padding
-        components.label(frame, row, 0, "Force Circular Padding",
-                         tooltip="Enables circular padding for all conv layers to better train seamless images")
-        components.switch(frame, row, 1, self.ui_state, "force_circular_padding")
+        if supports_circular_padding:
+            components.label(frame, row, 0, "Force Circular Padding",
+                             tooltip="Enables circular padding for all conv layers to better train seamless images")
+            components.switch(frame, row, 1, self.ui_state, "force_circular_padding")
 
     def __create_text_encoder_frame(self, master, row, supports_clip_skip=True, supports_training=True, supports_sequence_length=False):
         frame = ctk.CTkFrame(master=master, corner_radius=5)


### PR DESCRIPTION
Circular padding depends on conv2d layers in the image models.
Remove for all transformer models.
