### PR TITLE
Upgrade diffusers for faster z-image training

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -21,7 +21,7 @@ tensorboard==2.20.0
 pytorch-lightning==2.6.1
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@99daaa8#egg=diffusers
+-e git+https://github.com/huggingface/diffusers.git@da6718f#egg=diffusers
 gguf==0.17.1
 transformers==4.57.6
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading


### PR DESCRIPTION
speeds up Z-image by up to 25% because of https://github.com/huggingface/diffusers/pull/12955

it speeds up attention, therefore the most benefit get higher resolutions. speed-up for 512px is not that much.