### PR TITLE
fix: don't drop epoch validation on mid-epoch resume

### DIFF
--- a/modules/modelLoader/mixin/InternalModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/InternalModelLoaderMixin.py
@@ -28,6 +28,18 @@ class InternalModelLoaderMixin(metaclass=ABCMeta):
                     epoch_sample=meta['train_progress']['epoch_sample'],
                     global_step=meta['train_progress']['global_step'],
                 )
+                if 'last_action_epoch' in meta:
+                    train_progress.last_action_epoch = dict(meta['last_action_epoch'])
+                elif train_progress.epoch_step > 0:
+                    # Legacy backup taken mid-epoch: start-of-epoch actions
+                    # already fired in the pre-fix session. Pre-fill markers
+                    # to prevent a duplicate fire on the first resumed batch.
+                    train_progress.last_action_epoch = {
+                        'validate': train_progress.epoch,
+                        'sample': train_progress.epoch,
+                    }
+                else:
+                    train_progress.last_action_epoch = {}
 
             # optimizer
             with contextlib.suppress(FileNotFoundError):

--- a/modules/modelSaver/mixin/InternalModelSaverMixin.py
+++ b/modules/modelSaver/mixin/InternalModelSaverMixin.py
@@ -39,4 +39,5 @@ class InternalModelSaverMixin(metaclass=ABCMeta):
                     'epoch_sample': model.train_progress.epoch_sample,
                     'global_step': model.train_progress.global_step,
                 },
+                'last_action_epoch': dict(getattr(model.train_progress, 'last_action_epoch', {})),
             }, meta_file)

--- a/modules/util/TimedActionMixin.py
+++ b/modules/util/TimedActionMixin.py
@@ -26,7 +26,12 @@ class TimedActionMixin:
                 if int(interval) == 0:
                     return False
                 if start_at_zero:
-                    return train_progress.epoch % int(interval) == 0 and train_progress.epoch_step == 0
+                    last = train_progress.last_action_epoch.get(name, -1)
+                    fire = train_progress.epoch > last \
+                        and train_progress.epoch % int(interval) == 0
+                    if fire:
+                        train_progress.last_action_epoch[name] = train_progress.epoch
+                    return fire
                 else:
                     # should actually be the last step of each epoch, but we don't know how many steps an epoch has
                     return train_progress.epoch % int(interval) == 0 and train_progress.epoch_step == 0 \

--- a/modules/util/TrainProgress.py
+++ b/modules/util/TrainProgress.py
@@ -5,11 +5,13 @@ class TrainProgress:
             epoch_step: int = 0,
             epoch_sample: int = 0,
             global_step: int = 0,
+            last_action_epoch: dict | None = None,
     ):
         self.epoch = epoch
         self.epoch_step = epoch_step
         self.epoch_sample = epoch_sample
         self.global_step = global_step
+        self.last_action_epoch = last_action_epoch if last_action_epoch is not None else {}
 
     def next_step(self, batch_size: int):
         self.epoch_step += 1


### PR DESCRIPTION
If a backup is taken mid-epoch and training is resumed, the validation scheduled for that epoch gets silently dropped. Reproduce: validate every epoch, train through epochs 1–4, stop halfway through 4, resume. Epoch 4 finishes with no validation point; the next data point is end-of-epoch 5, leaving a visible gap in the val-loss chart.

Root cause: the EPOCH `start_at_zero=True` trigger is `epoch % interval == 0 AND epoch_step == 0`. On mid-epoch resume, `epoch_step` is whatever step the backup was taken at (not 0), so the check fails for every batch in the resumed epoch.

Replaced with a `last_action_epoch: dict[str, int]` marker on `TrainProgress`, persisted in `meta.json`. The new condition is `epoch > last_action_epoch[name] AND epoch % interval == 0`, with the marker updated whenever the action fires — so each scheduled epoch action fires exactly once per epoch regardless of where the resume lands. Only the `start_at_zero=True` branch is touched; backup/save (`start_at_zero=False`) keep their existing semantics.

Legacy backups load cleanly: if the meta is mid-epoch the marker pre-fills to the current epoch (assumes validate/sample already fired in the pre-fix session); otherwise empty. No KeyError on pre-existing `meta.json`.

Split from #1422 per dxqb's request so this can merge ahead of the TensorBoard-continuity discussion.