### PR TITLE
feat: stratified per-sample validation timesteps

### DIFF
--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -165,7 +165,7 @@ class BaseChromaSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -196,6 +196,7 @@ class BaseChromaSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseErnieSetup.py
+++ b/modules/modelSetup/BaseErnieSetup.py
@@ -79,7 +79,7 @@ class BaseErnieSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -110,6 +110,7 @@ class BaseErnieSetup(
                 scaled_latent_image.shape[0],
                 config,
                 shift=shift if config.dynamic_timestep_shifting else config.timestep_shift,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseFlux2Setup.py
+++ b/modules/modelSetup/BaseFlux2Setup.py
@@ -89,7 +89,7 @@ class BaseFlux2Setup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -119,6 +119,7 @@ class BaseFlux2Setup(
                 scaled_latent_image.shape[0],
                 config,
                 shift = shift if config.dynamic_timestep_shifting else config.timestep_shift,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -204,7 +204,7 @@ class BaseFluxSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -249,6 +249,7 @@ class BaseFluxSetup(
                 scaled_latent_image.shape[0],
                 config,
                 shift = shift if config.dynamic_timestep_shifting else config.timestep_shift,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -297,7 +297,7 @@ class BaseHiDreamSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -348,6 +348,7 @@ class BaseHiDreamSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -205,7 +205,7 @@ class BaseHunyuanVideoSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -243,6 +243,7 @@ class BaseHunyuanVideoSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -159,7 +159,7 @@ class BasePixArtAlphaSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -193,6 +193,7 @@ class BasePixArtAlphaSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image = self._add_noise_discrete(

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -86,7 +86,7 @@ class BaseQwenSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -114,6 +114,7 @@ class BaseQwenSetup(
                 scaled_latent_image.shape[0],
                 config,
                 shift = shift if config.dynamic_timestep_shifting else config.timestep_shift,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -169,7 +169,7 @@ class BaseSanaSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -203,6 +203,7 @@ class BaseSanaSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -247,7 +247,7 @@ class BaseStableDiffusion3Setup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -300,6 +300,7 @@ class BaseStableDiffusion3Setup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -151,7 +151,7 @@ class BaseStableDiffusionSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -182,6 +182,7 @@ class BaseStableDiffusionSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             latent_noise = self._create_noise(

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -195,7 +195,7 @@ class BaseStableDiffusionXLSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -233,6 +233,7 @@ class BaseStableDiffusionXLSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             latent_noise = self._create_noise(

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -210,7 +210,7 @@ class BaseWuerstchenSetup(
             elif model.model_type.is_stable_cascade():
                 scaled_latent_image = latent_image
 
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -222,6 +222,7 @@ class BaseWuerstchenSetup(
                 generator,
                 scaled_latent_image.shape[0],
                 config,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             if model.model_type.is_wuerstchen_v2():

--- a/modules/modelSetup/BaseZImageSetup.py
+++ b/modules/modelSetup/BaseZImageSetup.py
@@ -88,7 +88,7 @@ class BaseZImageSetup(
             deterministic: bool = False,
     ) -> dict:
         with model.autocast_context:
-            batch_seed = 0 if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
+            batch_seed = int(batch.get("__val_noise_seed__", 0)) if deterministic else train_progress.global_step * multi.world_size() + multi.rank()
             generator = torch.Generator(device=config.train_device)
             generator.manual_seed(batch_seed)
             rand = Random(batch_seed)
@@ -114,6 +114,7 @@ class BaseZImageSetup(
                 scaled_latent_image.shape[0],
                 config,
                 shift = shift if config.dynamic_timestep_shifting else config.timestep_shift,
+                validation_override=batch.get("__val_timestep_unit__"),
             )
 
             scaled_noisy_latent_image, sigma = self._add_noise_discrete(

--- a/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
+++ b/modules/modelSetup/mixin/ModelSetupNoiseMixin.py
@@ -126,14 +126,21 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
             batch_size: int,
             config: TrainConfig,
             shift: float = None,
+            validation_override: float | None = None,
     ) -> Tensor:
         if shift is None:
             shift = config.timestep_shift
 
         if deterministic:
-            # -1 is for zero-based indexing
+            if validation_override is not None:
+                # Already-shifted unit position in [0, 1]; map to integer timestep.
+                t = int(validation_override * num_train_timesteps)
+                t = max(0, min(num_train_timesteps - 1, t))
+            else:
+                # -1 is for zero-based indexing
+                t = int(num_train_timesteps * 0.5) - 1
             return torch.tensor(
-                int(num_train_timesteps * 0.5) - 1,
+                t,
                 dtype=torch.long,
                 device=generator.device,
             ).unsqueeze(0)
@@ -217,11 +224,13 @@ class ModelSetupNoiseMixin(metaclass=ABCMeta):
             generator: Generator,
             batch_size: int,
             config: TrainConfig,
+            validation_override: float | None = None,
     ) -> Tensor:
         if deterministic:
+            fill_value = float(validation_override) if validation_override is not None else 0.5
             return torch.full(
                 size=(batch_size,),
-                fill_value=0.5,
+                fill_value=fill_value,
                 device=generator.device,
             )
         else:

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -20,6 +20,7 @@ from modules.util import create, path_util
 from modules.util.bf16_stochastic_rounding import set_seed as bf16_stochastic_rounding_set_seed
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
+from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.SampleConfig import SampleConfig
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_grad_scaler, enable_grad_scaling
@@ -33,6 +34,11 @@ from modules.util.profiling_util import TorchMemoryRecorder, TorchProfiler
 from modules.util.time_util import get_string_timestamp
 from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
+from modules.util.validation_timestep import (
+    apply_timestep_shift_unit,
+    stratified_unit_position,
+    validation_noise_seed,
+)
 
 import torch
 from torch import Tensor, nn
@@ -364,9 +370,28 @@ class GenericTrainer(BaseTrainer):
             mapping_seed_to_label = {}
             mapping_label_to_seed = {}
 
-            for validation_batch in step_tqdm_validation:
+            concept_shift_by_seed = self.__validation_concept_shifts()
+            global_validation_shift = self.config.validation_timestep_shift
+            n_validation = current_epoch_length_validation
+
+            for i, validation_batch in enumerate(step_tqdm_validation):
                 if self.__needs_gc(train_progress):
                     torch_gc()
+
+                # since validation batch size = 1
+                concept_name = validation_batch["concept_name"][0]
+                concept_path = validation_batch["concept_path"][0]
+                concept_seed = validation_batch["concept_seed"].item()
+
+                shift_for_sample = concept_shift_by_seed.get(concept_seed)
+                if shift_for_sample is None:
+                    shift_for_sample = global_validation_shift
+
+                pos = stratified_unit_position(i, n_validation)
+                validation_batch["__val_timestep_unit__"] = apply_timestep_shift_unit(
+                    pos, shift_for_sample
+                )
+                validation_batch["__val_noise_seed__"] = validation_noise_seed(i)
 
                 with torch.no_grad():
                     model_output_data = self.model_setup.predict(
@@ -374,10 +399,6 @@ class GenericTrainer(BaseTrainer):
                     loss_validation = self.model_setup.calculate_loss(
                         self.model, validation_batch, model_output_data, self.config)
 
-                # since validation batch size = 1
-                concept_name = validation_batch["concept_name"][0]
-                concept_path = validation_batch["concept_path"][0]
-                concept_seed = validation_batch["concept_seed"].item()
                 loss = loss_validation.item()
 
                 label = concept_name if concept_name else os.path.basename(concept_path)
@@ -412,6 +433,24 @@ class GenericTrainer(BaseTrainer):
                 self.tensorboard.add_scalar("loss/validation_step/total_average",
                                             total_average_loss,
                                             train_progress.global_step)
+
+    def __validation_concept_shifts(self) -> dict[int, float]:
+        concepts = self.config.concepts
+        if concepts is None:
+            try:
+                with open(self.config.concept_file_name, 'r') as f:
+                    concepts = [ConceptConfig.default_values().from_dict(c) for c in json.load(f)]
+            except OSError:
+                return {}
+
+        shifts: dict[int, float] = {}
+        for concept in concepts:
+            if ConceptType(concept.type) != ConceptType.VALIDATION:
+                continue
+            override = getattr(concept, 'validation_timestep_shift', None)
+            if override is not None:
+                shifts[concept.seed] = float(override)
+        return shifts
 
     def __save_backup_config(self, backup_path):
         config_path = os.path.join(backup_path, "onetrainer_config")

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -437,20 +437,15 @@ class GenericTrainer(BaseTrainer):
     def __validation_concept_shifts(self) -> dict[int, float]:
         concepts = self.config.concepts
         if concepts is None:
-            try:
-                with open(self.config.concept_file_name, 'r') as f:
-                    concepts = [ConceptConfig.default_values().from_dict(c) for c in json.load(f)]
-            except OSError:
-                return {}
+            with open(self.config.concept_file_name, 'r') as f:
+                concepts = [ConceptConfig.default_values().from_dict(c) for c in json.load(f)]
 
-        shifts: dict[int, float] = {}
-        for concept in concepts:
-            if ConceptType(concept.type) != ConceptType.VALIDATION:
-                continue
-            override = getattr(concept, 'validation_timestep_shift', None)
-            if override is not None:
-                shifts[concept.seed] = float(override)
-        return shifts
+        return {
+            concept.seed: concept.validation_timestep_shift
+            for concept in concepts
+            if ConceptType(concept.type) == ConceptType.VALIDATION
+            and concept.validation_timestep_shift is not None
+        }
 
     def __save_backup_config(self, backup_path):
         config_path = os.path.join(backup_path, "onetrainer_config")

--- a/modules/ui/ConceptWindow.py
+++ b/modules/ui/ConceptWindow.py
@@ -198,6 +198,12 @@ class ConceptWindow(ctk.CTkToplevel):
                          tooltip="The loss multiplyer for this concept.")
         components.entry(frame, 9, 1, self.ui_state, "loss_weight")
 
+        # validation timestep shift (only meaningful for VALIDATION concepts)
+        components.label(frame, 10, 0, "Validation Timestep Shift",
+                         tooltip="Per-concept override for the global Validation Timestep Shift. Leave blank to inherit. Only used for VALIDATION concepts.",
+                         wide_tooltip=True)
+        components.entry(frame, 10, 1, self.ui_state, "validation_timestep_shift")
+
         frame.pack(fill="both", expand=1)
         return frame
 

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -693,7 +693,7 @@ class TrainingTab:
 
         # validation timestep shift
         components.label(frame, 9, 0, "Validation Timestep Shift",
-                         tooltip="Shift applied to the per-sample validation timestep distribution. Validation samples are spread across the full timestep range using stratified sampling, and this shift skews that range the same way Timestep Shift does for training. Concepts can override this value individually.", wide_tooltip=True)
+                         tooltip="Shift the validation timestep distribution. Concepts can override this value individually.")
         components.entry(frame, 9, 1, self.ui_state, "validation_timestep_shift", required=True)
 
         if supports_dynamic_timestep_shifting:

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -691,11 +691,16 @@ class TrainingTab:
                          tooltip="Shift the timestep distribution. Use the preview to see more details.")
         components.entry(frame, 8, 1, self.ui_state, "timestep_shift", required=True)
 
+        # validation timestep shift
+        components.label(frame, 9, 0, "Validation Timestep Shift",
+                         tooltip="Shift applied to the per-sample validation timestep distribution. Validation samples are spread across the full timestep range using stratified sampling, and this shift skews that range the same way Timestep Shift does for training. Concepts can override this value individually.", wide_tooltip=True)
+        components.entry(frame, 9, 1, self.ui_state, "validation_timestep_shift", required=True)
+
         if supports_dynamic_timestep_shifting:
             # dynamic timestep shifting
-            components.label(frame, 9, 0, "Dynamic Timestep Shifting",
+            components.label(frame, 10, 0, "Dynamic Timestep Shifting",
                              tooltip="Dynamically shift the timestep distribution based on resolution. If enabled, the shifting parameters are taken from the model's scheduler configuration and Timestep Shift is ignored. Note: For Z-Image and Flux2, the dynamic shifting parameters are likely wrong and unknown. Use with care or set your own, fixed shift.", wide_tooltip=True)
-            components.switch(frame, 9, 1, self.ui_state, "dynamic_timestep_shifting")
+            components.switch(frame, 10, 1, self.ui_state, "dynamic_timestep_shifting")
 
 
 

--- a/modules/util/config/ConceptConfig.py
+++ b/modules/util/config/ConceptConfig.py
@@ -136,6 +136,7 @@ class ConceptConfig(BaseConfig):
     text_variations: int
     repeats: float
     loss_weight: float
+    validation_timestep_shift: float | None
     concept_stats: dict
 
     image: ConceptImageConfig
@@ -195,6 +196,7 @@ class ConceptConfig(BaseConfig):
         data.append(("balancing", 1.0, float, False))
         data.append(("balancing_strategy", BalancingStrategy.REPEATS, BalancingStrategy, False))
         data.append(("loss_weight", 1.0, float, False))
+        data.append(("validation_timestep_shift", None, float, True))
         data.append(("concept_stats", {}, dict, False))
 
         return ConceptConfig(data)

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -447,6 +447,7 @@ class TrainConfig(BaseConfig):
 
     timestep_shift: float
     dynamic_timestep_shifting: bool
+    validation_timestep_shift: float
 
     # unet
     unet: TrainModelPartConfig
@@ -1024,6 +1025,7 @@ class TrainConfig(BaseConfig):
         data.append(("noising_bias", 0.0, float, False))
         data.append(("timestep_shift", 1.0, float, False))
         data.append(("dynamic_timestep_shifting", False, bool, False))
+        data.append(("validation_timestep_shift", 1.0, float, False))
 
 
         # unet

--- a/modules/util/validation_timestep.py
+++ b/modules/util/validation_timestep.py
@@ -20,15 +20,15 @@ NOISE_TAG = 0x5E2D88C1
 def stratified_unit_position(i: int, n: int, seed: int = VAL_SEED) -> float:
     if n <= 0:
         return 0.0
-    jitter = float(np.random.default_rng([int(seed), TIMESTEP_TAG, int(i)]).random())
-    return (int(i) + jitter) / int(n)
+    jitter = float(np.random.default_rng([seed, TIMESTEP_TAG, i]).random())
+    return (i + jitter) / n
 
 
 def validation_noise_seed(i: int, seed: int = VAL_SEED) -> int:
-    return int(np.random.default_rng([int(seed), NOISE_TAG, int(i)]).integers(0, 2 ** 31))
+    return int(np.random.default_rng([seed, NOISE_TAG, i]).integers(0, 2 ** 31))
 
 
 def apply_timestep_shift_unit(pos: float, shift: float) -> float:
     if shift == 1.0:
-        return float(pos)
-    return float(shift) * float(pos) / ((float(shift) - 1.0) * float(pos) + 1.0)
+        return pos
+    return shift * pos / ((shift - 1.0) * pos + 1.0)

--- a/modules/util/validation_timestep.py
+++ b/modules/util/validation_timestep.py
@@ -1,0 +1,34 @@
+"""Deterministic stratified validation timestep + noise assignment.
+
+Validation loss is averaged across the full timestep distribution by giving each
+sample a unique, persistent timestep derived from its index. Splitting [0, 1]
+into N equal bins and jittering the position within each bin gives an even
+spread at any N while remaining reproducible: identical configs and datasets
+yield identical assignments.
+"""
+
+import numpy as np
+
+# Distinct large constants keep the timestep stream and the noise stream
+# independent. Changing these values changes everyone's validation losses, so
+# they are baked in.
+VAL_SEED = 0
+TIMESTEP_TAG = 0xA5F13C7B
+NOISE_TAG = 0x5E2D88C1
+
+
+def stratified_unit_position(i: int, n: int, seed: int = VAL_SEED) -> float:
+    if n <= 0:
+        return 0.0
+    jitter = float(np.random.default_rng([int(seed), TIMESTEP_TAG, int(i)]).random())
+    return (int(i) + jitter) / int(n)
+
+
+def validation_noise_seed(i: int, seed: int = VAL_SEED) -> int:
+    return int(np.random.default_rng([int(seed), NOISE_TAG, int(i)]).integers(0, 2 ** 31))
+
+
+def apply_timestep_shift_unit(pos: float, shift: float) -> float:
+    if shift == 1.0:
+        return float(pos)
+    return float(shift) * float(pos) / ((float(shift) - 1.0) * float(pos) + 1.0)


### PR DESCRIPTION
## Description

Replaces the single hardcoded validation timestep (the midpoint of the scheduler, e.g. 499 for 1000-step diffusion) with deterministic stratified sampling across the full timestep distribution. Validation loss is now averaged over the entire noise range instead of being measured at one point.

The previous behaviour gives a snapshot of the model's compositional/detail balance at the midpoint, which is informative but not representative of how the model behaves at low or high noise. Loss at timestep 499 alone tends to wobble run-to-run in ways that don't track final sample quality. Spreading samples across the distribution and averaging gives a more stable signal that correlates better with actual generative behaviour.

Two users with identical configs and datasets still get bit-identical validation loss - the stratified positions and per-sample noise seeds are derived from a fixed seed via a NumPy SeedSequence, so the assignments are fully reproducible.

## How It Works

For a validation set of N samples, sample i gets:

1. A stratified position in the unit interval: pos_i = (i + jitter_i) / N, where jitter_i is drawn from `np.random.default_rng([VAL_SEED, TIMESTEP_TAG, i]).random()`. Each sample's position falls in its own [i/N, (i+1)/N) bucket so coverage is even at any N.
2. A per-concept (or global) timestep shift applied in the [0, 1] domain: u_i = s * pos_i / ((s - 1) * pos_i + 1). This is algebraically equivalent to the existing N-domain shift in `ModelSetupNoiseMixin._get_timestep_discrete`, just rearranged to operate on a unit value before the integer mapping.
3. The unit position multiplied by `num_train_timesteps` and clamped to a valid integer.
4. A per-sample noise seed: `np.random.default_rng([VAL_SEED, NOISE_TAG, i]).integers(0, 2**31)`.

Both streams are derived from `i` and recomputed each validation pass, so resumed runs reproduce the same timesteps and noise without needing to persist any extra state in `meta.json`.

The trainer mutates the validation batch dict with two private keys (`__val_timestep_unit__`, `__val_noise_seed__`) before passing it to `model_setup.predict()`. `_get_timestep_discrete` and `_get_timestep_continuous` pick those up; if absent they fall back to the existing midpoint behaviour. That keeps the Tools-menu "Calculate losses" path (`GenerateLossesModel`) unchanged - it doesn't set the keys, so it still reports loss at the midpoint as before.

## UI

A new "Validation Timestep Shift" entry sits directly underneath "Timestep Shift" in the noise frame of the Training tab. Default 1.0 (identity, matches the existing distribution). When Dynamic Timestep Shifting is supported, that toggle moves down one row.

In the concept editor, VALIDATION concepts get a per-concept "Validation Timestep Shift" entry. Leaving it blank means inherit the global value; setting a numeric value overrides it for that concept's samples. The field is harmless on non-validation concepts (the trainer only consults it for samples that come from VALIDATION concepts) but is shown for all concepts to keep the editor uniform.

## Backwards Compatibility

`validation_timestep_shift` is added to TrainConfig with default 1.0 and to ConceptConfig with default None. Old saved configs missing the field load through `BaseConfig.from_dict()` and pick up the defaults silently - no migration function needed. No existing field is renamed or removed.

The single-midpoint behaviour is preserved for any caller that doesn't populate `__val_timestep_unit__` in the batch. The only place that does set it is the validation loop in `GenericTrainer.__validate()`.

## Files Changed

- `modules/util/validation_timestep.py` - new helper module with the stratified position, noise seed, and shift transform
- `modules/util/config/TrainConfig.py` - global `validation_timestep_shift` field, default 1.0
- `modules/util/config/ConceptConfig.py` - per-concept nullable override, default None
- `modules/modelSetup/mixin/ModelSetupNoiseMixin.py` - `validation_override` parameter on the deterministic branches of `_get_timestep_discrete` and `_get_timestep_continuous`
- `modules/trainer/GenericTrainer.py` - precomputes per-sample positions and noise seeds, resolves global vs per-concept shift, mutates the validation batch dict
- `modules/modelSetup/Base*Setup.py` (14 files) - one-line change to the deterministic batch seed and one-line addition of `validation_override=batch.get("__val_timestep_unit__")` to the existing timestep call
- `modules/ui/TrainingTab.py` - new entry under Timestep Shift in the noise frame
- `modules/ui/ConceptWindow.py` - per-concept entry in the general tab

21 files changed, 135 insertions, 24 deletions.

## Testing Notes

Local pytest suite covers stratification (every position in its bucket at N = 10/50/100), shift transform monotonicity and endpoint stability at shifts 0.5/1.0/2.0/3.0, algebraic equivalence to the existing N-domain shift, determinism across reruns, persistence across simulated epoch boundaries, per-concept override resolution, backward-compat (configs missing the field load with defaults and round-trip cleanly), N=1 edge case, mixin override correctness for both discrete and continuous, and the `GenerateLossesModel` no-override path still returning the midpoint. All 34 tests pass.

Tested on Windows 11, Python 3.10. The local test file is not part of this PR.

Didn't run a full GPU validation cycle since my GPU was busy on another job; the change is metadata-plumbing plus a deterministic algorithm, so the blast radius on actual training and forward-pass behaviour is limited to the timestep that gets fed into existing code paths.
