### PR TITLE
fix: HiDream: tokenizer mixups

### DIFF
--- a/modules/modelLoader/hiDream/HiDreamModelLoader.py
+++ b/modules/modelLoader/hiDream/HiDreamModelLoader.py
@@ -102,7 +102,7 @@ class HiDreamModelLoader(
 
         tokenizer_2 = CLIPTokenizer.from_pretrained(
             base_model_name,
-            subfolder="tokenizer",
+            subfolder="tokenizer_2",
         ) if include_text_encoder_2 else None
 
         tokenizer_3 = T5Tokenizer.from_pretrained(
@@ -112,7 +112,7 @@ class HiDreamModelLoader(
 
         tokenizer_4 = LlamaTokenizerFast.from_pretrained(
             text_encoder_4_model_name,
-        ) if include_text_encoder_1 else None
+        ) if include_text_encoder_4 else None
 
         noise_scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
             base_model_name,


### PR DESCRIPTION
2 bugs that @claude has found during unrelated work:

tokenizer_2 (CLIP-G) was loaded from subfolder "tokenizer" instead of "tokenizer_2", giving it CLIP-L's pad_token ("!") instead of CLIP-G's ("<|endoftext|>"). Since CLIP-G was trained with EOS-padding, this caused degraded text_encoder_2 embeddings for short prompts.

- this might have affected training and sampling quality

tokenizer_4 (Llama) was guarded by include_text_encoder_1 instead of include_text_encoder_4, causing it to load/skip based on the wrong flag.

- probably didn't affect anything