### PR TITLE
Remove COFT

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -341,18 +341,14 @@ class OFTModule(PeftBase):
     oft_R: OFTRotationModule | None
     rank: int
     oft_block_size: int
-    coft: bool
-    coft_eps: float
     block_share: bool
     dropout_probability: float
     adjustment_info: tuple[int, int] | None # for reporting
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, coft: bool, coft_eps: float, block_share: bool, **kwargs):
+    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, **kwargs):
         super().__init__(prefix, orig_module)
         self.oft_block_size = oft_block_size
         self.rank = 0
-        self.coft = coft
-        self.coft_eps = coft_eps
         self.block_share = block_share
         self.dropout_probability = kwargs.pop('dropout_probability', 0.0)
         self.oft_R = None
@@ -418,8 +414,6 @@ class OFTModule(PeftBase):
             n_elements=n_elements,
             block_size=self.oft_block_size,
             in_features=in_features,
-            coft=self.coft,
-            coft_eps=self.coft_eps,
             block_share=self.block_share,
             use_cayley_neumann=True,
             num_cayley_neumann_terms=5,
@@ -625,8 +619,6 @@ class LoRAModuleWrapper:
             self.dummy_klass = DummyOFTModule
             self.additional_args = [
                 config.oft_block_size,
-                config.oft_coft,
-                config.coft_eps,
                 config.oft_block_share,
             ]
             self.additional_kwargs = {

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -41,8 +41,6 @@ class OFTRotationModule(nn.Module):
         n_elements,
         block_size,
         in_features,
-        coft=False,
-        coft_eps=6e-5,
         block_share=False,
         use_cayley_neumann=True,
         num_cayley_neumann_terms=5,
@@ -54,8 +52,6 @@ class OFTRotationModule(nn.Module):
         self.block_size = block_size
         self.in_features = in_features
         self.weight = nn.Parameter(torch.empty(r, n_elements))
-        self.coft = coft
-        self.coft_eps = coft_eps
         self.block_share = block_share
         self.use_cayley_neumann = use_cayley_neumann
         self.num_cayley_neumann_terms = num_cayley_neumann_terms
@@ -118,32 +114,12 @@ class OFTRotationModule(nn.Module):
 
         return R.to(previous_dtype)
 
-    def _project_batch(self, Q, coft_eps=1e-4):
-        oft_R = self._pytorch_skew_symmetric(Q, self.block_size)
-        # scaling factor for each of the smaller block matrix
-        coft_eps = coft_eps * 1 / torch.sqrt(torch.tensor(oft_R.shape[0]))
-        origin_matrix = (
-            torch.zeros((oft_R.size(1), oft_R.size(1)), device=oft_R.device, dtype=oft_R.dtype)
-            .unsqueeze(0)
-            .expand_as(oft_R)
-        )
-        diff = oft_R - origin_matrix
-        norm_diff = torch.norm(oft_R - origin_matrix, dim=(1, 2), keepdim=True)
-        mask = (norm_diff <= coft_eps).bool()
-        out = torch.where(mask, oft_R, origin_matrix + coft_eps * (diff / norm_diff))
-
-        return self._pytorch_skew_symmetric_inv(out, self.block_size)
-
     def forward(self, x):
         required_dtype = x.dtype
         if required_dtype != self.weight.dtype:
             x = x.to(self.weight.dtype)
 
         orig_shape = x.shape
-
-        if self.coft:
-            with torch.no_grad():
-                self.weight.copy_(self._project_batch(self.weight, coft_eps=self.coft_eps))
 
         orth_rotate = self._cayley_batch(
             self.weight, self.block_size, self.use_cayley_neumann, self.num_cayley_neumann_terms

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -121,19 +121,10 @@ class LoraTab:
                             tooltip=f"The block size parameter used when creating a new {name}")
             components.entry(master, 1, 1, self.ui_state, "oft_block_size", required=True)
 
-            # COFT
-            components.label(master, 1, 3, "Constrained OFT (COFT)",
-                             tooltip="Use the constrained variant of OFT. This constrains the learned rotation to stay very close to the identity matrix, limiting adaptation to only small changes. This improves training stability, helps prevent overfitting on small datasets, and better preserves the base models original knowledge but it may lack expressiveness for tasks requiring substantial adaptation and introduces an additional hyperparameter (COFT Epsilon) that needs tuning.")
-            components.switch(master, 1, 4, self.ui_state, "oft_coft")
-
-            components.label(master, 2, 3, "COFT Epsilon",
-                             tooltip="The control strength of COFT. Only has an effect if COFT is enabled.")
-            components.entry(master, 2, 4, self.ui_state, "coft_eps")
-
             # Block Share
-            components.label(master, 3, 3, "Block Share",
+            components.label(master, 1, 3, "Block Share",
                              tooltip="Share the OFT parameters between blocks. A single rotation matrix is shared across all blocks within a layer, drastically cutting the number of trainable parameters and yielding very compact adapter files, potentially improving generalization but at the cost of significant expressiveness, which can lead to underfitting on more complex or diverse tasks.")
-            components.switch(master, 3, 4, self.ui_state, "oft_block_share")
+            components.switch(master, 1, 4, self.ui_state, "oft_block_share")
 
             # Dropout Percentage
             components.label(master, 2, 0, "Dropout Probability",

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -520,8 +520,6 @@ class TrainConfig(BaseConfig):
 
     # oft
     oft_block_size: int
-    oft_coft: bool
-    coft_eps: float
     oft_block_share: bool
 
     # optimizer
@@ -1150,8 +1148,6 @@ class TrainConfig(BaseConfig):
 
         # oft
         data.append(("oft_block_size", 32, int, False))
-        data.append(("oft_coft", False, bool, False))
-        data.append(("coft_eps", 1e-4, float, False))
         data.append(("oft_block_share", False, bool, False))
 
         # optimizer


### PR DESCRIPTION
Since it never worked well, and because weight decay in OFT mathematically caps the maximum rotation angle the model can learn; it produces a COFT-like effect.