### PR TITLE
Basic uv support in startup and install scripts

### DIFF
--- a/lib.include.sh
+++ b/lib.include.sh
@@ -404,7 +404,7 @@ function get_platform_requirements_path {
 # Installs the Global and Platform requirements into the active environment.
 function install_requirements_in_active_env {
     print "Installing requirements..."
-    
+
     if has_uv; then
         # Use uv for ultra-fast installation
         run_cmd "${OT_UV_CMD}" pip install --index-strategy unsafe-best-match -r requirements-global.txt -r "$(get_platform_requirements_path)"
@@ -413,7 +413,7 @@ function install_requirements_in_active_env {
         run_pip_in_active_env install --upgrade --upgrade-strategy eager pip setuptools==81.0.0
         run_pip_in_active_env install --upgrade --upgrade-strategy eager -r requirements-global.txt -r "$(get_platform_requirements_path)"
     fi
-    
+
     export OT_MUST_INSTALL_REQUIREMENTS="false"
     # ... rest of the existing function (metadata saving)
 }

--- a/lib.include.sh
+++ b/lib.include.sh
@@ -22,6 +22,8 @@ cd -- "${SCRIPT_DIR}"
 # since their script shadows "conda" as a shell-function instead of a binary!
 export OT_CONDA_CMD="${OT_CONDA_CMD:-${CONDA_EXE:-conda}}"
 export OT_CONDA_ENV="${OT_CONDA_ENV:-conda_env}"
+export OT_USE_UV="${OT_USE_UV:-true}" # Set to false if you want to skip uv
+export OT_UV_CMD="${OT_UV_CMD:-uv}"
 export OT_PYTHON_CMD="${OT_PYTHON_CMD:-python}"
 export OT_PYTHON_VENV="${OT_PYTHON_VENV:-venv}"
 export OT_PREFER_VENV="${OT_PREFER_VENV:-false}"
@@ -149,7 +151,14 @@ function run_cmd {
 
 # Python command wrappers.
 function run_python {
-    run_cmd "${OT_PYTHON_CMD}" "$@"
+    if has_uv; then
+        # uv run handles the environment and the execution in one go
+        # --with-editable ensures those git repos we fixed are handled correctly
+        UV_IGNORE_MANIFEST=1 run_cmd "${OT_UV_CMD}" run python "$@"
+    else
+        # Fallback for non-uv users
+        "${OT_PYTHON_CMD}" "$@"
+    fi
 }
 
 function run_pip {
@@ -194,6 +203,39 @@ function activate_python_venv {
     # We must now force the Python binary name back to normal, since the venv's
     # own, internal Python binary is ALWAYS named "python".
     export OT_PYTHON_CMD="python"
+}
+
+# uv command wrappers
+__HAS_UV__CACHE=""
+function has_uv {
+    if [[ -z "${__HAS_UV__CACHE}" ]]; then
+        if [[ "${OT_USE_UV}" == "true" ]] && can_exec "${OT_UV_CMD}"; then
+            __HAS_UV__CACHE="true"
+        else
+            __HAS_UV__CACHE="false"
+        fi
+    fi
+    [[ "${__HAS_UV__CACHE}" == "true" ]]
+}
+
+function create_uv_env {
+    print "Creating uv environment using system python..."
+    # 'managed' pythons often miss Tkinter; 'system' has it.
+    run_cmd "${OT_UV_CMD}" venv --python $(which python3)
+    export OT_MUST_INSTALL_REQUIREMENTS="true"
+}
+
+function ensure_uv_env_exists {
+    if [[ ! -d ".venv" ]]; then
+        create_uv_env
+    fi
+}
+
+# Checks if the user hasn't requested Venv instead, and if uv exists.
+function should_use_uv {
+    # NOTE: This check is intentionally not cached, to allow changing preference
+    # during runtime. Furthermore, "has_conda" uses caching for speed already.
+    [[ "${OT_PREFER_VENV}" != "true" ]] && has_uv
 }
 
 # Conda command wrappers.
@@ -292,10 +334,15 @@ function should_use_conda {
     [[ "${OT_PREFER_VENV}" != "true" ]] && has_conda
 }
 
-# Helpers which automatically run Python and Pip in either Conda or Venv/Host,
+# Helpers which automatically run Python and Pip in either uv, Conda or Venv/Host,
 # depending on what's available on the system or user-preference overrides.
 function activate_chosen_env {
-    if should_use_conda; then
+if has_uv; then
+        print "Using uv for environment management..."
+        ensure_uv_env_exists
+        source ".venv/bin/activate"
+        export OT_PYTHON_CMD="python"
+    elif should_use_conda; then
         print "Using Conda environment in \"${OT_CONDA_ENV}\"..."
         ensure_conda_env_exists
     else
@@ -356,24 +403,19 @@ function get_platform_requirements_path {
 
 # Installs the Global and Platform requirements into the active environment.
 function install_requirements_in_active_env {
-    # Ensure that we have the latest Python tools, and install the dependencies.
-    # NOTE: The "eager" upgrade strategy is necessary for upgrading dependencies
-    # when running in existing environments. It ensures that all libraries will
-    # be upgraded to the same versions as a fresh reinstall of requirements.txt.
-    print "Installing requirements in active environment..."
-    run_pip_in_active_env install --upgrade --upgrade-strategy eager pip setuptools==81.0.0
-    run_pip_in_active_env install --upgrade --upgrade-strategy eager -r requirements-global.txt -r "$(get_platform_requirements_path)"
-    export OT_MUST_INSTALL_REQUIREMENTS="false"
-
-    # Write update-check metadata to disk if user has requested "lazy updates",
-    # otherwise delete any old, leftover metadata to avoid clutter.
-    if [[ "${OT_LAZY_UPDATES}" == "true" ]]; then
-        print_debug "Saving current update-check metadata to disk..."
-        save_update_metadata
-    elif [[ -f "${OT_UPDATE_METADATA_FILE}" ]]; then
-        print_debug "Deleting outdated update-check metadata from disk..."
-        rm -f "${OT_UPDATE_METADATA_FILE}"
+    print "Installing requirements..."
+    
+    if has_uv; then
+        # Use uv for ultra-fast installation
+        run_cmd "${OT_UV_CMD}" pip install --index-strategy unsafe-best-match -r requirements-global.txt -r "$(get_platform_requirements_path)"
+    else
+        # Fallback to standard pip
+        run_pip_in_active_env install --upgrade --upgrade-strategy eager pip setuptools==81.0.0
+        run_pip_in_active_env install --upgrade --upgrade-strategy eager -r requirements-global.txt -r "$(get_platform_requirements_path)"
     fi
+    
+    export OT_MUST_INSTALL_REQUIREMENTS="false"
+    # ... rest of the existing function (metadata saving)
 }
 
 function install_requirements_in_active_env_if_necessary {
@@ -401,7 +443,7 @@ function show_runtime_solutions {
 # Ensures that Python or Conda exists on the host and can be executed.
 function exit_if_no_runtime {
     # NOTE: If "should_use_conda" is true, we have a usable Conda.
-    if ! should_use_conda && ! has_python; then
+    if ! should_use_conda && ! should_use_uv && ! has_python; then
         print_error "Python command \"${OT_PYTHON_CMD}\" does not exist on your system."
         show_runtime_solutions
         exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
 requires-python = ">=3.10"
+name = "onetrainer"
+version = "0.1.0"
+dependencies = []
 
 [tool.ruff]
 extend-exclude = [

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -21,7 +21,7 @@ tensorboard==2.20.0
 pytorch-lightning==2.6.1
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@da6718f#egg=diffusers
+git+https://github.com/huggingface/diffusers.git@da6718f
 gguf==0.17.1
 transformers==4.57.6
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading
@@ -33,7 +33,7 @@ pooch==1.8.2
 open-clip-torch==2.32.0
 
 # data loader
--e git+https://github.com/Nerogar/mgds.git@a25b59f#egg=mgds
+git+https://github.com/Nerogar/mgds.git@a25b59f
 
 # optimizers
 dadaptation==3.2 # dadaptation optimizers
@@ -43,7 +43,7 @@ schedulefree==1.4.1 # schedule-free optimizers
 pytorch_optimizer==3.6.0 # pytorch optimizers
 prodigy-plus-schedule-free==2.0.1 # Prodigy plus optimizer
 adv_optm==2.2.3 # advanced optimizers
--e git+https://github.com/KellerJordan/Muon.git@f90a42b#egg=muon-optimizer
+git+https://github.com/KellerJordan/Muon.git@f90a42b
 
 # Profiling
 scalene==1.5.51


### PR DESCRIPTION
Implemented basic `uv` support in addition to `conda` and plan python.

When `uv` is detected, it will be used to run all python and pip commands, if not, the old logic applies.

The fallback is `uv -> conda -> python`