### PR TITLE
AI slop PR, closed due to lack of quality

### DIFF
--- a/modules/dataLoader/LtxVideoBaseDataLoader.py
+++ b/modules/dataLoader/LtxVideoBaseDataLoader.py
@@ -1,0 +1,75 @@
+import torch
+from torch.utils.data import DataLoader
+from modules.dataLoader.BaseDataLoader import BaseDataLoader
+from modules.dataLoader.DataLoaderText2ImageMixin import DataLoaderText2ImageMixin
+from modules.model.LtxVideoModel import LtxVideoModel
+from modules.util.TrainProgress import TrainProgress
+from modules.util.config.TrainConfig import TrainConfig
+from modules.util.enum.DataType import DataType
+
+class LtxVideoBaseDataLoader(BaseDataLoader, DataLoaderText2ImageMixin):
+    def __init__(self, train_progress: TrainProgress, config: TrainConfig, model: LtxVideoModel, device: torch.device):
+        super().__init__(train_progress, config, model, device)
+        self.frame_rate = 25
+        self.latent_scaling_factor = model.latent_scaling_factor if hasattr(model, 'latent_scaling_factor') else 0.18215
+
+    def load_batch(self, batch: dict) -> dict:
+        video_path = batch['video_path']
+        frames = self._load_video_frames(video_path, batch.get('start_frame', 0), batch.get('num_frames', 16))
+        latents = batch.get('latents')
+        if latents is None:
+            latents = self.encode_latents(frames)
+        else:
+            latents = latents.to(self.device)
+        conditioning = self.encode_prompts(batch.get('caption', ''))
+        mask = batch.get('mask')
+        if mask is not None:
+            mask = mask.to(self.device)
+        return {
+            'latents': latents,
+            'conditioning': conditioning,
+            'mask': mask,
+            'frames': frames.to(self.device) if batch.get('return_frames', False) else None
+        }
+
+    def encode_prompts(self, caption: str) -> dict:
+        tokenizer = self.model.tokenizer
+        text_encoder = self.model.text_encoder
+        tokens = tokenizer(caption, return_tensors='pt', padding=True, truncation=True, max_length=77).to(self.device)
+        with torch.no_grad():
+            encoder_hidden_states = text_encoder(tokens.input_ids)[0]
+        return {'encoder_hidden_states': encoder_hidden_states, 'attention_mask': tokens.attention_mask}
+
+    def encode_latents(self, frames: torch.Tensor) -> torch.Tensor:
+        vae = self.model.vae
+        frames = frames.to(self.device)
+        with torch.no_grad():
+            latents = vae.encode(frames).latent_dist.sample() * self.latent_scaling_factor
+        return latents
+
+    def _load_video_frames(self, video_path: str, start_frame: int, num_frames: int) -> torch.Tensor:
+        import decord
+        from decord import VideoReader, cpu
+        vr = VideoReader(video_path, ctx=cpu(0))
+        total_frames = len(vr)
+        end_frame = min(start_frame + num_frames, total_frames)
+        indices = list(range(start_frame, end_frame))
+        if len(indices) < num_frames:
+            indices = indices + [indices[-1]] * (num_frames - len(indices))
+        frames = vr.get_batch(indices).asnumpy()
+        frames = torch.from_numpy(frames).float() / 127.5 - 1.0
+        frames = frames.permute(0, 3, 1, 2)
+        return frames
+
+    def __getitem__(self, index):
+        sample = self.dataset[index]
+        batch = self.load_batch(sample)
+        return batch
+
+    def collate_fn(self, batch):
+        latents = torch.stack([item['latents'] for item in batch])
+        conditioning = {'encoder_hidden_states': torch.stack([item['conditioning']['encoder_hidden_states'] for item in batch]),
+                        'attention_mask': torch.stack([item['conditioning']['attention_mask'] for item in batch])}
+        mask = torch.stack([item['mask'] for item in batch]) if batch[0]['mask'] is not None else None
+        frames = torch.stack([item['frames'] for item in batch]) if batch[0]['frames'] is not None else None
+        return {'latents': latents, 'conditioning': conditioning, 'mask': mask, 'frames': frames}

--- a/modules/model/LtxVideoModel.py
+++ b/modules/model/LtxVideoModel.py
@@ -1,0 +1,113 @@
+import torch
+import torch.nn as nn
+from diffusers import LTXPipeline, AutoencoderKLLTX, LTXTransformer3DModel
+from transformers import T5EncoderModel, T5Tokenizer
+from modules.model.BaseModel import BaseModel
+from modules.util import list_utils
+from modules.util.TrainProgress import TrainProgress
+
+
+class LtxVideoModel(BaseModel):
+    def __init__(self, model_config):
+        super().__init__(model_config)
+        self.model: LTXTransformer3DModel = None
+        self.vae: AutoencoderKLLTX = None
+        self.text_encoder: T5EncoderModel = None
+        self.tokenizer: T5Tokenizer = None
+        self.pipeline: LTXPipeline = None
+
+    def load_model(self, model_path, vae_path=None, text_encoder_path=None, weight_dtype=torch.float32):
+        self.pipeline = LTXPipeline.from_pretrained(model_path, torch_dtype=weight_dtype)
+        self.model = self.pipeline.transformer
+        self.vae = self.pipeline.vae
+        self.text_encoder = self.pipeline.text_encoder
+        self.tokenizer = self.pipeline.tokenizer
+
+        if vae_path:
+            self.vae = AutoencoderKLLTX.from_pretrained(vae_path, torch_dtype=weight_dtype)
+        if text_encoder_path:
+            self.text_encoder = T5EncoderModel.from_pretrained(text_encoder_path, torch_dtype=weight_dtype)
+
+        self.model.requires_grad_(True)
+        self.vae.requires_grad_(False)
+        self.text_encoder.requires_grad_(False)
+
+    def encode(self, video_frames, frames_indices=None):
+        batch_size, num_frames, channels, height, width = video_frames.shape
+        video_frames = video_frames.to(self.vae.device, dtype=self.vae.dtype)
+        latents = []
+        for t in range(num_frames):
+            frame = video_frames[:, t, :, :, :]
+            latent = self.vae.encode(frame).latent_dist.sample()
+            latents.append(latent)
+        latents = torch.stack(latents, dim=1)
+        return latents * self.vae.config.scaling_factor
+
+    def get_noise_prediction(self, latents, timestep, conditioning, mask=None):
+        latents = latents.to(self.model.device, dtype=self.model.dtype)
+        timestep = timestep.to(self.model.device)
+        conditioning = conditioning.to(self.model.device, dtype=self.model.dtype)
+        noise_pred = self.model(
+            latent_sample=latents,
+            timestep=timestep,
+            encoder_hidden_states=conditioning,
+            return_dict=False
+        )[0]
+        return noise_pred
+
+    def get_target(self, latents, noise):
+        return noise
+
+    def get_conditioning(self, prompt, negative_prompt=None, prompt_2=None, negative_prompt_2=None):
+        text_inputs = self.tokenizer(prompt, padding='max_length', max_length=512, truncation=True, return_tensors='pt')
+        text_embeddings = self.text_encoder(text_inputs.input_ids.to(self.text_encoder.device))[0]
+        if negative_prompt:
+            neg_inputs = self.tokenizer(negative_prompt, padding='max_length', max_length=512, truncation=True, return_tensors='pt')
+            neg_embeddings = self.text_encoder(neg_inputs.input_ids.to(self.text_encoder.device))[0]
+            return torch.cat([neg_embeddings, text_embeddings])
+        return text_embeddings
+
+    def decode_latent(self, latents, frames_indices=None):
+        latents = latents / self.vae.config.scaling_factor
+        batch_size, num_frames, channels, height, width = latents.shape
+        decoded_frames = []
+        for t in range(num_frames):
+            frame_latent = latents[:, t, :, :, :]
+            decoded = self.vae.decode(frame_latent).sample
+            decoded_frames.append(decoded)
+        decoded_frames = torch.stack(decoded_frames, dim=1)
+        return decoded_frames.clamp(-1, 1)
+
+    def get_latent_shape(self, batch_size, num_frames, height, width):
+        latent_height = height // self.vae.config.downsampling_factor
+        latent_width = width // self.vae.config.downsampling_factor
+        return (batch_size, num_frames, self.vae.config.latent_channels, latent_height, latent_width)
+
+    def apply_lora(self, lora_path, alpha=1.0, target_modules=None):
+        from peft import LoraConfig, get_peft_model
+        lora_config = LoraConfig(
+            r=int(alpha * 16),
+            lora_alpha=alpha,
+            target_modules=target_modules or ["to_q", "to_k", "to_v", "to_out"],
+            lora_dropout=0.0,
+            bias="none",
+        )
+        self.model = get_peft_model(self.model, lora_config)
+        lora_state = torch.load(lora_path, map_location='cpu')
+        self.model.load_state_dict(lora_state, strict=False)
+
+    def save_lora(self, output_path):
+        lora_state = {k: v for k, v in self.model.state_dict().items() if 'lora' in k}
+        torch.save(lora_state, output_path)
+
+    def to(self, device, dtype=None):
+        self.model.to(device, dtype=dtype)
+        self.vae.to(device, dtype=dtype)
+        self.text_encoder.to(device, dtype=dtype)
+        return self
+
+    def train(self):
+        self.model.train()
+
+    def eval(self):
+        self.model.eval()


### PR DESCRIPTION
## Summary

fix: resolve #1423 — [Feat]: LTX 2.3 support

## Problem

**Severity**: `Medium` | **File**: `modules/model/LtxVideoModel.py`

Create a new model class for LTX Video 2.3 supporting LoRA/DoRA training. The class should inherit from BaseModel and implement methods for loading the transformer, VAE, and text encoder (T5). It must handle video latents, frame handling, and conditioning. Since LTX 2.3 uses a DiT architecture, the model will follow patterns from HunyuanVideoModel.

## Solution

Implement LtxVideoModel with attributes: model (transformer), vae, text_encoder (T5), and possibly additional encoders. Override `load_model`, `encode`, `get_noise_prediction`, `get_target`, `get_conditioning`, etc. Use `diffusers` pipeline if available; otherwise implement custom loading from checkpoint. For LoRA, use `peft` or manual patching. Ensure compatibility with OneTrainer's training loop.

## Changes

- `modules/model/LtxVideoModel.py` (new)
- `modules/dataLoader/LtxVideoBaseDataLoader.py` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"