### PR TITLE
fix: continue TensorBoard run across backup resume

### DIFF
--- a/modules/model/BaseModel.py
+++ b/modules/model/BaseModel.py
@@ -76,6 +76,8 @@ class BaseModel(metaclass=ABCMeta):
     embedding_state_dicts: dict[str, dict[str, Tensor]] | None
     autocast_context: torch.autocast | nullcontext
     train_dtype: DataType
+    resumed_tensorboard_subdir: str | None
+    tensorboard_subdir: str | None
 
     def __init__(
             self,
@@ -93,6 +95,8 @@ class BaseModel(metaclass=ABCMeta):
         self.embedding_state_dicts = {}
         self.autocast_context = nullcontext()
         self.train_dtype = DataType.FLOAT_32
+        self.resumed_tensorboard_subdir = None
+        self.tensorboard_subdir = None
 
     @abstractmethod
     def to(self, device: torch.device):

--- a/modules/modelLoader/mixin/InternalModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/InternalModelLoaderMixin.py
@@ -28,6 +28,7 @@ class InternalModelLoaderMixin(metaclass=ABCMeta):
                     epoch_sample=meta['train_progress']['epoch_sample'],
                     global_step=meta['train_progress']['global_step'],
                 )
+                resumed_tb_subdir = meta.get('tensorboard_subdir', None)
 
             # optimizer
             with contextlib.suppress(FileNotFoundError):
@@ -40,3 +41,4 @@ class InternalModelLoaderMixin(metaclass=ABCMeta):
 
             # meta
             model.train_progress = train_progress
+            model.resumed_tensorboard_subdir = resumed_tb_subdir

--- a/modules/modelSaver/mixin/InternalModelSaverMixin.py
+++ b/modules/modelSaver/mixin/InternalModelSaverMixin.py
@@ -31,6 +31,7 @@ class InternalModelSaverMixin(metaclass=ABCMeta):
             torch.save(model.ema.state_dict(), os.path.join(destination, "ema", "ema.pt"))
 
         # meta
+        tensorboard_subdir = getattr(model, "tensorboard_subdir", None)
         with open(os.path.join(destination, "meta.json"), "w") as meta_file:
             json.dump({
                 'train_progress': {
@@ -39,4 +40,5 @@ class InternalModelSaverMixin(metaclass=ABCMeta):
                     'epoch_sample': model.train_progress.epoch_sample,
                     'global_step': model.train_progress.global_step,
                 },
+                'tensorboard_subdir': tensorboard_subdir,
             }, meta_file)

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -68,11 +68,11 @@ class GenericTrainer(BaseTrainer):
         super().__init__(config, callbacks, commands)
 
         if multi.is_master():
-            tensorboard_log_dir = os.path.join(config.workspace_dir, "tensorboard")
-            os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
-            self.tensorboard = SummaryWriter(os.path.join(tensorboard_log_dir, f"{config.save_filename_prefix}{get_string_timestamp()}"))
+            # TB writer creation is deferred to start() so a backup's tensorboard_subdir
+            # can be reused and logging continues in the same TB run on resume.
             if config.tensorboard and not config.tensorboard_always_on:
                 super()._start_tensorboard()
+        self.tensorboard = None
 
         self.model = None
         self.one_step_trained = False
@@ -160,6 +160,39 @@ class GenericTrainer(BaseTrainer):
             self.validation_data_loader = self.create_data_loader(
                 self.model, self.model_setup, self.model.train_progress, is_validation=True
             )
+
+        if multi.is_master():
+            self._init_tensorboard_writer()
+
+    def _init_tensorboard_writer(self):
+        """Construct the SummaryWriter.
+
+        On resume (model.resumed_tensorboard_subdir is set and the directory still
+        exists under workspace_dir/tensorboard), reuse the existing subdir so the
+        TB UI shows a single continuous run across stop/resume cycles. Use
+        purge_step to trim any scalars written after the backup point by a
+        previous session that crashed mid-log.
+        """
+        tensorboard_log_dir = os.path.join(self.config.workspace_dir, "tensorboard")
+        os.makedirs(Path(tensorboard_log_dir).absolute(), exist_ok=True)
+
+        resumed = getattr(self.model, "resumed_tensorboard_subdir", None)
+        reuse_path = None
+        if resumed:
+            candidate = os.path.join(tensorboard_log_dir, resumed)
+            if os.path.isdir(candidate):
+                reuse_path = candidate
+
+        if reuse_path is not None:
+            self.model.tensorboard_subdir = resumed
+            self.tensorboard = SummaryWriter(
+                reuse_path,
+                purge_step=self.model.train_progress.global_step,
+            )
+        else:
+            subdir = f"{self.config.save_filename_prefix}{get_string_timestamp()}"
+            self.model.tensorboard_subdir = subdir
+            self.tensorboard = SummaryWriter(os.path.join(tensorboard_log_dir, subdir))
 
     def __save_config_to_workspace(self):
         path = path_util.canonical_join(self.config.workspace_dir, "config")


### PR DESCRIPTION
Resuming from a backup currently starts a brand new TensorBoard run in a fresh timestamped folder. After a few stop/resume cycles, the TB sidebar fills with overlapping partial runs and the loss curves stack on each other, becoming unreadable.

This persists the TB subdir name in `meta.json`. On resume, if that subdir still exists under `workspace_dir/tensorboard`, the trainer reuses it with `purge_step=global_step` so any phantom scalars written after the backup point by a previously-crashed session get trimmed. If the subdir is missing (workspace moved between machines), it falls back to creating a fresh timestamped dir.

`SummaryWriter` construction moves from `GenericTrainer.__init__` to the end of `start()`, after the model loader has read the backup — previously the writer was built before the backup was even loaded, so the resumed subdir name was unreachable.

Legacy backups without the field load cleanly (`meta.get('tensorboard_subdir', None)`); continuity kicks in once the first new backup is taken on this code.

Per dxqb's comment, split from the original combined diff so the validation fix (#1470) can land separately. Open to feedback on whether always-reuse is the right default — happy to make this opt-in if the per-resume-as-separate-run workflow needs to be preserved (e.g. branching off a backup to try two different LRs).