### PR TITLE
Security: Path traversal in SDConfigModelLoaderMixin

### DIFF
--- a/modules/modelLoader/mixin/SDConfigModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/SDConfigModelLoaderMixin.py
@@ -24,12 +24,12 @@ class SDConfigModelLoaderMixin(metaclass=ABCMeta):
         yaml_name = None
 
         if base_model_name:
-            new_yaml_name = os.path.splitext(base_model_name)[0] + '.yaml'
+            new_yaml_name = os.path.splitext(os.path.basename(base_model_name))[0] + '.yaml'
             if os.path.exists(new_yaml_name):
                 yaml_name = new_yaml_name
 
             if not yaml_name:
-                new_yaml_name = os.path.splitext(base_model_name)[0] + '.yml'
+                new_yaml_name = os.path.splitext(os.path.basename(base_model_name))[0] + '.yml'
                 if os.path.exists(new_yaml_name):
                     yaml_name = new_yaml_name
 


### PR DESCRIPTION
## Summary

Security: Path traversal in SDConfigModelLoaderMixin

## Problem

**Severity**: `High` | **File**: `modules/modelLoader/mixin/SDConfigModelLoaderMixin.py:L25`

The method `_get_sd_config_name` constructs a file path by appending '.yaml' or '.yml' to the base model name without sanitizing directory traversal sequences (e.g., '../'). An attacker who controls `base_model_name` (e.g., via a model file path provided by the user) could cause the application to read arbitrary files from the filesystem. The path is then opened and parsed as YAML, potentially leaking sensitive information.

## Solution

Validate and sanitize `base_model_name` before using it to construct file paths. Use `os.path.basename` to strip directory components, or use a whitelist of allowed characters. Consider using a secure path resolution function that resolves the path relative to a trusted root directory and checks that the resolved path stays within that root.

## Changes

- `modules/modelLoader/mixin/SDConfigModelLoaderMixin.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"