### PR TITLE
Fix: apply aux optimizer defaults when current_state is empty

### DIFF
--- a/modules/ui/OptimizerParamsWindow.py
+++ b/modules/ui/OptimizerParamsWindow.py
@@ -271,7 +271,7 @@ class OptimizerParamsWindow(ctk.CTkToplevel):
         else:
             defaults = OPTIMIZER_DEFAULT_PARAMETERS[Optimizer.ADAMW_ADV]
 
-        if current_state is None:
+        if not current_state:
             adam_config.from_dict(defaults)
             if current_optimizer != Optimizer.MUON:
                 adam_config.optimizer = Optimizer.ADAMW_ADV


### PR DESCRIPTION
## Summary

- `OptimizerParamsWindow` checked `current_state is None` before populating defaults, but `current_state` can also be an empty dict `{}` when no config has been saved yet
- Changed to `not current_state` so defaults are applied for both `None` and empty state
- Fixes MuonWithAuxAdam aux optimizer window showing blank fields instead of defaults on first open

## Test plan

- [x] Select MuonWithAuxAdam, open the aux optimizer params window with no prior config — confirm beta1/beta2/eps/weight\_decay show their default values