### PR TITLE
fix: filter concept uploads to cloud to training-relevant files only

### DIFF
--- a/modules/cloud/BaseCloud.py
+++ b/modules/cloud/BaseCloud.py
@@ -2,6 +2,7 @@ import json
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 
+from modules.util import path_util
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
 from modules.util.config.CloudConfig import CloudConfig
@@ -54,6 +55,7 @@ class BaseCloud(metaclass=ABCMeta):
             if hasattr(add_embedding,"local_model_name"):
                 self.file_sync.sync_up(local=Path(add_embedding.local_model_name),remote=Path(add_embedding.model_name))
 
+        concept_extensions = path_util.supported_image_extensions() | path_util.supported_video_extensions() | {'.txt'}
         for concept in self.config.concepts:
             print(f"uploading concept {concept.name}...")
             if commands and commands.get_stop_command():
@@ -63,7 +65,9 @@ class BaseCloud(metaclass=ABCMeta):
                 self.file_sync.sync_up_dir(
                     local=Path(concept.local_path),
                     remote=Path(concept.path),
-                    recursive=concept.include_subdirectories)
+                    recursive=concept.include_subdirectories,
+                    skip_hidden=True,
+                    allowed_extensions=concept_extensions)
 
             if hasattr(concept.text,"local_prompt_path"):
                 self.file_sync.sync_up_file(local=Path(concept.text.local_prompt_path),remote=Path(concept.text.prompt_path))

--- a/modules/cloud/BaseCloud.py
+++ b/modules/cloud/BaseCloud.py
@@ -55,7 +55,7 @@ class BaseCloud(metaclass=ABCMeta):
             if hasattr(add_embedding,"local_model_name"):
                 self.file_sync.sync_up(local=Path(add_embedding.local_model_name),remote=Path(add_embedding.model_name))
 
-        concept_extensions = path_util.supported_image_extensions() | path_util.supported_video_extensions() | {'.txt'}
+        concept_extensions = path_util.supported_image_extensions() | path_util.supported_video_extensions() | path_util.supported_caption_extensions()
         for concept in self.config.concepts:
             print(f"uploading concept {concept.name}...")
             if commands and commands.get_stop_command():

--- a/modules/cloud/BaseFileSync.py
+++ b/modules/cloud/BaseFileSync.py
@@ -25,7 +25,7 @@ class BaseFileSync(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def sync_up_dir(self,local : Path,remote: Path,recursive: bool,
+    def sync_up_dir(self,local : Path,remote: Path,recursive: bool,sync_info=None,
                     skip_hidden: bool=False, allowed_extensions: set[str] | None=None):
         pass
 

--- a/modules/cloud/BaseFileSync.py
+++ b/modules/cloud/BaseFileSync.py
@@ -25,7 +25,8 @@ class BaseFileSync(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def sync_up_dir(self,local : Path,remote: Path,recursive: bool):
+    def sync_up_dir(self,local : Path,remote: Path,recursive: bool,
+                    skip_hidden: bool=False, allowed_extensions: set[str] | None=None):
         pass
 
     @abstractmethod

--- a/modules/cloud/BaseSSHFileSync.py
+++ b/modules/cloud/BaseSSHFileSync.py
@@ -46,7 +46,8 @@ class BaseSSHFileSync(BaseFileSync):
         self.upload_file(local_file=local,remote_file=remote)
 
 
-    def sync_up_dir(self,local : Path,remote: Path,recursive: bool,sync_info=None):
+    def sync_up_dir(self,local : Path,remote: Path,recursive: bool,sync_info=None,
+                    skip_hidden: bool=False, allowed_extensions: set[str] | None=None):
         if sync_info is None:
             sync_info=self.__get_sync_info(remote)
         self.sync_connection.open()
@@ -54,11 +55,17 @@ class BaseSSHFileSync(BaseFileSync):
         files=[]
         for local_entry in local.iterdir():
             if local_entry.is_file():
+                if allowed_extensions is not None and local_entry.suffix.lower() not in allowed_extensions:
+                    continue
                 remote_entry=remote/local_entry.name
                 if self.__needs_upload(local=local_entry,remote=remote_entry,sync_info=sync_info):
                     files.append(local_entry)
             elif recursive and local_entry.is_dir():
-                self.sync_up_dir(local=local_entry,remote=remote/local_entry.name,recursive=True,sync_info=sync_info)
+                if skip_hidden and local_entry.name.startswith('.'):
+                    continue
+                self.sync_up_dir(local=local_entry,remote=remote/local_entry.name,recursive=True,
+                                 sync_info=sync_info,skip_hidden=skip_hidden,
+                                 allowed_extensions=allowed_extensions)
 
         self.upload_files(local_files=files,remote_dir=remote)
 

--- a/modules/util/path_util.py
+++ b/modules/util/path_util.py
@@ -36,6 +36,7 @@ def write_json_atomic(path: str, obj: Any):
 
 SUPPORTED_IMAGE_EXTENSIONS = {'.bmp', '.jpg', '.jpeg', '.png', '.tif', '.tiff', '.webp', '.avif'}
 SUPPORTED_VIDEO_EXTENSIONS = {'.webm', '.mkv', '.flv', '.avi', '.mov', '.wmv', '.mp4', '.mpeg', '.m4v'}
+SUPPORTED_CAPTION_EXTENSIONS = {'.txt'}
 
 
 def supported_image_extensions() -> set[str]:
@@ -52,3 +53,7 @@ def supported_video_extensions() -> set[str]:
 
 def is_supported_video_extension(extension: str) -> bool:
     return extension.lower() in SUPPORTED_VIDEO_EXTENSIONS
+
+
+def supported_caption_extensions() -> set[str]:
+    return SUPPORTED_CAPTION_EXTENSIONS


### PR DESCRIPTION
## Summary
- Cloud concept uploads previously transferred every file and directory indiscriminately, including hidden directories (`.thumbnails`, `.trash`, `.index`, etc.) and non-training files (archives, databases, etc.)
- With large dataset folders this causes uploads to appear stuck at extremely low throughput due to per-file SCP/SFTP overhead on hundreds of thousands of irrelevant files
- Concept uploads now skip hidden directories and only transfer files with supported image/video extensions and `.txt` caption files

## Files changed
- `modules/cloud/BaseSSHFileSync.py` - `sync_up_dir()` gains optional `skip_hidden` and `allowed_extensions` parameters
- `modules/cloud/BaseFileSync.py` - updated abstract signature to match
- `modules/cloud/BaseCloud.py` - concept uploads pass `skip_hidden=True` and the set of training-relevant extensions