### PR TITLE
Clipped OFT Norm for Long-term Stability

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -578,11 +578,11 @@ class OFTModule(PeftBase):
     oft_block_size: int
     block_share: bool
     oft_scaled: bool
-    oft_clipped_norm: float
+    oft_clipped_norm: float | None
     dropout_probability: float
     adjustment_info: tuple[int, int] | None # for reporting
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_clipped_norm: float, **kwargs):
+    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_clipped_norm: float | None, **kwargs):
         super().__init__(prefix, orig_module)
         self.oft_block_size = oft_block_size
         self.rank = 0

--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -578,11 +578,11 @@ class OFTModule(PeftBase):
     oft_block_size: int
     block_share: bool
     oft_scaled: bool
-    oft_clipped_norm: bool
+    oft_clipped_norm: float
     dropout_probability: float
     adjustment_info: tuple[int, int] | None # for reporting
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_clipped_norm: bool, **kwargs):
+    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_clipped_norm: float, **kwargs):
         super().__init__(prefix, orig_module)
         self.oft_block_size = oft_block_size
         self.rank = 0

--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -578,15 +578,17 @@ class OFTModule(PeftBase):
     oft_block_size: int
     block_share: bool
     oft_scaled: bool
+    oft_clipped_norm: bool
     dropout_probability: float
     adjustment_info: tuple[int, int] | None # for reporting
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, **kwargs):
+    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_clipped_norm: bool, **kwargs):
         super().__init__(prefix, orig_module)
         self.oft_block_size = oft_block_size
         self.rank = 0
         self.block_share = block_share
         self.oft_scaled = oft_scaled
+        self.oft_clipped_norm = oft_clipped_norm
         self.dropout_probability = kwargs.pop('dropout_probability', 0.0)
         self.oft_R = None
         self.adjustment_info = None
@@ -656,6 +658,7 @@ class OFTModule(PeftBase):
             use_cayley_neumann=True,
             num_cayley_neumann_terms=5,
             dropout_probability=self.dropout_probability,
+            oft_clipped_norm=self.oft_clipped_norm,
         )
 
         nn.init.zeros_(self.oft_R.weight)
@@ -864,6 +867,7 @@ class LoRAModuleWrapper:
                 config.oft_block_size,
                 config.oft_block_share,
                 config.oft_scaled,
+                config.oft_clipped_norm,
             ]
             self.additional_kwargs = {
                 'dropout_probability': config.dropout_probability,

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -48,7 +48,7 @@ class OFTRotationModule(nn.Module):
         use_cayley_neumann=True,
         num_cayley_neumann_terms=5,
         dropout_probability=0.0,
-        oft_clipped_norm: float | None = 1.0,
+        oft_clipped_norm: float | None = 0.95,
     ):
         super().__init__()
         self.r = r
@@ -71,9 +71,7 @@ class OFTRotationModule(nn.Module):
         self.register_buffer("cols", cols, persistent=False)
         self.dropout = MultiplicativeDropoutLayer(p=dropout_probability)
         self.oft_clipped_norm = oft_clipped_norm
-        if use_cayley_neumann and oft_clipped_norm is not None:
-            if oft_clipped_norm > 1:
-                raise ValueError("OFT clipped norm must be <=1.")
+        if oft_clipped_norm is not None:
             self.register_buffer("clipped_oft", torch.tensor(self.oft_clipped_norm))
             # Initialize states for Spectral Normalization via Power Iteration
             u = torch.randn(r, block_size)
@@ -131,14 +129,14 @@ class OFTRotationModule(nn.Module):
 
         Q_skew = self._pytorch_skew_symmetric(Q, block_size)
 
-        if use_cayley_neumann and self.oft_clipped_norm is not None:
+        if self.oft_clipped_norm is not None:
             # The Neumann series only converges if the spectral norm ||Q||_2 < 1.
             # We estimate the spectral norm using a single step of Power Iteration.
             v_norm, u_norm = self._spectral_norm(Q_skew)
             # Estimate sigma (The spectral norm)
             u_raw_grad = torch.bmm(Q_skew, v_norm)
             sigma = torch.sum(u_norm * u_raw_grad, dim=1, keepdim=True)
-            max_norm = 0.999 * self.oft_clipped_norm
+            max_norm = self.oft_clipped_norm
             Q_skew = Q_skew * (max_norm / torch.clamp(sigma, min=max_norm))
 
         if use_cayley_neumann:

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -99,6 +99,25 @@ class OFTRotationModule(nn.Module):
         vec = matrix[:, self.rows, self.cols]
         return vec
 
+    @torch.no_grad()
+    def _spectral_norm(self, Q_skew):
+        u = self.u_state.unsqueeze(-1).to(Q_skew.dtype)
+        v = self.v_state.unsqueeze(-1).to(Q_skew.dtype)
+        # Update v (Right Singular Vector)
+        v_raw = torch.bmm(Q_skew.mT, u)
+        v_norm = torch.linalg.vector_norm(v_raw, dim=1, keepdim=True)
+        candidate_v = v_raw / v_norm.clamp_min(1e-8)
+        next_v = torch.where(v_norm >= 1e-6, candidate_v, v)
+        # Update u (Left Singular Vector)
+        u_raw = torch.bmm(Q_skew, next_v)
+        u_norm = torch.linalg.vector_norm(u_raw, dim=1, keepdim=True)
+        candidate_u = u_raw / u_norm.clamp_min(1e-8)
+        next_u = torch.where(u_norm >= 1e-6, candidate_u, u)
+        if self.training:
+            self.v_state.copy_(next_v.squeeze(-1))
+            self.u_state.copy_(next_u.squeeze(-1))
+        return next_v, next_u
+
     def _cayley_batch(
         self, Q: torch.Tensor, block_size: int, use_cayley_neumann: bool = True, num_neumann_terms: int = 5
     ) -> torch.Tensor:
@@ -113,22 +132,7 @@ class OFTRotationModule(nn.Module):
         if use_cayley_neumann and self.oft_clipped_norm:
             # The Neumann series only converges if the spectral norm ||Q||_2 < 1.
             # We estimate the spectral norm using a single step of Power Iteration.
-            with torch.no_grad():
-                u = self.u_state.unsqueeze(-1).to(Q_skew.dtype)
-                v = self.v_state.unsqueeze(-1).to(Q_skew.dtype)
-                # Update v (Right Singular Vector)
-                v_raw = torch.bmm(Q_skew.mT, u)
-                v_norm = torch.linalg.vector_norm(v_raw, dim=1, keepdim=True)
-                candidate_v = v_raw / v_norm.clamp_min(1e-8)
-                next_v = torch.where(v_norm >= 1e-6, candidate_v, v)
-                # Update u (Left Singular Vector)
-                u_raw = torch.bmm(Q_skew, next_v)
-                u_norm = torch.linalg.vector_norm(u_raw, dim=1, keepdim=True)
-                candidate_u = u_raw / u_norm.clamp_min(1e-8)
-                next_u = torch.where(u_norm >= 1e-6, candidate_u, u)
-                if self.training:
-                    self.v_state.copy_(next_v.squeeze(-1))
-                    self.u_state.copy_(next_u.squeeze(-1))
+            next_v, next_u = self._spectral_norm(Q_skew)
             # Estimate sigma (The spectral norm)
             u_raw_grad = torch.bmm(Q_skew, next_v)
             sigma = torch.sum(next_u * u_raw_grad, dim=1, keepdim=True)

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -132,10 +132,10 @@ class OFTRotationModule(nn.Module):
         if use_cayley_neumann and self.oft_clipped_norm:
             # The Neumann series only converges if the spectral norm ||Q||_2 < 1.
             # We estimate the spectral norm using a single step of Power Iteration.
-            next_v, next_u = self._spectral_norm(Q_skew)
+            v_norm, u_norm = self._spectral_norm(Q_skew)
             # Estimate sigma (The spectral norm)
-            u_raw_grad = torch.bmm(Q_skew, next_v)
-            sigma = torch.sum(next_u * u_raw_grad, dim=1, keepdim=True)
+            u_raw_grad = torch.bmm(Q_skew, v_norm)
+            sigma = torch.sum(u_norm * u_raw_grad, dim=1, keepdim=True)
             max_norm = 0.999
             Q_skew = Q_skew * (max_norm / torch.clamp(sigma, min=max_norm))
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -48,6 +48,7 @@ class OFTRotationModule(nn.Module):
         use_cayley_neumann=True,
         num_cayley_neumann_terms=5,
         dropout_probability=0.0,
+        oft_clipped_norm=False,
     ):
         super().__init__()
         self.r = r
@@ -69,6 +70,9 @@ class OFTRotationModule(nn.Module):
         self.register_buffer("rows", rows, persistent=False)
         self.register_buffer("cols", cols, persistent=False)
         self.dropout = MultiplicativeDropoutLayer(p=dropout_probability)
+        self.oft_clipped_norm = oft_clipped_norm
+        if oft_clipped_norm:
+            self.register_buffer("clipped_oft", torch.tensor(True))
 
 
     def _pytorch_skew_symmetric(self, vec, block_size):
@@ -98,6 +102,13 @@ class OFTRotationModule(nn.Module):
         previous_dtype = Q.dtype
 
         Q_skew = self._pytorch_skew_symmetric(Q, block_size)
+
+        if use_cayley_neumann and self.oft_clipped_norm:
+            # The Neumann series only converges if the matrix norm Q < 1.
+            # Cap the Frobenius norm at sqrt(2), which strictly bounds the Spectral norm at < 1.0
+            norms = torch.linalg.vector_norm(Q_skew, ord=2, dim=(-2, -1), keepdim=True)
+            max_norm = math.sqrt(2) * 0.999
+            Q_skew = Q_skew * (max_norm / torch.clamp(norms, min=max_norm))
 
         if use_cayley_neumann:
             R = torch.eye(block_size, device=Q.device, dtype=Q.dtype).repeat(b, 1, 1)

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -73,6 +73,13 @@ class OFTRotationModule(nn.Module):
         self.oft_clipped_norm = oft_clipped_norm
         if oft_clipped_norm:
             self.register_buffer("clipped_oft", torch.tensor(True))
+            # Initialize states for Spectral Normalization via Power Iteration
+            u = torch.randn(r, block_size)
+            u = u / u.norm(dim=1, keepdim=True).clamp_min(1e-12)
+            self.register_buffer("u_state", u, persistent=False)
+            v = torch.randn(r, block_size)
+            v = v / v.norm(dim=1, keepdim=True).clamp_min(1e-12)
+            self.register_buffer("v_state", v, persistent=False)
 
 
     def _pytorch_skew_symmetric(self, vec, block_size):
@@ -104,11 +111,29 @@ class OFTRotationModule(nn.Module):
         Q_skew = self._pytorch_skew_symmetric(Q, block_size)
 
         if use_cayley_neumann and self.oft_clipped_norm:
-            # The Neumann series only converges if the matrix norm Q < 1.
-            # Cap the Frobenius norm at sqrt(2), which strictly bounds the Spectral norm at < 1.0
-            norms = torch.linalg.vector_norm(Q_skew, ord=2, dim=(-2, -1), keepdim=True)
-            max_norm = math.sqrt(2) * 0.999
-            Q_skew = Q_skew * (max_norm / torch.clamp(norms, min=max_norm))
+            # The Neumann series only converges if the spectral norm ||Q||_2 < 1.
+            # We estimate the spectral norm using a single step of Power Iteration.
+            with torch.no_grad():
+                u = self.u_state.unsqueeze(-1).to(Q_skew.dtype)
+                v = self.v_state.unsqueeze(-1).to(Q_skew.dtype)
+                # Update v (Right Singular Vector)
+                v_raw = torch.bmm(Q_skew.mT, u)
+                v_norm = torch.linalg.vector_norm(v_raw, dim=1, keepdim=True)
+                candidate_v = v_raw / v_norm.clamp_min(1e-8)
+                next_v = torch.where(v_norm >= 1e-6, candidate_v, v)
+                # Update u (Left Singular Vector)
+                u_raw = torch.bmm(Q_skew, next_v)
+                u_norm = torch.linalg.vector_norm(u_raw, dim=1, keepdim=True)
+                candidate_u = u_raw / u_norm.clamp_min(1e-8)
+                next_u = torch.where(u_norm >= 1e-6, candidate_u, u)
+                if self.training:
+                    self.v_state.copy_(next_v.squeeze(-1))
+                    self.u_state.copy_(next_u.squeeze(-1))
+            # Estimate sigma (The spectral norm)
+            u_raw_grad = torch.bmm(Q_skew, next_v)
+            sigma = torch.sum(next_u * u_raw_grad, dim=1, keepdim=True)
+            max_norm = 0.999
+            Q_skew = Q_skew * (max_norm / torch.clamp(sigma, min=max_norm))
 
         if use_cayley_neumann:
             R = torch.eye(block_size, device=Q.device, dtype=Q.dtype).repeat(b, 1, 1)

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -48,7 +48,7 @@ class OFTRotationModule(nn.Module):
         use_cayley_neumann=True,
         num_cayley_neumann_terms=5,
         dropout_probability=0.0,
-        oft_clipped_norm=False,
+        oft_clipped_norm: float | None = 1.0,
     ):
         super().__init__()
         self.r = r
@@ -71,8 +71,10 @@ class OFTRotationModule(nn.Module):
         self.register_buffer("cols", cols, persistent=False)
         self.dropout = MultiplicativeDropoutLayer(p=dropout_probability)
         self.oft_clipped_norm = oft_clipped_norm
-        if oft_clipped_norm:
-            self.register_buffer("clipped_oft", torch.tensor(True))
+        if use_cayley_neumann and oft_clipped_norm is not None:
+            if oft_clipped_norm > 1:
+                raise ValueError("OFT clipped norm must be <=1.")
+            self.register_buffer("clipped_oft", torch.tensor(self.oft_clipped_norm))
             # Initialize states for Spectral Normalization via Power Iteration
             u = torch.randn(r, block_size)
             u = u / u.norm(dim=1, keepdim=True).clamp_min(1e-12)
@@ -129,14 +131,14 @@ class OFTRotationModule(nn.Module):
 
         Q_skew = self._pytorch_skew_symmetric(Q, block_size)
 
-        if use_cayley_neumann and self.oft_clipped_norm:
+        if use_cayley_neumann and self.oft_clipped_norm is not None:
             # The Neumann series only converges if the spectral norm ||Q||_2 < 1.
             # We estimate the spectral norm using a single step of Power Iteration.
             v_norm, u_norm = self._spectral_norm(Q_skew)
             # Estimate sigma (The spectral norm)
             u_raw_grad = torch.bmm(Q_skew, v_norm)
             sigma = torch.sum(u_norm * u_raw_grad, dim=1, keepdim=True)
-            max_norm = 0.999
+            max_norm = 0.999 * self.oft_clipped_norm
             Q_skew = Q_skew * (max_norm / torch.clamp(sigma, min=max_norm))
 
         if use_cayley_neumann:

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -136,7 +136,7 @@ class LoraTab:
 
             # Clip OFT max norm
             components.label(master, 5, 0, "Spectral Norm Clipping",
-                             tooltip="Strictly clips the spectral norm of the OFT matrix to guarantee convergence of the Cayley parametrization (requires norm <= 1.0). Smaller values constrain the learned rotation to stay near the identity matrix, limiting adaptation to minor adjustments Default: 1.0 (e.g. 0.8 = 80% of maximum expressiveness). Leave empty to disable.")
+                             tooltip="Strictly clips the spectral norm of the OFT matrix to guarantee convergence of the Cayley parametrization (requires norm <= 1.0). Smaller values constrain the learned rotation to stay near the identity matrix, limiting adaptation. Default: 1.0 (e.g. 0.8 = 80% of maximum expressiveness). Leave empty to disable.")
             components.entry(master, 5, 1, self.ui_state, "oft_clipped_norm")
 
             # Dropout Percentage

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -136,8 +136,8 @@ class LoraTab:
 
             # Clip OFT max norm
             components.label(master, 5, 0, "Spectral Norm Clipping",
-                             tooltip="Strictly clips the spectral norm of the OFT matrix at 1. This guarantees the convergence of the Cayley parametrization, which mathematically requires a spectral norm of <= 1.")
-            components.switch(master, 5, 1, self.ui_state, "oft_clipped_norm")
+                             tooltip="Strictly clips the spectral norm of the OFT matrix to guarantee convergence of the Cayley parametrization (requires norm <= 1.0). Smaller values constrain the learned rotation to stay near the identity matrix, limiting adaptation to minor adjustments Default: 1.0 (e.g. 0.8 = 80% of maximum expressiveness). Leave empty to disable.")
+            components.entry(master, 5, 1, self.ui_state, "oft_clipped_norm")
 
             # Dropout Percentage
             components.label(master, 2, 0, "Dropout Probability",

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -135,8 +135,8 @@ class LoraTab:
             components.switch(master, 2, 4, self.ui_state, "oft_scaled")
 
             # Clip OFT max norm
-            components.label(master, 5, 0, "Clip OFT Norm",
-                             tooltip="Strictly clips the max Frobenius norm of the OFT matrix at 1. This guarantees the convergence of the Cayley parametrization, which mathematically requires a matrix norm of <= 1.")
+            components.label(master, 5, 0, "Spectral Norm Clipping",
+                             tooltip="Strictly clips the spectral norm of the OFT matrix at 1. This guarantees the convergence of the Cayley parametrization, which mathematically requires a spectral norm of <= 1.")
             components.switch(master, 5, 1, self.ui_state, "oft_clipped_norm")
 
             # Dropout Percentage

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -134,6 +134,11 @@ class LoraTab:
                              tooltip="Applies a scaling factor to the learned weights. This ensures that the effective learning rate remains consistent across different block sizes. Without this, different block sizes require significantly different learning rates.")
             components.switch(master, 2, 4, self.ui_state, "oft_scaled")
 
+            # Clip OFT max norm
+            components.label(master, 5, 0, "Clip OFT Norm",
+                             tooltip="Strictly clips the max Frobenius norm of the OFT matrix at 1. This guarantees the convergence of the Cayley parametrization, which mathematically requires a matrix norm of <= 1.")
+            components.switch(master, 5, 1, self.ui_state, "oft_clipped_norm")
+
             # Dropout Percentage
             components.label(master, 2, 0, "Dropout Probability",
                             tooltip="Dropout probability. This percentage of the rotated adapter nodes that will be randomly restored to the base model initial statue. Helps with overfitting. 0 disables, 1 maximum.")

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -522,6 +522,7 @@ class TrainConfig(BaseConfig):
     oft_block_size: int
     oft_block_share: bool
     oft_scaled: bool
+    oft_clipped_norm: bool
 
     # lokr
     lokr_dim: int
@@ -1161,6 +1162,7 @@ class TrainConfig(BaseConfig):
         data.append(("oft_block_size", 32, int, False))
         data.append(("oft_block_share", False, bool, False))
         data.append(("oft_scaled", False, bool, False))
+        data.append(("oft_clipped_norm", True, bool, False))
 
         # lokr
         data.append(("lokr_dim", 16, int, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -522,7 +522,7 @@ class TrainConfig(BaseConfig):
     oft_block_size: int
     oft_block_share: bool
     oft_scaled: bool
-    oft_clipped_norm: bool
+    oft_clipped_norm: float
 
     # lokr
     lokr_dim: int
@@ -1162,7 +1162,7 @@ class TrainConfig(BaseConfig):
         data.append(("oft_block_size", 32, int, False))
         data.append(("oft_block_share", False, bool, False))
         data.append(("oft_scaled", False, bool, False))
-        data.append(("oft_clipped_norm", True, bool, False))
+        data.append(("oft_clipped_norm", 1.0, float, False))
 
         # lokr
         data.append(("lokr_dim", 16, int, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -1162,7 +1162,7 @@ class TrainConfig(BaseConfig):
         data.append(("oft_block_size", 32, int, False))
         data.append(("oft_block_share", False, bool, False))
         data.append(("oft_scaled", False, bool, False))
-        data.append(("oft_clipped_norm", 1.0, float, True))
+        data.append(("oft_clipped_norm", 0.95, float, True))
 
         # lokr
         data.append(("lokr_dim", 16, int, False))

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -522,7 +522,7 @@ class TrainConfig(BaseConfig):
     oft_block_size: int
     oft_block_share: bool
     oft_scaled: bool
-    oft_clipped_norm: float
+    oft_clipped_norm: float | None
 
     # lokr
     lokr_dim: int
@@ -1162,7 +1162,7 @@ class TrainConfig(BaseConfig):
         data.append(("oft_block_size", 32, int, False))
         data.append(("oft_block_share", False, bool, False))
         data.append(("oft_scaled", False, bool, False))
-        data.append(("oft_clipped_norm", 1.0, float, False))
+        data.append(("oft_clipped_norm", 1.0, float, True))
 
         # lokr
         data.append(("lokr_dim", 16, int, False))


### PR DESCRIPTION
### Issue

In OFT, the Neumann series only converges if the matrix norm $Q < 1$.
If the norm of $Q$ hits or exceeds 1 (e.g., 1.01), the sequence diverges (the terms start getting larger instead of smaller).
This results in "garbage" gradients and updates.

### Solution

This PR introduces a simple safeguard fix: if the $Q$ norm exceeds 1, it is clipped back to 1.0 to guarantee convergence and ensure long-term training stability.
