### PR TITLE
[OFT] Chebyshev-Optimized Newton-Schulz (CANS): Faster and Better

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -671,7 +671,14 @@ class OFTModule(PeftBase):
             rotated_x = self.oft_R(x)
             return self.orig_forward(rotated_x, *args, **kwargs)
 
-        scaling_factor = 2 * math.sqrt(self.oft_R.block_size - 1) if self.oft_scaled else 1
+        if self.oft_scaled:
+            scaling_factor = math.sqrt(self.oft_R.block_size - 1)
+            if not self.oft_cans:
+                scaling_factor = scaling_factor * 2
+            effective_weight = self.oft_R.weight / scaling_factor
+        else:
+            effective_weight = self.oft_R.weight
+
         effective_weight = self.oft_R.weight / scaling_factor
 
         # For Conv2d, we must rotate the weights, not the input, to preserve spatial information.

--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -671,14 +671,7 @@ class OFTModule(PeftBase):
             rotated_x = self.oft_R(x)
             return self.orig_forward(rotated_x, *args, **kwargs)
 
-        if self.oft_scaled:
-            scaling_factor = math.sqrt(self.oft_R.block_size - 1)
-            if not self.oft_cans:
-                scaling_factor = scaling_factor * 2
-            effective_weight = self.oft_R.weight / scaling_factor
-        else:
-            effective_weight = self.oft_R.weight
-
+        scaling_factor = 2 * math.sqrt(self.oft_R.block_size - 1) if self.oft_scaled else 1
         effective_weight = self.oft_R.weight / scaling_factor
 
         # For Conv2d, we must rotate the weights, not the input, to preserve spatial information.

--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -578,15 +578,17 @@ class OFTModule(PeftBase):
     oft_block_size: int
     block_share: bool
     oft_scaled: bool
+    oft_cans: bool
     dropout_probability: float
     adjustment_info: tuple[int, int] | None # for reporting
 
-    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, **kwargs):
+    def __init__(self, prefix: str, orig_module: nn.Module | None, oft_block_size: int, block_share: bool, oft_scaled: bool, oft_cans: bool, **kwargs):
         super().__init__(prefix, orig_module)
         self.oft_block_size = oft_block_size
         self.rank = 0
         self.block_share = block_share
         self.oft_scaled = oft_scaled
+        self.oft_cans = oft_cans
         self.dropout_probability = kwargs.pop('dropout_probability', 0.0)
         self.oft_R = None
         self.adjustment_info = None
@@ -656,6 +658,7 @@ class OFTModule(PeftBase):
             use_cayley_neumann=True,
             num_cayley_neumann_terms=5,
             dropout_probability=self.dropout_probability,
+            oft_cans=self.oft_cans,
         )
 
         nn.init.zeros_(self.oft_R.weight)
@@ -673,7 +676,7 @@ class OFTModule(PeftBase):
 
         # For Conv2d, we must rotate the weights, not the input, to preserve spatial information.
         orth_rotate = self.oft_R._cayley_batch(
-            effective_weight, self.oft_R.block_size, self.oft_R.use_cayley_neumann, self.oft_R.num_cayley_neumann_terms
+            effective_weight, self.oft_R.block_size, self.oft_R.use_cayley_neumann, self.oft_R.num_cayley_neumann_terms, self.oft_R.oft_cans
         )
         orth_rotate = self.oft_R.dropout(orth_rotate)
 
@@ -864,6 +867,7 @@ class LoRAModuleWrapper:
                 config.oft_block_size,
                 config.oft_block_share,
                 config.oft_scaled,
+                config.oft_cans,
             ]
             self.additional_kwargs = {
                 'dropout_probability': config.dropout_probability,

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -112,8 +112,9 @@ class OFTRotationModule(nn.Module):
         # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X
         # is guaranteed to be >= 1 / ||G||_F.
         # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
-        lower_bound = (1.0 / g_norm).clamp(min=1e-5, max=0.9)
-        upper_bound = 1
+        lower_bound = (1.0 / g_norm.detach()).clamp(min=1e-5, max=0.9)
+        one = torch.ones_like(lower_bound)
+        upper_bound = one
 
         for _ in range(steps):
             lb, ub = lower_bound, upper_bound
@@ -125,12 +126,15 @@ class OFTRotationModule(nn.Module):
             alpha = 6.0 / denom
             c1 = alpha * e_sq
             c3 = -alpha / 3.0
-            A = X @ X.mT
-            X = c1 * X + c3 * (A @ X)
+
+            A = torch.bmm(X, X.mT)
+            X = c1 * X + c3 * torch.bmm(A, X)
+
             # Dynamically update bounds for the next step
             eps_val = (K - L) / denom
-            lower_bound = 1.0 - eps_val
-            upper_bound = 1.0 + eps_val
+            lower_bound = one - eps_val
+            upper_bound = one + eps_val
+
         return X.to(original_dtype)
 
     def _cayley_batch(

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -67,7 +67,7 @@ class OFTRotationModule(nn.Module):
         self.num_cayley_neumann_terms = num_cayley_neumann_terms
         self.oft_cans = oft_cans
         if oft_cans:
-            self.register_buffer("oft_cans", torch.tensor(True))
+            self.register_buffer("cans_oft", torch.tensor(True))
         # Create indices for upper triangle (excluding diagonal)
         rows, cols = torch.triu_indices(block_size, block_size, 1)
         self.register_buffer("rows", rows, persistent=False)

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -174,10 +174,10 @@ class OFTRotationModule(nn.Module):
             # Empirically, BF16 requires 5 steps to converge to ortho error ~1e-2 (its limit)
             # While FP32 takes 7 steps to converge to ortho error ~1e-6
             steps = 5 if G.dtype == torch.bfloat16 else 7
-            R = self._cans_newton_schulz_iteration(G=G, steps=steps)
+            R_half = self._cans_newton_schulz_iteration(G=G, steps=steps)
             # Squaring the matrix doubles the rotation range from (-90°, 90°) to (-180°, 180°) and 
             # matches Cayley (I + 2Q).
-            R = torch.bmm(R, R)
+            R = torch.bmm(R_half, R_half)
         else:
             R = torch.linalg.solve(self.id_mat + Q_skew, self.id_mat - Q_skew, left=False)
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -175,6 +175,9 @@ class OFTRotationModule(nn.Module):
             # While FP32 takes 7 steps to converge to ortho error ~1e-6
             steps = 5 if G.dtype == torch.bfloat16 else 7
             R = self._cans_newton_schulz_iteration(G=G, steps=steps)
+            # Squaring the matrix doubles the rotation range from (-90°, 90°) to (-180°, 180°) and 
+            # matches Cayley (I + 2Q).
+            R = torch.bmm(R, R)
         else:
             R = torch.linalg.solve(self.id_mat + Q_skew, self.id_mat - Q_skew, left=False)
 
@@ -187,13 +190,8 @@ class OFTRotationModule(nn.Module):
 
         orig_shape = x.shape
 
-        if self.oft_scaled:
-            scaling_factor = math.sqrt(self.block_size - 1)
-            if not self.oft_cans:
-                scaling_factor = scaling_factor * 2
-            effective_weight = self.weight / scaling_factor
-        else:
-            effective_weight = self.weight
+        scaling_factor = 2 * math.sqrt(self.block_size - 1) if self.oft_scaled else 1
+        effective_weight = self.weight / scaling_factor
 
         orth_rotate = self._cayley_batch(
             effective_weight, self.block_size, self.use_cayley_neumann, self.num_cayley_neumann_terms, self.oft_cans

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -102,21 +102,19 @@ class OFTRotationModule(nn.Module):
         Chebyshev-Optimized Newton-Schulz iteration with a dynamically computed Chebyshev lower bound.
         Optimized for G = I + Q (where Q is skew-symmetric).
         """
-        assert G.ndim in (2, 3), f"Input must be 2D or 3D, got {G.ndim}D"
-        X = G
-        transposed = X.size(-2) > X.size(-1)
-        if transposed:
-            X = X.mT
-        # Compute Frobenius norm of the unnormalized matrix G
-        # We use this to establish a tight, safe lower bound dynamically per batch element.
-        g_norm = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
-        # Normalize X
+        original_dtype = G.dtype
+        X = G.bfloat16()
+
+        # Max row sum is guaranteed to be >= the maximum singular value of X.
+        g_norm = torch.linalg.matrix_norm(X, ord=float('inf'), keepdim=True).clamp_min(eps)
         X = X / g_norm
+
         # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X
         # is guaranteed to be >= 1 / ||G||_F.
         # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
         lower_bound = (1.0 / g_norm).clamp(min=1e-5, max=0.9)
         upper_bound = 1
+
         for _ in range(steps):
             lb, ub = lower_bound, upper_bound
             lb_ub = lb * ub
@@ -133,9 +131,7 @@ class OFTRotationModule(nn.Module):
             eps_val = (K - L) / denom
             lower_bound = 1.0 - eps_val
             upper_bound = 1.0 + eps_val
-        if transposed:
-            X = X.mT
-        return X
+        return X.to(original_dtype)
 
     def _cayley_batch(
         self, Q: torch.Tensor, block_size: int, use_cayley_neumann: bool = True, num_neumann_terms: int = 5, oft_cans: bool = False,
@@ -170,7 +166,7 @@ class OFTRotationModule(nn.Module):
             )
             if oft_cans:
                 G = id_mat + Q_skew
-                R = self._cans_newton_schulz_iteration(G=G, steps=7)
+                R = self._cans_newton_schulz_iteration(G=G, steps=5)
             else:
                 R = torch.linalg.solve(id_mat + Q_skew, id_mat - Q_skew, left=False)
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -108,13 +108,13 @@ class OFTRotationModule(nn.Module):
         X = G
 
         # Max row sum is guaranteed to be >= the maximum singular value of X.
-        g_norm = X.abs().sum(dim=-1, keepdim=True).amax(dim=-2, keepdim=True).clamp_min(eps)
+        g_norm = X.abs().sum(dim=-1, keepdim=True).amax(dim=-2, keepdim=True).clamp_min(eps).detach()
         X = X / g_norm
 
         # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X
         # is guaranteed to be >= 1 / ||G||_F.
         # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
-        lower_bound = (1.0 / g_norm.detach()).clamp(min=1e-5, max=0.9)
+        lower_bound = (1.0 / g_norm).clamp(min=1e-5, max=0.9)
         upper_bound = 1
 
         for _ in range(steps):

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -106,7 +106,7 @@ class OFTRotationModule(nn.Module):
         X = G.bfloat16()
 
         # Max row sum is guaranteed to be >= the maximum singular value of X.
-        g_norm = torch.linalg.matrix_norm(X, ord=float('inf'), keepdim=True).clamp_min(eps)
+        g_norm = X.abs().sum(dim=-1, keepdim=True).amax(dim=-2, keepdim=True).clamp_min(eps)
         X = X / g_norm
 
         # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -175,7 +175,7 @@ class OFTRotationModule(nn.Module):
             # While FP32 takes 7 steps to converge to ortho error ~1e-6
             steps = 5 if G.dtype == torch.bfloat16 else 7
             R_half = self._cans_newton_schulz_iteration(G=G, steps=steps)
-            # Squaring the matrix doubles the rotation range from (-90°, 90°) to (-180°, 180°) and 
+            # Squaring the matrix doubles the rotation range from (-90°, 90°) to (-180°, 180°) and
             # matches Cayley (I + 2Q).
             R = torch.bmm(R_half, R_half)
         else:

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -184,8 +184,13 @@ class OFTRotationModule(nn.Module):
 
         orig_shape = x.shape
 
-        scaling_factor = 2 * math.sqrt(self.block_size - 1) if self.oft_scaled else 1
-        effective_weight = self.weight / scaling_factor
+        if self.oft_scaled:
+            scaling_factor = math.sqrt(self.block_size - 1)
+            if not self.oft_cans:
+                scaling_factor = scaling_factor * 2
+            effective_weight = self.weight / scaling_factor
+        else:
+            effective_weight = self.weight
 
         orth_rotate = self._cayley_batch(
             effective_weight, self.block_size, self.use_cayley_neumann, self.num_cayley_neumann_terms, self.oft_cans

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -170,14 +170,14 @@ class OFTRotationModule(nn.Module):
                     Q_power = torch.bmm(Q_power, Q_skew)
                     R.add_(Q_power)
         elif oft_cans:
-            G = self.id_mat + Q_skew
+            # Compute G = (I + Q)^2 = I + 2Q + Q^2
+            # Squaring the matrix doubles the rotation range and matches Cayley (I + 2Q).
+            Q_squared = torch.bmm(Q_skew, Q_skew)
+            G = self.id_mat + 2 * Q_skew + Q_squared
             # Empirically, BF16 requires 5 steps to converge to ortho error ~1e-2 (its limit)
             # While FP32 takes 7 steps to converge to ortho error ~1e-6
             steps = 5 if G.dtype == torch.bfloat16 else 7
-            R_half = self._cans_newton_schulz_iteration(G=G, steps=steps)
-            # Squaring the matrix doubles the rotation range from (-90°, 90°) to (-180°, 180°) and
-            # matches Cayley (I + 2Q).
-            R = torch.bmm(R_half, R_half)
+            R = self._cans_newton_schulz_iteration(G=G, steps=steps)
         else:
             R = torch.linalg.solve(self.id_mat + Q_skew, self.id_mat - Q_skew, left=False)
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -113,8 +113,7 @@ class OFTRotationModule(nn.Module):
 
         # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X
         # is guaranteed to be >= 1 / ||G||_F.
-        # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
-        lower_bound = (1.0 / g_norm).clamp(min=1e-5, max=0.9)
+        lower_bound = (1.0 / g_norm)
         upper_bound = 1
 
         for _ in range(steps):

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -73,7 +73,9 @@ class OFTRotationModule(nn.Module):
         self.register_buffer("rows", rows, persistent=False)
         self.register_buffer("cols", cols, persistent=False)
         self.dropout = MultiplicativeDropoutLayer(p=dropout_probability)
-
+        if not self.use_cayley_neumann:
+            id_mat = (torch.eye(block_size).unsqueeze(0).expand(r, block_size, block_size))
+            self.register_buffer("id_mat", id_mat, persistent=False)
 
     def _pytorch_skew_symmetric(self, vec, block_size):
         batch_size = vec.shape[0]
@@ -113,8 +115,7 @@ class OFTRotationModule(nn.Module):
         # is guaranteed to be >= 1 / ||G||_F.
         # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
         lower_bound = (1.0 / g_norm.detach()).clamp(min=1e-5, max=0.9)
-        one = torch.ones_like(lower_bound)
-        upper_bound = one
+        upper_bound = 1
 
         for _ in range(steps):
             lb, ub = lower_bound, upper_bound
@@ -132,8 +133,14 @@ class OFTRotationModule(nn.Module):
 
             # Dynamically update bounds for the next step
             eps_val = (K - L) / denom
-            lower_bound = one - eps_val
-            upper_bound = one + eps_val
+
+            # bmm acts as an opaque boundary, forcing Inductor to 
+            # materialize eps_val and severing the exponential AST tree.
+            # Shape is (B, 1, 1), so ones_like acts as an identity.
+            eps_val = torch.bmm(eps_val, torch.ones_like(eps_val))
+
+            lower_bound = 1 - eps_val
+            upper_bound = 1 + eps_val
 
         return X.to(original_dtype)
 
@@ -162,17 +169,11 @@ class OFTRotationModule(nn.Module):
                         R.add_(Q_power, alpha=2.0)
                     Q_power = torch.bmm(Q_power, Q_skew)
                     R.add_(Q_power)
+        elif oft_cans:
+            G = self.id_mat + Q_skew
+            R = self._cans_newton_schulz_iteration(G=G, steps=5)
         else:
-            id_mat = (
-                torch.eye(Q_skew.shape[-1], device=Q_skew.device)
-                .unsqueeze(0)
-                .expand(b, Q_skew.shape[-1], Q_skew.shape[-1])
-            )
-            if oft_cans:
-                G = id_mat + Q_skew
-                R = self._cans_newton_schulz_iteration(G=G, steps=5)
-            else:
-                R = torch.linalg.solve(id_mat + Q_skew, id_mat - Q_skew, left=False)
+            R = torch.linalg.solve(self.id_mat + Q_skew, self.id_mat - Q_skew, left=False)
 
         return R.to(previous_dtype)
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -134,7 +134,7 @@ class OFTRotationModule(nn.Module):
             # Dynamically update bounds for the next step
             eps_val = (K - L) / denom
 
-            # bmm acts as an opaque boundary, forcing Inductor to 
+            # bmm acts as an opaque boundary, forcing Inductor to
             # materialize eps_val and severing the exponential AST tree.
             # Shape is (B, 1, 1), so ones_like acts as an identity.
             eps_val = torch.bmm(eps_val, torch.ones_like(eps_val))

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -105,7 +105,7 @@ class OFTRotationModule(nn.Module):
         Optimized for G = I + Q (where Q is skew-symmetric).
         """
         original_dtype = G.dtype
-        X = G.bfloat16()
+        X = G
 
         # Max row sum is guaranteed to be >= the maximum singular value of X.
         g_norm = X.abs().sum(dim=-1, keepdim=True).amax(dim=-2, keepdim=True).clamp_min(eps)
@@ -171,7 +171,10 @@ class OFTRotationModule(nn.Module):
                     R.add_(Q_power)
         elif oft_cans:
             G = self.id_mat + Q_skew
-            R = self._cans_newton_schulz_iteration(G=G, steps=5)
+            # Empirically, BF16 requires 5 steps to converge to ortho error ~1e-2 (its limit)
+            # While FP32 takes 7 steps to converge to ortho error ~1e-6
+            steps = 5 if G.dtype == torch.bfloat16 else 7
+            R = self._cans_newton_schulz_iteration(G=G, steps=steps)
         else:
             R = torch.linalg.solve(self.id_mat + Q_skew, self.id_mat - Q_skew, left=False)
 

--- a/modules/module/oft_utils.py
+++ b/modules/module/oft_utils.py
@@ -47,6 +47,7 @@ class OFTRotationModule(nn.Module):
         oft_scaled=False,
         use_cayley_neumann=True,
         num_cayley_neumann_terms=5,
+        oft_cans=False,
         dropout_probability=0.0,
     ):
         super().__init__()
@@ -62,8 +63,11 @@ class OFTRotationModule(nn.Module):
             # allowing inference tools to automatically detect scaled oft.
             self.register_buffer("scaled_oft", torch.tensor(True))
         self.oft_scaled = oft_scaled
-        self.use_cayley_neumann = use_cayley_neumann
+        self.use_cayley_neumann = use_cayley_neumann and not oft_cans
         self.num_cayley_neumann_terms = num_cayley_neumann_terms
+        self.oft_cans = oft_cans
+        if oft_cans:
+            self.register_buffer("oft_cans", torch.tensor(True))
         # Create indices for upper triangle (excluding diagonal)
         rows, cols = torch.triu_indices(block_size, block_size, 1)
         self.register_buffer("rows", rows, persistent=False)
@@ -88,8 +92,53 @@ class OFTRotationModule(nn.Module):
         vec = matrix[:, self.rows, self.cols]
         return vec
 
+    def _cans_newton_schulz_iteration(
+        self,
+        G: torch.Tensor,
+        steps: int = 7,
+        eps: float = 1e-7,
+    ) -> torch.Tensor:
+        """
+        Chebyshev-Optimized Newton-Schulz iteration with a dynamically computed Chebyshev lower bound.
+        Optimized for G = I + Q (where Q is skew-symmetric).
+        """
+        assert G.ndim in (2, 3), f"Input must be 2D or 3D, got {G.ndim}D"
+        X = G
+        transposed = X.size(-2) > X.size(-1)
+        if transposed:
+            X = X.mT
+        # Compute Frobenius norm of the unnormalized matrix G
+        # We use this to establish a tight, safe lower bound dynamically per batch element.
+        g_norm = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+        # Normalize X
+        X = X / g_norm
+        # Since min_singular_value(I + Q) >= 1, the min_singular_value of normalized X
+        # is guaranteed to be >= 1 / ||G||_F.
+        # We clamp it to prevent numerical edge cases (e.g. extremely large norms).
+        lower_bound = (1.0 / g_norm).clamp(min=1e-5, max=0.9)
+        upper_bound = 1
+        for _ in range(steps):
+            lb, ub = lower_bound, upper_bound
+            lb_ub = lb * ub
+            e_sq = (lb**2 + lb_ub + ub**2) / 3.0
+            K = 2.0 * e_sq**1.5
+            L = lb_ub * (lb + ub)
+            denom = K + L
+            alpha = 6.0 / denom
+            c1 = alpha * e_sq
+            c3 = -alpha / 3.0
+            A = X @ X.mT
+            X = c1 * X + c3 * (A @ X)
+            # Dynamically update bounds for the next step
+            eps_val = (K - L) / denom
+            lower_bound = 1.0 - eps_val
+            upper_bound = 1.0 + eps_val
+        if transposed:
+            X = X.mT
+        return X
+
     def _cayley_batch(
-        self, Q: torch.Tensor, block_size: int, use_cayley_neumann: bool = True, num_neumann_terms: int = 5
+        self, Q: torch.Tensor, block_size: int, use_cayley_neumann: bool = True, num_neumann_terms: int = 5, oft_cans: bool = False,
     ) -> torch.Tensor:
         """
         Perform the Cayley parametrization on a batch of skew-symmetric matrices.
@@ -119,7 +168,11 @@ class OFTRotationModule(nn.Module):
                 .unsqueeze(0)
                 .expand(b, Q_skew.shape[-1], Q_skew.shape[-1])
             )
-            R = torch.linalg.solve(id_mat + Q_skew, id_mat - Q_skew, left=False)
+            if oft_cans:
+                G = id_mat + Q_skew
+                R = self._cans_newton_schulz_iteration(G=G, steps=7)
+            else:
+                R = torch.linalg.solve(id_mat + Q_skew, id_mat - Q_skew, left=False)
 
         return R.to(previous_dtype)
 
@@ -134,7 +187,7 @@ class OFTRotationModule(nn.Module):
         effective_weight = self.weight / scaling_factor
 
         orth_rotate = self._cayley_batch(
-            effective_weight, self.block_size, self.use_cayley_neumann, self.num_cayley_neumann_terms
+            effective_weight, self.block_size, self.use_cayley_neumann, self.num_cayley_neumann_terms, self.oft_cans
         )
         orth_rotate = self.dropout(orth_rotate)
 

--- a/modules/ui/LoraTab.py
+++ b/modules/ui/LoraTab.py
@@ -134,6 +134,11 @@ class LoraTab:
                              tooltip="Applies a scaling factor to the learned weights. This ensures that the effective learning rate remains consistent across different block sizes. Without this, different block sizes require significantly different learning rates.")
             components.switch(master, 2, 4, self.ui_state, "oft_scaled")
 
+            # CANS OFT
+            components.label(master, 4, 3, "Accelerated Newton-Schulz",
+                             tooltip="Replaces Cayley-Neumann with Chebyshev-Optimized Newton-Schulz (CANS) to improve orthogonalization stability and reduce error without the high computational cost of the exact solver.")
+            components.switch(master, 4, 4, self.ui_state, "oft_cans")
+
             # Dropout Percentage
             components.label(master, 2, 0, "Dropout Probability",
                             tooltip="Dropout probability. This percentage of the rotated adapter nodes that will be randomly restored to the base model initial statue. Helps with overfitting. 0 disables, 1 maximum.")

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -522,6 +522,7 @@ class TrainConfig(BaseConfig):
     oft_block_size: int
     oft_block_share: bool
     oft_scaled: bool
+    oft_cans: bool
 
     # lokr
     lokr_dim: int
@@ -1161,6 +1162,7 @@ class TrainConfig(BaseConfig):
         data.append(("oft_block_size", 32, int, False))
         data.append(("oft_block_share", False, bool, False))
         data.append(("oft_scaled", False, bool, False))
+        data.append(("oft_cans", False, bool, False))
 
         # lokr
         data.append(("lokr_dim", 16, int, False))


### PR DESCRIPTION
## The Issue 

In OFT, we currently orthogonalize the weights using two different methods:
- **Default:** Truncated Cayley-Neumann 
- **Exact Solver:** Exact matrix math

The exact solver is typically excluded from practical use because it is computationally slow and scales poorly. On the other hand, the Cayley-Neumann method exhibits a relatively high orthogonalization error. While the exact solver achieves an error of around $10^{-6}$, Cayley-Neumann's error ranges between $0.1$ and $0.5$. It is also unstable for matrices with higher norms (as noted in #1492) and converges poorly in those cases. Which makes it scale variant and prone to error.

Standard alternative approximations, such as standard Newton-Schulz, were evaluated but did not resolve these issues.


## Our Solution (CANS)

CANS is a variant of the Newton-Schulz (NS) algorithm designed to achieve strict orthogonality.
> Note: Standard NS flattens singular values but is not explicitly optimized to reach true orthogonality.

A known limitation of CANS is that it requires tuning a lower bound parameter to converge optimally. However, for the OFT formulation ($I + Q$), we can define this lower bound simply as:
`1 / Frobenius norm of I+Q`

Using this bound makes CANS highly suitable for OFT.

---

### Convergence compared to current methods

<img width="1745" height="879" alt="Figurerit10_1" src="https://github.com/user-attachments/assets/23bd078f-9598-4f7d-93a9-e9d9a56629e6" />

The plot above shows the performance on a random matrix. In this test case, CANS (red) achieves lower orthogonalization error than both Cayley-Neumann and the exact solver.

---

### Block-size invariant & Number of iterations - matmuls required

<img width="2100" height="900" alt="oft_cans_convergence" src="https://github.com/user-attachments/assets/4982b527-fc3f-4929-b678-04cd58cc2818" />

It only requires 7 iterations (14 matmuls) to fully converge in FP32.
* Note: It has 2 matmuls per iteration, unlike standard NS, which has 3 matmuls per iteration. This makes 7 CNS iterations faster than 5 standard iterations.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- No AI involvement

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->

## Sources:
[Accelerating Newton-Schulz Iteration for Orthogonalization via Chebyshev-type Polynomials](https://arxiv.org/abs/2506.10935)