### PR TITLE
Upgrade diffusers, use deprecated Wuerstchen pipeline

### DIFF
--- a/modules/model/WuerstchenModel.py
+++ b/modules/model/WuerstchenModel.py
@@ -15,7 +15,7 @@ from diffusers import ConfigMixin, DDPMWuerstchenScheduler, DiffusionPipeline, M
 from diffusers.configuration_utils import register_to_config
 from diffusers.models import StableCascadeUNet
 from diffusers.pipelines.stable_cascade import StableCascadeCombinedPipeline
-from diffusers.pipelines.wuerstchen import PaellaVQModel, WuerstchenDiffNeXt, WuerstchenPrior
+from diffusers.pipelines.deprecated.wuerstchen import PaellaVQModel, WuerstchenDiffNeXt, WuerstchenPrior
 from transformers import CLIPTextModel, CLIPTokenizer
 
 

--- a/modules/model/WuerstchenModel.py
+++ b/modules/model/WuerstchenModel.py
@@ -14,8 +14,8 @@ from torch import Tensor, nn
 from diffusers import ConfigMixin, DDPMWuerstchenScheduler, DiffusionPipeline, ModelMixin, WuerstchenCombinedPipeline
 from diffusers.configuration_utils import register_to_config
 from diffusers.models import StableCascadeUNet
-from diffusers.pipelines.stable_cascade import StableCascadeCombinedPipeline
 from diffusers.pipelines.deprecated.wuerstchen import PaellaVQModel, WuerstchenDiffNeXt, WuerstchenPrior
+from diffusers.pipelines.stable_cascade import StableCascadeCombinedPipeline
 from transformers import CLIPTextModel, CLIPTokenizer
 
 

--- a/modules/modelLoader/wuerstchen/WuerstchenModelLoader.py
+++ b/modules/modelLoader/wuerstchen/WuerstchenModelLoader.py
@@ -12,7 +12,7 @@ from modules.util.ModelWeightDtypes import ModelWeightDtypes
 
 from diffusers import DDPMWuerstchenScheduler
 from diffusers.models import StableCascadeUNet
-from diffusers.pipelines.wuerstchen import PaellaVQModel, WuerstchenDiffNeXt, WuerstchenPrior
+from diffusers.pipelines.deprecated.wuerstchen import PaellaVQModel, WuerstchenDiffNeXt, WuerstchenPrior
 from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
 
 from safetensors import safe_open

--- a/modules/modelSaver/mixin/DtypeModelSaverMixin.py
+++ b/modules/modelSaver/mixin/DtypeModelSaverMixin.py
@@ -12,8 +12,6 @@ from modules.util.modelSpec.ModelSpec import ModelSpec
 import torch
 from torch import Tensor
 
-import safetensors.torch as safetensors
-
 
 class DtypeModelSaverMixin:
     def __init__(self):
@@ -54,8 +52,8 @@ class DtypeModelSaverMixin:
         sha256_hash = hashlib.sha256()
 
         ordered_state_dict = OrderedDict(sorted(state_dict.items()))
-        for key, tensor in ordered_state_dict.items():
-            data = safetensors._tobytes(tensor, key)
+        for tensor in ordered_state_dict.values():
+            data = tensor.contiguous().cpu().view(torch.uint8).numpy().tobytes()
             sha256_hash.update(data)
 
         return f"0x{sha256_hash.hexdigest()}"

--- a/modules/modelSaver/mixin/DtypeModelSaverMixin.py
+++ b/modules/modelSaver/mixin/DtypeModelSaverMixin.py
@@ -53,7 +53,7 @@ class DtypeModelSaverMixin:
 
         ordered_state_dict = OrderedDict(sorted(state_dict.items()))
         for tensor in ordered_state_dict.values():
-            data = tensor.contiguous().cpu().view(torch.uint8).numpy().tobytes()
+            data = tensor.contiguous().cpu().flatten().view(torch.uint8).numpy().tobytes()
             sha256_hash.update(data)
 
         return f"0x{sha256_hash.hexdigest()}"

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -21,7 +21,7 @@ tensorboard==2.20.0
 pytorch-lightning==2.6.1
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@0f1abc4#egg=diffusers
+-e git+https://github.com/huggingface/diffusers.git@ad3a3af#egg=diffusers
 gguf==0.17.1
 transformers==4.57.6
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -21,7 +21,7 @@ tensorboard==2.20.0
 pytorch-lightning==2.6.1
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@ad3a3af#egg=diffusers
+-e git+https://github.com/huggingface/diffusers.git@0f1abc4#egg=diffusers
 gguf==0.17.1
 transformers==4.57.6
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -16,7 +16,7 @@ setuptools==81.0.0
 
 # pytorch
 accelerate==1.12.0
-safetensors==0.7.0
+safetensors==0.8.0rc0
 tensorboard==2.20.0
 pytorch-lightning==2.6.1
 

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -21,7 +21,7 @@ tensorboard==2.20.0
 pytorch-lightning==2.6.1
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@da6718f#egg=diffusers
+-e git+https://github.com/huggingface/diffusers.git@0f1abc4#egg=diffusers
 gguf==0.17.1
 transformers==4.57.6
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading


### PR DESCRIPTION
the Wuerstchen pipeline is only deprecated by diffusers, not removed. However, they don't import all pipeline components under `diffusers.pipelines` anymore. Directly import from `diffusers.pipelines.deprecated` to avoid import errors



