### PR TITLE
Track models/ directory with .gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ debug*.py
 
 # user data
 /workspace*
-/models*
+/models/*
+!/models/.gitkeep
 /training_concepts
 /training_samples
 /training_user_settings


### PR DESCRIPTION
since UI validiation, the UI complains if `models/` doesn't exist.
this PR makes it exist
or do you prefer another solution, @O-J1 ?