### PR TITLE
fix: upload tag_dropout_special_tags file for cloud training

### DIFF
--- a/modules/cloud/BaseCloud.py
+++ b/modules/cloud/BaseCloud.py
@@ -68,6 +68,9 @@ class BaseCloud(metaclass=ABCMeta):
             if hasattr(concept.text,"local_prompt_path"):
                 self.file_sync.sync_up_file(local=Path(concept.text.local_prompt_path),remote=Path(concept.text.prompt_path))
 
+            if hasattr(concept.text,"local_tag_dropout_special_tags"):
+                self.file_sync.sync_up_file(local=Path(concept.text.local_tag_dropout_special_tags),remote=Path(concept.text.tag_dropout_special_tags))
+
     @staticmethod
     def _filter_download(config : CloudConfig,path : Path):
         if 'samples' in path.parts:

--- a/modules/trainer/CloudTrainer.py
+++ b/modules/trainer/CloudTrainer.py
@@ -175,6 +175,10 @@ class CloudTrainer(BaseTrainer):
         for concept in remote.concepts:
             adjust(concept,"path", if_exists=True)
             adjust(concept.text,"prompt_path")
+            #tag_dropout_special_tags may hold an inline tag list or a path to a .txt/.csv file;
+            #only remap+upload it when it's actually a file, matching DropTags' own detection:
+            if concept.text.tag_dropout_special_tags.lower().endswith((".txt", ".csv")):
+                adjust(concept.text,"tag_dropout_special_tags", if_exists=True)
 
         if remote.train_device == "cpu":
             #if there is no local GPU, "cpu" is the default, but not correct for cloud training


### PR DESCRIPTION
When tag_dropout_special_tags is a path to a .txt/.csv file, remap it to its remote location and upload it, mirroring prompt_path. Previously the file was never uploaded and the path not remapped, so cloud DropTags silently treated the path string as an inline tag list.

obscure bug @claude found during review of https://github.com/Nerogar/OneTrainer/pull/1406