### PR TITLE
 fix: initialize torch.compile per thread, even for backward thread

### DIFF
--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -112,6 +112,9 @@ class OffloadCheckpointLayer(BaseCheckpointLayer):
         self.layer_index = layer_index
 
     def __checkpointing_forward(self, dummy: torch.Tensor, call_id: int, *args):
+        # during the backward pass, this runs on an autograd worker thread, which needs its own
+        # dynamo config initialization (see init_compile)
+        init_compile()
         if self.layer_index == 0 and not torch.is_grad_enabled():
             self.conductor.start_forward(True)
 

--- a/modules/util/compile_util.py
+++ b/modules/util/compile_util.py
@@ -6,10 +6,11 @@ from sympy import S
 
 #code from https://github.com/pytorch/pytorch/blob/ed82d5fcfd80110565f69130f286c7bfec6db2dc/torch/utils/_sympy/functions.py#L481
 #but accepts negative numbers, to avoid https://github.com/Nerogar/OneTrainer/issues/1126
-#torch 2.12 (https://github.com/pytorch/pytorch/pull/169726) fixed the call path of that issue, but Mod.eval
-#itself still raises on negative numbers, and inductor's tiling_utils still calls sympy is_constant() (which
+#torch 2.12 merged the fix PR https://github.com/pytorch/pytorch/pull/169726, but according to Claude's analysis this bug
+#still exists. TODO confirm manually by testing https://github.com/Nerogar/OneTrainer/issues/1126:
+#Claude: "Mod.eval itself still raises on negative numbers, and inductor's tiling_utils still calls sympy is_constant() (which
 #substitutes negative test values) on expressions that can contain Mod. can be removed once Mod.eval itself
-#accepts negative numbers in a torch version we use
+#accepts negative numbers in a torch version we use"
 @classmethod
 def Mod_patched_eval(cls, p, q):
     # This was adapted from: sympy/core/mod.py

--- a/modules/util/compile_util.py
+++ b/modules/util/compile_util.py
@@ -1,11 +1,15 @@
 import torch
+import torch.utils._sympy.functions
 
 from sympy import S
 
 
 #code from https://github.com/pytorch/pytorch/blob/ed82d5fcfd80110565f69130f286c7bfec6db2dc/torch/utils/_sympy/functions.py#L481
 #but accepts negative numbers, to avoid https://github.com/Nerogar/OneTrainer/issues/1126
-#can be removed once https://github.com/pytorch/pytorch/pull/169726 is merged into a torch version we use
+#torch 2.12 (https://github.com/pytorch/pytorch/pull/169726) fixed the call path of that issue, but Mod.eval
+#itself still raises on negative numbers, and inductor's tiling_utils still calls sympy is_constant() (which
+#substitutes negative test values) on expressions that can contain Mod. can be removed once Mod.eval itself
+#accepts negative numbers in a torch version we use
 @classmethod
 def Mod_patched_eval(cls, p, q):
     # This was adapted from: sympy/core/mod.py
@@ -58,5 +62,11 @@ def Mod_patched_eval(cls, p, q):
 
 def init_compile():
     # cache_size_limit and recompile_limit are aliases for the same dynamo config value.
+    # since torch 2.12, dynamo config overrides are stored in ContextVars (pytorch/pytorch#173568),
+    # which threads don't inherit. init_compile() must therefore be called in every thread that can
+    # trigger a compilation - including the autograd worker threads, which recompute checkpointed
+    # modules during the backward pass.
     torch._dynamo.config.cache_size_limit = 8192
-    torch.utils._sympy.functions.Mod.eval = Mod_patched_eval
+
+
+torch.utils._sympy.functions.Mod.eval = Mod_patched_eval


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Workaround for https://github.com/pytorch/pytorch/issues/186537 on top of https://github.com/Nerogar/OneTrainer/pull/1495, which wasn't sufficient, because it didn't address the backward thread

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Flux2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
