### PR TITLE
fix: ignore submodule overrides when continuing fine-tune from backup

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -107,6 +107,8 @@ class GenericTrainer(BaseTrainer):
                     model_names.embedding.model_name = last_backup_path
                 else:  # fine-tunes
                     model_names.base_model = last_backup_path
+                    # drop submodule overrides so the backup is loaded in full
+                    model_names.clear_overrides()
 
                 print(f"Continuing training from backup '{last_backup_path}'...")
             else:

--- a/modules/util/ModelNames.py
+++ b/modules/util/ModelNames.py
@@ -41,6 +41,17 @@ class ModelNames:
         self.include_text_encoder_3 = include_text_encoder_3
         self.include_text_encoder_4 = include_text_encoder_4
 
+    # reset all base-model submodule overrides. used when continuing a
+    # fine-tune from a backup: the backup is a complete internal model, so
+    # overrides must not shadow it
+    def clear_overrides(self):
+        self.prior_model = ""
+        self.transformer_model = ""
+        self.effnet_encoder_model = ""
+        self.decoder_model = ""
+        self.text_encoder_4 = ""
+        self.vae_model = ""
+
     def all_embedding(self):
         if self.embedding is not None:
             return self.additional_embeddings + [self.embedding]


### PR DESCRIPTION
fixes https://github.com/Nerogar/OneTrainer/issues/1402