### PR TITLE
Dark mode for Qt6

### DIFF
--- a/modules/util/ui/pyside6_util.py
+++ b/modules/util/ui/pyside6_util.py
@@ -3,8 +3,8 @@ import signal
 import sys
 from abc import ABCMeta
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor, QPalette
+from modules.util.ui.theme import apply_theme
+
 from PySide6.QtWidgets import QApplication, QStyleFactory, QWidget
 
 
@@ -32,36 +32,7 @@ def create_application() -> QApplication:
     # controls via OS theme APIs, which breaks once an application stylesheet
     # is set, producing a flatter look than Fusion's own stylesheet-aware painting.
     app.setStyle(QStyleFactory.create("Fusion"))
-    app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
-    palette = app.palette()
-    palette.setColor(QPalette.ColorRole.Base, QColor("white"))
-    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, QColor("#e0e0e0"))
-    app.setPalette(palette)
-
-    app.setStyleSheet("""
-        QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
-            padding: 2px 2px;
-        }
-        QCheckBox::indicator {
-            width: 16px;
-            height: 16px;
-        }
-        QProgressBar {
-            background-color: #c8c8c8;
-        }
-        QToolButton {
-            padding-top: 0px;
-            padding-bottom: 0px;
-            padding-right: 40px;
-        }
-        QToolButton::menu-indicator {
-            subcontrol-origin: padding;
-            subcontrol-position: right center;
-            width: 12px;
-            height: 12px;
-            right: 10px;
-        }
-    """)
+    apply_theme(app)
 
     return app

--- a/modules/util/ui/theme.py
+++ b/modules/util/ui/theme.py
@@ -1,11 +1,8 @@
 import os
-import platform
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
-
-IS_WINDOWS = platform.system() == "Windows"
 
 # Lets reviewers whose OS never reports dark still see the dark theme, by pretending it did.
 OT_FORCE_DARK = os.environ.get("OT_FORCE_DARK") == "1"
@@ -17,9 +14,6 @@ _BASE_STYLESHEET = """
     QCheckBox::indicator {
         width: 16px;
         height: 16px;
-    }
-    QProgressBar {
-        background-color: #c8c8c8;
     }
     QToolButton {
         padding-top: 0px;
@@ -35,16 +29,24 @@ _BASE_STYLESHEET = """
     }
 """
 
+# grey-on-dark is unreadable (see #1488 review discussion); only apply the grey progress bar in light mode.
+_LIGHT_STYLESHEET = """
+    QProgressBar {
+        background-color: #c8c8c8;
+    }
+"""
+
 def apply_theme(app: QApplication) -> None:
-    is_dark =  app.palette().color(QPalette.ColorRole.Window).lightness() < 128
-    palette = app.palette()
     if OT_FORCE_DARK:
         app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
-        palette = app.palette()
-    elif not IS_WINDOWS or not is_dark:
+        is_dark = True
+    else:
+        is_dark = app.styleHints().colorScheme() == Qt.ColorScheme.Dark
+
+    palette = app.palette()
+    if not is_dark:
         app.styleHints().setColorScheme(Qt.ColorScheme.Light)
-        palette = app.palette()
         palette.setColor(QPalette.ColorRole.Base, QColor("white"))
         palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, QColor("#e0e0e0"))
     app.setPalette(palette)
-    app.setStyleSheet(_BASE_STYLESHEET)
+    app.setStyleSheet(_BASE_STYLESHEET if is_dark else _BASE_STYLESHEET + _LIGHT_STYLESHEET)

--- a/modules/util/ui/theme.py
+++ b/modules/util/ui/theme.py
@@ -29,7 +29,6 @@ _BASE_STYLESHEET = """
     }
 """
 
-# grey-on-dark is unreadable (see #1488 review discussion); only apply the grey progress bar in light mode.
 _LIGHT_STYLESHEET = """
     QProgressBar {
         background-color: #c8c8c8;

--- a/modules/util/ui/theme.py
+++ b/modules/util/ui/theme.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 from PySide6.QtCore import Qt
@@ -5,6 +6,9 @@ from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
 
 IS_WINDOWS = platform.system() == "Windows"
+
+# Lets reviewers whose OS never reports dark still see the dark theme, by pretending it did.
+OT_FORCE_DARK = os.environ.get("OT_FORCE_DARK") == "1"
 
 _BASE_STYLESHEET = """
     QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
@@ -34,7 +38,10 @@ _BASE_STYLESHEET = """
 def apply_theme(app: QApplication) -> None:
     is_dark =  app.palette().color(QPalette.ColorRole.Window).lightness() < 128
     palette = app.palette()
-    if not IS_WINDOWS or not is_dark:
+    if OT_FORCE_DARK:
+        app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
+        palette = app.palette()
+    elif not IS_WINDOWS or not is_dark:
         app.styleHints().setColorScheme(Qt.ColorScheme.Light)
         palette = app.palette()
         palette.setColor(QPalette.ColorRole.Base, QColor("white"))

--- a/modules/util/ui/theme.py
+++ b/modules/util/ui/theme.py
@@ -1,0 +1,43 @@
+import platform
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
+
+IS_WINDOWS = platform.system() == "Windows"
+
+_BASE_STYLESHEET = """
+    QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
+        padding: 2px 2px;
+    }
+    QCheckBox::indicator {
+        width: 16px;
+        height: 16px;
+    }
+    QProgressBar {
+        background-color: #c8c8c8;
+    }
+    QToolButton {
+        padding-top: 0px;
+        padding-bottom: 0px;
+        padding-right: 40px;
+    }
+    QToolButton::menu-indicator {
+        subcontrol-origin: padding;
+        subcontrol-position: right center;
+        width: 12px;
+        height: 12px;
+        right: 10px;
+    }
+"""
+
+def apply_theme(app: QApplication) -> None:
+    is_dark =  app.palette().color(QPalette.ColorRole.Window).lightness() < 128
+    palette = app.palette()
+    if not IS_WINDOWS or not is_dark:
+        app.styleHints().setColorScheme(Qt.ColorScheme.Light)
+        palette = app.palette()
+        palette.setColor(QPalette.ColorRole.Base, QColor("white"))
+        palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, QColor("#e0e0e0"))
+    app.setPalette(palette)
+    app.setStyleSheet(_BASE_STYLESHEET)


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read AGENTS.md (project rules for any AI-assisted work) before opening this PR,
and docs/Contributing.md / docs/ProjectStructure.md for the wider project guide.
-->

## Summary

Fix various small issues that occured on Windows:
- _Remove SetProcessDpiAwareness(1) hack that prevented Qt6 from setting its preferred DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 context. I've tested this as I have two monitor and didn't got the transparent issue or the UI re-render on the other screen FYI._ -> Already in preview now
- Replace the forced light-mode workaround with a Windows-scoped apply_theme() that respects the system dark/light
  preference. Linux/macOS keep Qt's native theming untouched.
 - Add theme.py which applies the existing base stylesheet on all platforms and, on Windows only, layers QSS overrides
  (QTabWidget::pane / QTabBar contrast fixes + an adaptive progressbar) plus a white text-box fix for light mode — since
  Qt's dark mode renders tabs with no contrast on Windows.

The important gist is that the preferred mode is now respected and both light and dark are usable.

<img width="1748" height="1330" alt="Screenshot 2026-05-30 204634" src="https://github.com/user-attachments/assets/112bd0fe-b365-4a1b-9943-ac2e13bf9ca3" />
<img width="1751" height="1336" alt="Screenshot 2026-05-30 204639" src="https://github.com/user-attachments/assets/ab666f67-94a7-4d65-925d-ca40e9c87f42" />


## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Change is purely UI/Visual so no need for such test here)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->


