### PR TITLE
Skip TE dropout for models when set to zero

### DIFF
--- a/modules/model/ChromaModel.py
+++ b/modules/model/ChromaModel.py
@@ -208,7 +208,7 @@ class ChromaModel(BaseModel):
         )
 
         # apply dropout FIXME not a real dropout
-        if text_encoder_dropout_probability is not None:
+        if text_encoder_dropout_probability is not None and text_encoder_dropout_probability > 0.0:
             dropout_text_encoder_mask = (torch.tensor(
                 [rand.random() > text_encoder_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/FluxModel.py
+++ b/modules/model/FluxModel.py
@@ -287,13 +287,13 @@ class FluxModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_1_dropout_probability is not None:
+        if text_encoder_1_dropout_probability is not None and text_encoder_1_dropout_probability > 0.0:
             dropout_text_encoder_1_mask = (torch.tensor(
                 [rand.random() > text_encoder_1_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             pooled_text_encoder_1_output = pooled_text_encoder_1_output * dropout_text_encoder_1_mask[:, None]
 
-        if text_encoder_2_dropout_probability is not None:
+        if text_encoder_2_dropout_probability is not None and text_encoder_2_dropout_probability > 0.0:
             dropout_text_encoder_2_mask = (torch.tensor(
                 [rand.random() > text_encoder_2_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/HiDreamModel.py
+++ b/modules/model/HiDreamModel.py
@@ -442,26 +442,26 @@ class HiDreamModel(BaseModel):
         # )
 
         # apply dropout
-        if text_encoder_1_dropout_probability is not None:
+        if text_encoder_1_dropout_probability is not None and text_encoder_1_dropout_probability > 0.0:
             dropout_text_encoder_1_mask = (torch.tensor(
                 [rand.random() > text_encoder_1_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             pooled_text_encoder_1_output = pooled_text_encoder_1_output * dropout_text_encoder_1_mask[:, None]
 
-        if text_encoder_2_dropout_probability is not None:
+        if text_encoder_2_dropout_probability is not None and text_encoder_2_dropout_probability > 0.0:
             dropout_text_encoder_2_mask = (torch.tensor(
                 [rand.random() > text_encoder_2_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             pooled_text_encoder_2_output = pooled_text_encoder_2_output * dropout_text_encoder_2_mask[:, None]
 
-        if text_encoder_3_dropout_probability is not None:
+        if text_encoder_3_dropout_probability is not None and text_encoder_3_dropout_probability > 0.0:
             dropout_text_encoder_3_mask = (torch.tensor(
                 [rand.random() > text_encoder_3_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             text_encoder_3_output = text_encoder_3_output * dropout_text_encoder_3_mask[:, None, None]
 
         text_encoder_4_output = torch.stack(text_encoder_4_output, dim=0)
-        if text_encoder_4_dropout_probability is not None:
+        if text_encoder_4_dropout_probability is not None and text_encoder_4_dropout_probability > 0.0:
             dropout_text_encoder_4_mask = (torch.tensor(
                 [rand.random() > text_encoder_4_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/HunyuanVideoModel.py
+++ b/modules/model/HunyuanVideoModel.py
@@ -300,13 +300,13 @@ class HunyuanVideoModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_1_dropout_probability is not None:
+        if text_encoder_1_dropout_probability is not None and text_encoder_1_dropout_probability > 0.0:
             dropout_text_encoder_1_mask = (torch.tensor(
                 [rand.random() > text_encoder_1_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             text_encoder_1_output = text_encoder_1_output * dropout_text_encoder_1_mask[:, None, None]
 
-        if text_encoder_2_dropout_probability is not None:
+        if text_encoder_2_dropout_probability is not None and text_encoder_2_dropout_probability > 0.0:
             dropout_text_encoder_2_mask = (torch.tensor(
                 [rand.random() > text_encoder_2_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/PixArtAlphaModel.py
+++ b/modules/model/PixArtAlphaModel.py
@@ -211,7 +211,7 @@ class PixArtAlphaModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_dropout_probability is not None:
+        if text_encoder_dropout_probability is not None and text_encoder_dropout_probability > 0.0:
             dropout_text_encoder_mask = (torch.tensor(
                 [rand.random() > text_encoder_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/SanaModel.py
+++ b/modules/model/SanaModel.py
@@ -200,7 +200,7 @@ class SanaModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_dropout_probability is not None:
+        if text_encoder_dropout_probability is not None and text_encoder_dropout_probability > 0.0:
             dropout_text_encoder_mask = (torch.tensor(
                 [rand.random() > text_encoder_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/StableDiffusion3Model.py
+++ b/modules/model/StableDiffusion3Model.py
@@ -394,21 +394,21 @@ class StableDiffusion3Model(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_1_dropout_probability is not None:
+        if text_encoder_1_dropout_probability is not None and text_encoder_1_dropout_probability > 0.0:
             dropout_text_encoder_1_mask = (torch.tensor(
                 [rand.random() > text_encoder_1_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             text_encoder_1_output = text_encoder_1_output * dropout_text_encoder_1_mask[:, None, None]
             pooled_text_encoder_1_output = pooled_text_encoder_1_output * dropout_text_encoder_1_mask[:, None]
 
-        if text_encoder_2_dropout_probability is not None:
+        if text_encoder_2_dropout_probability is not None and text_encoder_2_dropout_probability > 0.0:
             dropout_text_encoder_2_mask = (torch.tensor(
                 [rand.random() > text_encoder_2_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             text_encoder_2_output = text_encoder_2_output * dropout_text_encoder_2_mask[:, None, None]
             pooled_text_encoder_2_output = pooled_text_encoder_2_output * dropout_text_encoder_2_mask[:, None]
 
-        if text_encoder_3_dropout_probability is not None:
+        if text_encoder_3_dropout_probability is not None and text_encoder_3_dropout_probability > 0.0:
             dropout_text_encoder_3_mask = (torch.tensor(
                 [rand.random() > text_encoder_3_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/StableDiffusionModel.py
+++ b/modules/model/StableDiffusionModel.py
@@ -224,7 +224,7 @@ class StableDiffusionModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_dropout_probability is not None:
+        if text_encoder_dropout_probability is not None and text_encoder_dropout_probability > 0.0:
             dropout_text_encoder_mask = (torch.tensor(
                 [rand.random() > text_encoder_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/StableDiffusionXLModel.py
+++ b/modules/model/StableDiffusionXLModel.py
@@ -270,13 +270,13 @@ class StableDiffusionXLModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_1_dropout_probability is not None:
+        if text_encoder_1_dropout_probability is not None and text_encoder_1_dropout_probability > 0.0:
             dropout_text_encoder_1_mask = (torch.tensor(
                 [rand.random() > text_encoder_1_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()
             text_encoder_1_output = text_encoder_1_output * dropout_text_encoder_1_mask[:, None, None]
 
-        if text_encoder_2_dropout_probability is not None:
+        if text_encoder_2_dropout_probability is not None and text_encoder_2_dropout_probability > 0.0:
             dropout_text_encoder_2_mask = (torch.tensor(
                 [rand.random() > text_encoder_2_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()

--- a/modules/model/WuerstchenModel.py
+++ b/modules/model/WuerstchenModel.py
@@ -261,7 +261,7 @@ class WuerstchenModel(BaseModel):
         )
 
         # apply dropout
-        if text_encoder_dropout_probability is not None:
+        if text_encoder_dropout_probability is not None and text_encoder_dropout_probability > 0.0:
             dropout_text_encoder_mask = (torch.tensor(
                 [rand.random() > text_encoder_dropout_probability for _ in range(batch_size)],
                 device=train_device)).float()


### PR DESCRIPTION
This fixes a small logic issue in the text path where the dropout branch still ran when the configured dropout probability was 0.0. The old check only guarded on the value being present, so we were still building the dropout mask and paying the associated CUDA sync/copy overhead even though dropout was effectively off.

The change makes the branch run only when the dropout probability is greater than zero. This preserves behavior for real dropout values while avoiding unnecessary work when text encoder dropout is disabled.