### PR TITLE
Integrate SmartDiskCache for hash-based persistent caching

### DIFF
--- a/modules/dataLoader/BaseDataLoader.py
+++ b/modules/dataLoader/BaseDataLoader.py
@@ -31,6 +31,7 @@ class BaseDataLoader(
 
         self.train_device = train_device
         self.temp_device = temp_device
+        self.stop_check_fun = lambda: False
 
         if is_validation:
             config = copy.copy(config)

--- a/modules/dataLoader/Flux2BaseDataLoader.py
+++ b/modules/dataLoader/Flux2BaseDataLoader.py
@@ -1,7 +1,7 @@
 import os
 
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
-from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin, text_encode_batch_size
 from modules.model.Flux2Model import (
     MISTRAL_HIDDEN_STATES_LAYERS,
     MISTRAL_SYSTEM_MESSAGE,
@@ -39,24 +39,33 @@ class Flux2BaseDataLoader(
         encode_image = EncodeVAE(in_name='image', out_name='latent_image_distribution', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         image_sample = SampleVAEDistribution(in_name='latent_image_distribution', out_name='latent_image', mode='mean')
         downscale_mask = ScaleImage(in_name='mask', out_name='latent_mask', factor=0.125)
+        # Collector only - no trim_padding: this pipeline caches the full
+        # padded hidden state, so padded rows must remain the encoder's own
+        # outputs. Batching is the win that matters here anyway: one
+        # weight-stream per batch through the 24B Mistral (dev) instead of
+        # one per caption.
+        text_encode_batch = text_encode_batch_size()
+        use_batch_collector = config.latent_caching and text_encode_batch > 1
         if model.is_dev():
             tokenize_prompt = Tokenize(in_name='prompt', tokens_out_name='tokens', mask_out_name='tokens_mask', tokenizer=model.tokenizer, max_token_length=config.text_encoder_sequence_length,
                                         apply_chat_template = lambda caption: mistral_format_input([caption], MISTRAL_SYSTEM_MESSAGE), apply_chat_template_kwargs = {'add_generation_prompt': False},
                                       )
-            if config.dataloader_threads > 1:
+            if config.dataloader_threads > 1 or use_batch_collector:
                 apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
             encode_prompt = EncodeMistralText(tokens_name='tokens', tokens_attention_mask_in_name='tokens_mask', hidden_state_out_name='text_encoder_hidden_state', tokens_attention_mask_out_name='tokens_mask',
                                               text_encoder=model.text_encoder, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(),
                                               hidden_state_output_index=MISTRAL_HIDDEN_STATES_LAYERS,
+                                              batch_collector=use_batch_collector, max_batch_size=text_encode_batch,
                                              )
         else: #klein
             tokenize_prompt = Tokenize(in_name='prompt', tokens_out_name='tokens', mask_out_name='tokens_mask', tokenizer=model.tokenizer, max_token_length=config.text_encoder_sequence_length,
                                         apply_chat_template = lambda caption: qwen3_format_input(caption), apply_chat_template_kwargs = {'add_generation_prompt': True, 'enable_thinking': False}
                                       )
-            if config.dataloader_threads > 1:
+            if config.dataloader_threads > 1 or use_batch_collector:
                 apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
             encode_prompt = EncodeQwenText(tokens_name='tokens', tokens_attention_mask_in_name='tokens_mask', hidden_state_out_name='text_encoder_hidden_state', tokens_attention_mask_out_name='tokens_mask',
-                                           text_encoder=model.text_encoder, hidden_state_output_index=QWEN3_HIDDEN_STATES_LAYERS, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
+                                           text_encoder=model.text_encoder, hidden_state_output_index=QWEN3_HIDDEN_STATES_LAYERS, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(),
+                                           batch_collector=use_batch_collector, max_batch_size=text_encode_batch)
 
 
         modules = [rescale_image, encode_image, image_sample]
@@ -91,6 +100,9 @@ class Flux2BaseDataLoader(
             sort_names=sort_names,
             config=config,
             text_caching=True,
+            # Match the encoder's batch collector so a full batch of encode
+            # requests can be in flight during the text cache build.
+            text_cache_build_workers=text_encode_batch_size() if config.latent_caching else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: Flux2Model, model_setup: BaseFlux2Setup):

--- a/modules/dataLoader/HiDreamBaseDataLoader.py
+++ b/modules/dataLoader/HiDreamBaseDataLoader.py
@@ -2,7 +2,7 @@ import os
 
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
 from modules.dataLoader.flux.ShuffleFluxFillMaskChannels import ShuffleFluxFillMaskChannels
-from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin, text_encode_batch_size
 from modules.model.BaseModel import BaseModel
 from modules.model.HiDreamModel import HiDreamModel
 from modules.modelSetup.BaseHiDreamSetup import BaseHiDreamSetup
@@ -10,6 +10,7 @@ from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
+from modules.util.thread_safety import apply_thread_safe_forward
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.pipelineModules.DecodeTokens import DecodeTokens
@@ -57,8 +58,20 @@ class HiDreamBaseDataLoader(
         encode_prompt_3 = EncodeT5Text(tokens_in_name='tokens_3', tokens_attention_mask_in_name=None, hidden_state_out_name='text_encoder_3_hidden_state', pooled_out_name=None, add_layer_norm=True,
                                        text_encoder=model.text_encoder_3, hidden_state_output_index=-(1 + config.text_encoder_3_layer_skip), autocast_contexts=[model.autocast_context, model.text_encoder_3_autocast_context],
                                        dtype=model.text_encoder_3_train_dtype.torch_dtype())
+        # Batch concurrent cache-build encodes through the 8B Llama; the CLIP
+        # and T5 encoders stay bs=1 but get the thread-safe forward wrapper so
+        # the widened text cache build pool can drive them from multiple
+        # threads (transformers#42673). Collector only, no trim_padding: this
+        # pipeline caches full padded hidden states.
+        text_encode_batch = text_encode_batch_size()
+        use_batch_collector = config.latent_caching and text_encode_batch > 1
+        if config.dataloader_threads > 1 or text_encode_batch > 1:
+            for text_encoder in [model.text_encoder_1, model.text_encoder_2, model.text_encoder_3, model.text_encoder_4]:
+                if text_encoder is not None:
+                    apply_thread_safe_forward(text_encoder)
         encode_prompt_4 = EncodeLlamaText(tokens_name='tokens_4', tokens_attention_mask_in_name='tokens_mask_4', hidden_state_out_name='text_encoder_4_hidden_state', tokens_attention_mask_out_name='tokens_mask_4', text_encoder=model.text_encoder_4,
-                                          output_all_hidden_states=True, all_hidden_state_output_indices=model.transformer.config.llama_layers, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
+                                          output_all_hidden_states=True, all_hidden_state_output_indices=model.transformer.config.llama_layers, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(),
+                                          batch_collector=use_batch_collector, max_batch_size=text_encode_batch)
 
         modules = [rescale_image, encode_image, image_sample]
         if config.model_type.has_mask_input():
@@ -136,6 +149,9 @@ class HiDreamBaseDataLoader(
                       or not config.train_text_encoder_2_or_embedding() \
                       or not config.train_text_encoder_3_or_embedding() \
                       or not config.train_text_encoder_4_or_embedding(),
+            # Match the Llama encoder's batch collector so a full batch of
+            # encode requests can be in flight during the text cache build.
+            text_cache_build_workers=text_encode_batch_size() if config.latent_caching else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: HiDreamModel, model_setup: BaseHiDreamSetup):

--- a/modules/dataLoader/HunyuanVideoBaseDataLoader.py
+++ b/modules/dataLoader/HunyuanVideoBaseDataLoader.py
@@ -1,7 +1,7 @@
 import os
 
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
-from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin, text_encode_batch_size
 from modules.model.BaseModel import BaseModel
 from modules.model.HunyuanVideoModel import (
     DEFAULT_PROMPT_TEMPLATE,
@@ -13,6 +13,7 @@ from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
+from modules.util.thread_safety import apply_thread_safe_forward
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.pipelineModules.DecodeTokens import DecodeTokens
@@ -43,8 +44,20 @@ class HunyuanVideoBaseDataLoader(
         tokenize_prompt_1 = Tokenize(in_name='prompt_1', tokens_out_name='tokens_1', mask_out_name='tokens_mask_1', tokenizer=model.tokenizer_1, max_token_length=77,
                                      format_text=DEFAULT_PROMPT_TEMPLATE, additional_format_text_tokens=DEFAULT_PROMPT_TEMPLATE_CROP_START)
         tokenize_prompt_2 = Tokenize(in_name='prompt_2', tokens_out_name='tokens_2', mask_out_name='tokens_mask_2', tokenizer=model.tokenizer_2, max_token_length=77)
+        # Batch concurrent cache-build encodes through the Llama encoder; the
+        # CLIP encoder stays bs=1 but gets the thread-safe forward wrapper so
+        # the widened text cache build pool can drive it from multiple threads
+        # (transformers#42673). Collector only, no trim_padding: this pipeline
+        # caches full padded hidden states.
+        text_encode_batch = text_encode_batch_size()
+        use_batch_collector = config.latent_caching and text_encode_batch > 1
+        if config.dataloader_threads > 1 or text_encode_batch > 1:
+            for text_encoder in [model.text_encoder_1, model.text_encoder_2]:
+                if text_encoder is not None:
+                    apply_thread_safe_forward(text_encoder)
         encode_prompt_1 = EncodeLlamaText(tokens_name='tokens_1', tokens_attention_mask_in_name='tokens_mask_1', hidden_state_out_name='text_encoder_1_hidden_state', tokens_attention_mask_out_name='tokens_mask_1', text_encoder=model.text_encoder_1,
-                                          hidden_state_output_index=-(1 + config.text_encoder_2_layer_skip), autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(), crop_start=DEFAULT_PROMPT_TEMPLATE_CROP_START)
+                                          hidden_state_output_index=-(1 + config.text_encoder_2_layer_skip), autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(), crop_start=DEFAULT_PROMPT_TEMPLATE_CROP_START,
+                                          batch_collector=use_batch_collector, max_batch_size=text_encode_batch)
         encode_prompt_2 = EncodeClipText(in_name='tokens_2', tokens_attention_mask_in_name=None, hidden_state_out_name='text_encoder_2_hidden_states', pooled_out_name='text_encoder_2_pooled_state', add_layer_norm=False,
                                          text_encoder=model.text_encoder_2, hidden_state_output_index=-(2 + config.text_encoder_layer_skip), autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
 
@@ -98,6 +111,9 @@ class HunyuanVideoBaseDataLoader(
             sort_names=sort_names,
             config=config,
             text_caching=not config.train_text_encoder_or_embedding() or not config.train_text_encoder_2_or_embedding(),
+            # Match the Llama encoder's batch collector so a full batch of
+            # encode requests can be in flight during the text cache build.
+            text_cache_build_workers=text_encode_batch_size() if config.latent_caching else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: HunyuanVideoModel, model_setup: BaseHunyuanVideoSetup):

--- a/modules/dataLoader/QwenBaseDataLoader.py
+++ b/modules/dataLoader/QwenBaseDataLoader.py
@@ -1,7 +1,7 @@
 import os
 
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
-from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin, text_encode_batch_size
 from modules.model.BaseModel import BaseModel
 from modules.model.QwenModel import (
     DEFAULT_PROMPT_TEMPLATE,
@@ -14,6 +14,7 @@ from modules.modelSetup.BaseQwenSetup import BaseQwenSetup
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
+from modules.util.thread_safety import apply_thread_safe_forward
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.pipelineModules.DecodeTokens import DecodeTokens
@@ -41,8 +42,19 @@ class QwenBaseDataLoader(
         downscale_mask = ScaleImage(in_name='mask', out_name='latent_mask', factor=0.125)
         tokenize_prompt = Tokenize(in_name='prompt', tokens_out_name='tokens', mask_out_name='tokens_mask', tokenizer=model.tokenizer, max_token_length=PROMPT_MAX_LENGTH,
                                    format_text=DEFAULT_PROMPT_TEMPLATE, additional_format_text_tokens=DEFAULT_PROMPT_TEMPLATE_CROP_START)
+        # Mirrors the Z-Image wiring: PruneMaskedTokens (added below under the
+        # same condition) discards every padded hidden-state row before the
+        # cache stores it, so trimming the padding off the forward and
+        # batching concurrent cache-build encodes yield equivalent cached
+        # artifacts. crop_start composes with trim: one slices the template
+        # head after encoding, the other skips the padded tail.
+        text_caching_active = config.latent_caching and not config.train_text_encoder_or_embedding()
+        text_encode_batch = text_encode_batch_size()
+        if text_caching_active and (config.dataloader_threads > 1 or text_encode_batch > 1):
+            apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
         encode_prompt = EncodeQwenText(tokens_name='tokens', tokens_attention_mask_in_name='tokens_mask', hidden_state_out_name='text_encoder_hidden_state', tokens_attention_mask_out_name='tokens_mask',
-                                       text_encoder=model.text_encoder, hidden_state_output_index=-1, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(), crop_start=DEFAULT_PROMPT_TEMPLATE_CROP_START)
+                                       text_encoder=model.text_encoder, hidden_state_output_index=-1, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(), crop_start=DEFAULT_PROMPT_TEMPLATE_CROP_START,
+                                       trim_padding=text_caching_active, batch_collector=text_caching_active and text_encode_batch > 1, max_batch_size=text_encode_batch)
         prune_masked_tokens = PruneMaskedTokens(tokens_name='tokens', tokens_mask_name='tokens_mask', hidden_state_name='text_encoder_hidden_state')
 
         modules = [rescale_image, encode_image, image_sample]
@@ -85,6 +97,9 @@ class QwenBaseDataLoader(
             sort_names=sort_names,
             config=config,
             text_caching=not config.train_text_encoder_or_embedding(),
+            # Match the encoder's batch collector so a full batch of encode
+            # requests can be in flight during the text cache build.
+            text_cache_build_workers=text_encode_batch_size() if config.latent_caching and not config.train_text_encoder_or_embedding() else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: QwenModel, model_setup: BaseQwenSetup):

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -17,7 +17,7 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 from mgds.pipelineModules.CalcAspect import CalcAspect
 from mgds.pipelineModules.CollectPaths import CollectPaths
 from mgds.pipelineModules.DecodeVAE import DecodeVAE
-from mgds.pipelineModules.DiskCache import DiskCache
+from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.EncodeVAE import EncodeVAE
 from mgds.pipelineModules.InlineAspectBatchSorting import InlineAspectBatchSorting
 from mgds.pipelineModules.LoadImage import LoadImage
@@ -190,8 +190,10 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         def before_cache_fun():
             self._setup_cache_device(model, self.train_device, self.temp_device, config)
 
-        disk_cache = DiskCache(cache_dir=config.cache_dir, split_names=split_names, aggregate_names=aggregate_names, variations_in_name='concept.image_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
-                               variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_fun)
+        disk_cache = SmartDiskCache(cache_dir=config.cache_dir, split_names=split_names, aggregate_names=aggregate_names, variations_in_name='concept.image_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
+                                   variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_fun,
+                                   modeltype=config.model_type.value, source_path_in_name='image_path',
+                                   sourceless=config.sourceless_training and config.latent_caching)
         variation_sorting = VariationSorting(names=sort_names, balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'],
                                group_enabled_in_name='concept.enabled')
 
@@ -263,6 +265,17 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
             train_progress: TrainProgress,
             is_validation: bool = False,
     ):
+        cache_modules = self.__cache_modules(config, model)
+        output_modules = self.__output_modules(config)
+
+        if config.sourceless_training and config.latent_caching:
+            return self._create_mgds(
+                config,
+                [cache_modules, output_modules],
+                train_progress,
+                is_validation,
+            )
+
         enumerate_input = self.__enumerate_input_modules(config)
         load_input = self.__load_input_modules(config)
         mask_augmentation = self.__mask_augmentation_modules(config)
@@ -270,8 +283,6 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         crop_modules = self.__crop_modules(config)
         augmentation_modules = self.__augmentation_modules(config)
         preparation_modules = self.__preparation_modules(config, model)
-        cache_modules = self.__cache_modules(config, model)
-        output_modules = self.__output_modules(config)
 
         debug_modules = self.__debug_modules(config, model)
 

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -191,7 +191,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
             self._setup_cache_device(model, self.train_device, self.temp_device, config)
 
         disk_cache = SmartDiskCache(cache_dir=config.cache_dir, split_names=split_names, aggregate_names=aggregate_names, variations_in_name='concept.image_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
-                                   variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_fun,
+                                   variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_fun, stop_check_fun=lambda: self.stop_check_fun(),
                                    modeltype=config.model_type.value, source_path_in_name='image_path',
                                    sourceless=config.sourceless_training and config.latent_caching)
         variation_sorting = VariationSorting(names=sort_names, balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'],

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -17,7 +17,6 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 from mgds.pipelineModules.CalcAspect import CalcAspect
 from mgds.pipelineModules.CollectPaths import CollectPaths
 from mgds.pipelineModules.DecodeVAE import DecodeVAE
-from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.EncodeVAE import EncodeVAE
 from mgds.pipelineModules.InlineAspectBatchSorting import InlineAspectBatchSorting
 from mgds.pipelineModules.LoadImage import LoadImage
@@ -34,6 +33,7 @@ from mgds.pipelineModules.SaveImage import SaveImage
 from mgds.pipelineModules.ScaleCropImage import ScaleCropImage
 from mgds.pipelineModules.ScaleImage import ScaleImage
 from mgds.pipelineModules.SingleAspectCalculation import SingleAspectCalculation
+from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.VariationSorting import VariationSorting
 
 import torch

--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -1,7 +1,7 @@
 import os
 
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
-from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.dataLoader.mixin.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin, text_encode_batch_size
 from modules.model.BaseModel import BaseModel
 from modules.model.ZImageModel import PROMPT_MAX_LENGTH, ZImageModel, format_input
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
@@ -26,20 +26,6 @@ from mgds.pipelineModules.ScaleImage import ScaleImage
 from mgds.pipelineModules.Tokenize import Tokenize
 
 
-def _text_encode_batch_size() -> int:
-    """Encode batch size and build worker count for the text cache.
-
-    Batching several captions per forward amortizes the per-forward fixed
-    cost (weight streaming under layer offload, dequant, kernel launches)
-    that dominates a bs=1 encode through the 4B Qwen encoder. Set
-    OT_TEXT_CACHE_BATCH=1 to restore strictly serial bs=1 encoding.
-    """
-    try:
-        return max(1, int(os.environ.get('OT_TEXT_CACHE_BATCH', '8')))
-    except ValueError:
-        return 8
-
-
 class ZImageBaseDataLoader(
     BaseDataLoader,
     DataLoaderText2ImageMixin,
@@ -52,7 +38,7 @@ class ZImageBaseDataLoader(
         tokenize_prompt = Tokenize(in_name='prompt', tokens_out_name='tokens', mask_out_name='tokens_mask', tokenizer=model.tokenizer, max_token_length=PROMPT_MAX_LENGTH,
                                     apply_chat_template = lambda caption: format_input(caption), apply_chat_template_kwargs = {'add_generation_prompt': True, 'enable_thinking': True}
                                   )
-        text_encode_batch = _text_encode_batch_size()
+        text_encode_batch = text_encode_batch_size()
         if config.dataloader_threads > 1 or text_encode_batch > 1:
             apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
         # trim_padding/batch_collector are gated on latent_caching:
@@ -105,7 +91,7 @@ class ZImageBaseDataLoader(
             text_caching=True,
             # Match the encoder's batch collector so a full batch of encode
             # requests can be in flight during the text cache build.
-            text_cache_build_workers=_text_encode_batch_size() if config.latent_caching else None,
+            text_cache_build_workers=text_encode_batch_size() if config.latent_caching else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: ZImageModel, model_setup: BaseZImageSetup):

--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -26,6 +26,20 @@ from mgds.pipelineModules.ScaleImage import ScaleImage
 from mgds.pipelineModules.Tokenize import Tokenize
 
 
+def _text_encode_batch_size() -> int:
+    """Encode batch size and build worker count for the text cache.
+
+    Batching several captions per forward amortizes the per-forward fixed
+    cost (weight streaming under layer offload, dequant, kernel launches)
+    that dominates a bs=1 encode through the 4B Qwen encoder. Set
+    OT_TEXT_CACHE_BATCH=1 to restore strictly serial bs=1 encoding.
+    """
+    try:
+        return max(1, int(os.environ.get('OT_TEXT_CACHE_BATCH', '8')))
+    except ValueError:
+        return 8
+
+
 class ZImageBaseDataLoader(
     BaseDataLoader,
     DataLoaderText2ImageMixin,
@@ -38,10 +52,18 @@ class ZImageBaseDataLoader(
         tokenize_prompt = Tokenize(in_name='prompt', tokens_out_name='tokens', mask_out_name='tokens_mask', tokenizer=model.tokenizer, max_token_length=PROMPT_MAX_LENGTH,
                                     apply_chat_template = lambda caption: format_input(caption), apply_chat_template_kwargs = {'add_generation_prompt': True, 'enable_thinking': True}
                                   )
-        if config.dataloader_threads > 1:
+        text_encode_batch = _text_encode_batch_size()
+        if config.dataloader_threads > 1 or text_encode_batch > 1:
             apply_thread_safe_forward(model.text_encoder)  # workaround for transformers#42673
+        # trim_padding/batch_collector are gated on latent_caching:
+        # PruneMaskedTokens then discards every padded hidden-state row before
+        # the cache stores it, so trimming the padding off the forward (and
+        # zero-filling those rows) yields an equivalent cached artifact.
+        # Without caching, padded rows flow to the trainer and must stay the
+        # encoder's own outputs.
         encode_prompt = EncodeQwenText(tokens_name='tokens', tokens_attention_mask_in_name='tokens_mask', hidden_state_out_name='text_encoder_hidden_state', tokens_attention_mask_out_name='tokens_mask',
-                                       text_encoder=model.text_encoder, hidden_state_output_index=-2, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
+                                       text_encoder=model.text_encoder, hidden_state_output_index=-2, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype(),
+                                       trim_padding=config.latent_caching, batch_collector=config.latent_caching and text_encode_batch > 1, max_batch_size=text_encode_batch)
         prune_masked_tokens = PruneMaskedTokens(tokens_name='tokens', tokens_mask_name='tokens_mask', hidden_state_name='text_encoder_hidden_state')
 
         modules = [rescale_image, encode_image, image_sample]
@@ -81,6 +103,9 @@ class ZImageBaseDataLoader(
             sort_names=sort_names,
             config=config,
             text_caching=True,
+            # Match the encoder's batch collector so a full batch of encode
+            # requests can be in flight during the text cache build.
+            text_cache_build_workers=_text_encode_batch_size() if config.latent_caching else None,
         )
 
     def _output_modules(self, config: TrainConfig, model: ZImageModel, model_setup: BaseZImageSetup):

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -55,6 +55,21 @@ import torch
 from diffusers import AutoencoderKL
 
 
+def text_encode_batch_size() -> int:
+    """Encode batch size and build worker count for text caches.
+
+    Batching several captions per forward amortizes the per-forward fixed
+    cost (weight streaming under layer offload, dequant, kernel launches)
+    that dominates a bs=1 encode through a multi-billion-parameter text
+    encoder. Set OT_TEXT_CACHE_BATCH=1 to restore strictly serial bs=1
+    encoding.
+    """
+    try:
+        return max(1, int(os.environ.get('OT_TEXT_CACHE_BATCH', '8')))
+    except ValueError:
+        return 8
+
+
 class DataLoaderText2ImageMixin(metaclass=ABCMeta):
     def _enumerate_input_modules(self, config: TrainConfig, allow_videos: bool = False) -> list:
         supported_extensions = set()

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -351,7 +351,8 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
 
         sourceless = config.sourceless_training and config.latent_caching
 
-        stop_check = lambda: self.stop_check_fun()
+        def stop_check():
+            return self.stop_check_fun()
 
         image_disk_cache = SmartDiskCache(cache_dir=image_cache_dir, split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
                                          balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'],

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -351,14 +351,16 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
 
         sourceless = config.sourceless_training and config.latent_caching
 
+        stop_check = lambda: self.stop_check_fun()
+
         image_disk_cache = SmartDiskCache(cache_dir=image_cache_dir, split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
                                          balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'],
-                                         group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun,
+                                         group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun, stop_check_fun=stop_check,
                                          modeltype=config.model_type.value, source_path_in_name='image_path', sourceless=sourceless)
 
         text_disk_cache = SmartDiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
-                                        variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun,
-                                        modeltype=config.model_type.value, source_path_in_name='prompt_path', sourceless=sourceless)
+                                        variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun, stop_check_fun=stop_check,
+                                        modeltype=config.model_type.value, source_path_in_name='image_path', sourceless=sourceless)
 
         modules = []
 

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -361,7 +361,7 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
 
         text_disk_cache = SmartDiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
                                         variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun, stop_check_fun=stop_check,
-                                        modeltype=config.model_type.value, source_path_in_name='image_path', sourceless=sourceless)
+                                        modeltype=config.model_type.value, source_path_in_name='sample_prompt_path', sourceless=sourceless)
 
         modules = []
 

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -334,6 +334,7 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
             config: TrainConfig,
             text_caching: bool,
             before_cache_image_fun: Callable[[], None] | None = None,
+            text_cache_build_workers: int | None = None,
     ):
         image_cache_dir = os.path.join(config.cache_dir, "image")
         text_cache_dir = os.path.join(config.cache_dir, "text")
@@ -359,9 +360,14 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
                                          group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun, stop_check_fun=stop_check,
                                          modeltype=config.model_type.value, source_path_in_name='image_path', sourceless=sourceless)
 
+        # content_key_in_name: the final post-augmentation prompt string fully
+        # determines the cached text payload, so identical caption lines are
+        # encoded once and reused across variations, files and concepts.
+        # Editing one line of a multi-line caption re-encodes only that line.
         text_disk_cache = SmartDiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
                                         variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun, stop_check_fun=stop_check,
-                                        modeltype=config.model_type.value, source_path_in_name='sample_prompt_path', sourceless=sourceless)
+                                        modeltype=config.model_type.value, source_path_in_name='sample_prompt_path', sourceless=sourceless,
+                                        content_key_in_name='prompt', build_max_workers=text_cache_build_workers)
 
         modules = []
 

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -398,6 +398,11 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
         output_modules = self._output_modules(config, model, model_setup)
 
         if config.sourceless_training and config.latent_caching:
+            if hasattr(config, 'train_text_encoder_or_embedding') and config.train_text_encoder_or_embedding():
+                raise RuntimeError(
+                    "Sourceless training cannot be used with text encoder training. "
+                    "Disable sourceless_training or disable text encoder training."
+                )
             return self._create_mgds(
                 config,
                 [cache_modules, output_modules],

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -19,7 +19,7 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 from mgds.pipelineModules.CalcAspect import CalcAspect
 from mgds.pipelineModules.CapitalizeTags import CapitalizeTags
 from mgds.pipelineModules.CollectPaths import CollectPaths
-from mgds.pipelineModules.DiskCache import DiskCache
+from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.DistributedSampler import DistributedSampler
 from mgds.pipelineModules.DownloadHuggingfaceDatasets import DownloadHuggingfaceDatasets
 from mgds.pipelineModules.DropTags import DropTags
@@ -349,12 +349,16 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
         def before_cache_text_fun():
             model_setup.prepare_text_caching(model, config)
 
-        image_disk_cache = DiskCache(cache_dir=image_cache_dir, split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
-                                     balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'],
-                                     group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun)
+        sourceless = config.sourceless_training and config.latent_caching
 
-        text_disk_cache = DiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
-                                    variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun)
+        image_disk_cache = SmartDiskCache(cache_dir=image_cache_dir, split_names=image_split_names, aggregate_names=image_aggregate_names, variations_in_name='concept.image_variations',
+                                         balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy', variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.image'],
+                                         group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_image_fun,
+                                         modeltype=config.model_type.value, source_path_in_name='image_path', sourceless=sourceless)
+
+        text_disk_cache = SmartDiskCache(cache_dir=text_cache_dir, split_names=text_split_names, aggregate_names=[], variations_in_name='concept.text_variations', balancing_in_name='concept.balancing', balancing_strategy_in_name='concept.balancing_strategy',
+                                        variations_group_in_name=['concept.path', 'concept.seed', 'concept.include_subdirectories', 'concept.text'], group_enabled_in_name='concept.enabled', before_cache_fun=before_cache_text_fun,
+                                        modeltype=config.model_type.value, source_path_in_name='prompt_path', sourceless=sourceless)
 
         modules = []
 
@@ -390,6 +394,17 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
             vae_frame_dim: bool=False,
             supports_inpainting: bool=True, #TODO many models probably don't support inpainting, but this has been enabled in most dataloaders before refactoring, too
     ):
+        cache_modules = self._cache_modules(config, model, model_setup)
+        output_modules = self._output_modules(config, model, model_setup)
+
+        if config.sourceless_training and config.latent_caching:
+            return self._create_mgds(
+                config,
+                [cache_modules, output_modules],
+                train_progress,
+                is_validation,
+            )
+
         enumerate_input = self._enumerate_input_modules(config, allow_videos=allow_video_files)
         load_input = self._load_input_modules(config, model.train_dtype, vae_frame_dim=vae_frame_dim)
         mask_augmentation = self._mask_augmentation_modules(config)
@@ -399,8 +414,6 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
         if supports_inpainting:
             inpainting_modules = self._inpainting_modules(config)
         preparation_modules = self._preparation_modules(config, model)
-        cache_modules = self._cache_modules(config, model, model_setup)
-        output_modules = self._output_modules(config, model, model_setup)
 
         debug_modules = self._debug_modules(config, model)
 
@@ -419,7 +432,6 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
                 output_modules,
 
                 debug_modules if config.debug_mode else None,
-                # inserted before output_modules, which contains a sorting operation
             ],
             train_progress,
             is_validation

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -19,7 +19,6 @@ from mgds.pipelineModules.AspectBucketing import AspectBucketing
 from mgds.pipelineModules.CalcAspect import CalcAspect
 from mgds.pipelineModules.CapitalizeTags import CapitalizeTags
 from mgds.pipelineModules.CollectPaths import CollectPaths
-from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.DistributedSampler import DistributedSampler
 from mgds.pipelineModules.DownloadHuggingfaceDatasets import DownloadHuggingfaceDatasets
 from mgds.pipelineModules.DropTags import DropTags
@@ -48,6 +47,7 @@ from mgds.pipelineModules.SelectInput import SelectInput
 from mgds.pipelineModules.SelectRandomText import SelectRandomText
 from mgds.pipelineModules.ShuffleTags import ShuffleTags
 from mgds.pipelineModules.SingleAspectCalculation import SingleAspectCalculation
+from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
 from mgds.pipelineModules.VariationSorting import VariationSorting
 
 import torch

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import modules.util.multi_gpu_util as multi
+from mgds.pipelineModules.SmartDiskCache import CachingStoppedException
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
 from modules.model.BaseModel import BaseModel
 from modules.modelLoader.BaseModelLoader import BaseModelLoader
@@ -148,6 +149,7 @@ class GenericTrainer(BaseTrainer):
         self.data_loader = self.create_data_loader(
             self.model, self.model_setup, self.model.train_progress
         )
+        self.data_loader.stop_check_fun = self.commands.get_stop_command
         self.model_saver = self.create_model_saver()
 
         self.model_sampler = self.create_model_sampler(self.model)
@@ -641,14 +643,16 @@ class GenericTrainer(BaseTrainer):
                 return
             self.callbacks.on_update_status("Starting epoch/caching")
 
-            #call start_next_epoch with only one process at first, because it might write to the cache. All subsequent processes can read in parallel:
-            for _ in multi.master_first():
-                if self.config.latent_caching:
-                    self.data_loader.get_data_set().start_next_epoch()
-                    self.model_setup.setup_train_device(self.model, self.config)
-                else:
-                    self.model_setup.setup_train_device(self.model, self.config)
-                    self.data_loader.get_data_set().start_next_epoch()
+            try:
+                for _ in multi.master_first():
+                    if self.config.latent_caching:
+                        self.data_loader.get_data_set().start_next_epoch()
+                        self.model_setup.setup_train_device(self.model, self.config)
+                    else:
+                        self.model_setup.setup_train_device(self.model, self.config)
+                        self.data_loader.get_data_set().start_next_epoch()
+            except CachingStoppedException:
+                return
 
             if self.config.debug_mode:
                 multi.warn_parameter_divergence(self.parameters, train_device)

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -9,7 +9,6 @@ from collections.abc import Callable
 from pathlib import Path
 
 import modules.util.multi_gpu_util as multi
-from mgds.pipelineModules.SmartDiskCache import CachingStoppedException
 from modules.dataLoader.BaseDataLoader import BaseDataLoader
 from modules.model.BaseModel import BaseModel
 from modules.modelLoader.BaseModelLoader import BaseModelLoader
@@ -34,6 +33,8 @@ from modules.util.profiling_util import TorchMemoryRecorder, TorchProfiler
 from modules.util.time_util import get_string_timestamp
 from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
+
+from mgds.pipelineModules.SmartDiskCache import CachingStoppedException
 
 import torch
 from torch import Tensor, nn

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -171,7 +171,8 @@ class GenericTrainer(BaseTrainer):
     def __clear_cache(self):
         print(
             f'Clearing cache directory {self.config.cache_dir}! '
-            f'You can disable this if you want to continue using the same cache.'
+            f'SmartCache validates files incrementally, so this is usually unnecessary. '
+            f'Disable "Clear cache before training" to keep your validated cache.'
         )
         if os.path.isdir(self.config.cache_dir):
             for filename in os.listdir(self.config.cache_dir):

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -365,7 +365,7 @@ class TrainUI(ctk.CTk):
 
         # clear cache before training
         components.label(frame, 2, 0, "Clear cache before training",
-                         tooltip="Clears the cache directory before starting to train. Only disable this if you want to continue using the same cached data. Disabling this can lead to errors, if other settings are changed during a restart")
+                         tooltip="Clears the cache directory before starting to train. SmartCache validates files incrementally, so this is usually unnecessary. Model type changes are detected automatically")
         components.switch(frame, 2, 1, self.ui_state, "clear_cache_before_training")
 
         # sourceless training

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -116,6 +116,7 @@ class TrainUI(ctk.CTk):
         self.eta_label = None
         self.training_button = None
         self.export_button = None
+        self.clean_button = None
         self.tabview = None
 
         self.model_tab = None
@@ -376,7 +377,7 @@ class TrainUI(ctk.CTk):
         # clean cache
         components.label(frame, 3, 3, "Clean Cache",
                          tooltip="Remove orphaned cache files from datasets that have been edited. Shows a preview before deleting anything")
-        components.button(frame, 3, 4, "Clean", self.__clean_cache)
+        self.clean_button = components.button(frame, 3, 4, "Clean", self.__clean_cache)
 
         frame.pack(fill="both", expand=1)
         return frame
@@ -799,6 +800,8 @@ class TrainUI(ctk.CTk):
                 return
 
             self._set_training_button_running()
+            if self.clean_button:
+                self.clean_button.configure(state="disabled")
 
             if self.train_config.tensorboard and not self.train_config.tensorboard_always_on and self.always_on_tensorboard_subprocess:
                 self._stop_always_on_tensorboard()
@@ -919,6 +922,8 @@ class TrainUI(ctk.CTk):
 
     def _set_training_button_idle(self):
         self._set_training_button_style("idle")
+        if self.clean_button:
+            self.clean_button.configure(state="normal")
 
     def _set_training_button_running(self):
         self._set_training_button_style("running")

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -368,6 +368,16 @@ class TrainUI(ctk.CTk):
                          tooltip="Clears the cache directory before starting to train. Only disable this if you want to continue using the same cached data. Disabling this can lead to errors, if other settings are changed during a restart")
         components.switch(frame, 2, 1, self.ui_state, "clear_cache_before_training")
 
+        # sourceless training
+        components.label(frame, 3, 0, "Sourceless Training",
+                         tooltip="Train from cached data only, without source images or text files. Requires a cache built with the latest version. Useful for sharing datasets without distributing original files")
+        components.switch(frame, 3, 1, self.ui_state, "sourceless_training")
+
+        # clean cache
+        components.label(frame, 3, 3, "Clean Cache",
+                         tooltip="Remove orphaned cache files from datasets that have been edited. Shows a preview before deleting anything")
+        components.button(frame, 3, 4, "Clean", self.__clean_cache)
+
         frame.pack(fill="both", expand=1)
         return frame
 
@@ -700,6 +710,34 @@ class TrainUI(ctk.CTk):
             )
             self.wait_window(window)
             training_callbacks.set_on_sample_custom()
+
+    def __clean_cache(self):
+        cache_dir = self.train_config.cache_dir
+        if not os.path.isdir(cache_dir):
+            messagebox.showinfo("Clean Cache", "No cache directory found.")
+            return
+
+        from mgds.pipelineModules.SmartDiskCache import SmartDiskCache
+        text_stats = SmartDiskCache.gc_preview(os.path.join(cache_dir, "text"))
+        image_stats = SmartDiskCache.gc_preview(os.path.join(cache_dir, "image"))
+
+        total_files = text_stats['orphan_count'] + image_stats['orphan_count']
+        total_mb = (text_stats['orphan_bytes'] + image_stats['orphan_bytes']) / (1024 * 1024)
+
+        if total_files == 0:
+            messagebox.showinfo("Clean Cache", "No orphaned cache files found.")
+            return
+
+        msg = (
+            f"Will remove {text_stats['orphan_count']} orphaned text cache files "
+            f"({text_stats['orphan_bytes'] / (1024*1024):.1f} MB), "
+            f"{image_stats['orphan_count']} orphaned image cache files "
+            f"({image_stats['orphan_bytes'] / (1024*1024):.1f} MB).\n\nProceed?"
+        )
+        if messagebox.askyesno("Clean Cache", msg):
+            SmartDiskCache.gc_clean(os.path.join(cache_dir, "text"))
+            SmartDiskCache.gc_clean(os.path.join(cache_dir, "image"))
+            messagebox.showinfo("Clean Cache", f"Removed {total_files} orphaned files ({total_mb:.1f} MB).")
 
     def __training_thread_function(self):
         error_caught = False

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -387,6 +387,7 @@ class TrainConfig(BaseConfig):
     aspect_ratio_bucketing: bool
     latent_caching: bool
     clear_cache_before_training: bool
+    sourceless_training: bool
 
     # training settings
     learning_rate_scheduler: LearningRateScheduler
@@ -560,7 +561,7 @@ class TrainConfig(BaseConfig):
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(
             data,
-            config_version=10,
+            config_version=11,
             config_migrations={
                 0: self.__migration_0,
                 1: self.__migration_1,
@@ -572,6 +573,7 @@ class TrainConfig(BaseConfig):
                 7: self.__migration_7,
                 8: self.__migration_8,
                 9: self.__migration_9,
+                10: self.__migration_10,
             }
         )
 
@@ -791,6 +793,11 @@ class TrainConfig(BaseConfig):
 
         return migrated_data
 
+    def __migration_10(self, data: dict) -> dict:
+        migrated_data = data.copy()
+        migrated_data.setdefault("sourceless_training", False)
+        return migrated_data
+
     def weight_dtypes(self) -> ModelWeightDtypes:
         return ModelWeightDtypes(
             self.train_dtype,
@@ -972,7 +979,8 @@ class TrainConfig(BaseConfig):
         data.append(("concepts", None, list[ConceptConfig], True))
         data.append(("aspect_ratio_bucketing", True, bool, False))
         data.append(("latent_caching", True, bool, False))
-        data.append(("clear_cache_before_training", True, bool, False))
+        data.append(("clear_cache_before_training", False, bool, False))
+        data.append(("sourceless_training", False, bool, False))
 
         # training settings
         data.append(("learning_rate_scheduler", LearningRateScheduler.CONSTANT, LearningRateScheduler, False))

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@1088282#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@675fb2f#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@9e39b2a#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@11df102#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -34,6 +34,7 @@ open-clip-torch==2.32.0
 
 # data loader
 -e git+https://github.com/Nerogar/mgds.git@a25b59f#egg=mgds
+xxhash
 
 # optimizers
 dadaptation==3.2 # dadaptation optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@35ee9c5#egg=mgds
+-e git+https://github.com/Nerogar/mgds.git@1088282#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@c71379a#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@e5b3324#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@905efb2#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@51b3f19#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@675fb2f#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@f65c2de#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@f65c2de#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@b0ecbfa#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@e5b3324#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@9e39b2a#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@b0ecbfa#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@905efb2#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@bfb3544#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@c71379a#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@b362520#egg=mgds
+-e git+https://github.com/Nerogar/mgds.git@35ee9c5#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/BitcrushedHeart/mgds.git@51b3f19#egg=mgds
+-e git+https://github.com/BitcrushedHeart/mgds.git@bfb3544#egg=mgds
 xxhash
 
 # optimizers

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@a25b59f#egg=mgds
+-e git+https://github.com/Nerogar/mgds.git@b362520#egg=mgds
 xxhash
 
 # optimizers


### PR DESCRIPTION
# SmartDiskCache Integration

## What This Is

Wires OneTrainer into the new 'SmartDiskCache' module from the companion mgds PR (Nerogar/mgds#49). The cache becomes persistent and content-addressed. It grows over time and only rebuilds what's genuinely stale, rather than wiping and rebuilding every time a file changes.

## What Changed

### Config

'sourceless_training' field added to `TrainConfig` with migration (migration_10). Default 'False'. 'clear_cache_before_training' default changed to `False` since SmartCache makes forced rebuilds unnecessary in most cases.

### UI

- **Sourceless Training** toggle in the Data tab - trains from cached `.pt` files without source images/text
- **Clean Cache** button in the Data tab. shows a preview of orphaned cache files (count + MB) before deleting anything, handles both text and image cache directories
- Updated `clear_cache_before_training` tooltip to reflect that SmartCache validates incrementally and detects model type changes automatically

### Dataloaders

All dataloaders that previously used `DiskCache` now use `SmartDiskCache` through `DataLoaderText2ImageMixin._cache_modules()`. The mixin passes `modeltype`, `source_path_in_name`, and `sourceless` to the SmartDiskCache constructor.

When 'sourceless_training' and 'latent_caching' are both enabled, '_create_dataset()' short-circuits to '[cache_modules, output_modules]', skipping file enumeration, loading, augmentation, and preparation modules entirely.

### Interruptible Caching

Pressing "Stop Training" during caching now finishes the current file, saves the cache index, and stops gracefully. The next run picks up where it left off.

### GenericTrainer

'__clear_cache()' now prints a message explaining that SmartCache makes clearing unnecessary. The wipe logic is preserved (deletes `image/`, `text/`, and `epoch-*` dirs) but the default is off.

---

Closes https://github.com/Nerogar/OneTrainer/issues/280
Closes https://github.com/Nerogar/OneTrainer/issues/109
Closes https://github.com/Nerogar/OneTrainer/issues/1357