### PR TITLE
Enable dynamic timestep shifting for Flux/Flux2 presets

### DIFF
--- a/modules/ui/TimestepDistributionWindow.py
+++ b/modules/ui/TimestepDistributionWindow.py
@@ -133,7 +133,7 @@ class TimestepDistributionWindow(ctk.CTkToplevel):
 
         # dynamic timestep shifting
         components.label(frame, 6, 0, "Dynamic Timestep Shifting",
-                         tooltip="Dynamically shift the timestep distribution based on resolution. If enabled, the shifting parameters are taken from the model's scheduler configuration and Timestep Shift is ignored. Dynamic Timestep Shifting is not shown in the preview. Note: For Z-Image and Flux2, the dynamic shifting parameters are likely wrong and unknown. Use with care or set your own, fixed shift.", wide_tooltip=True)
+                         tooltip="Dynamically shift the timestep distribution based on resolution. If enabled, the shifting parameters are taken from the model's scheduler configuration and Timestep Shift is ignored. Dynamic Timestep Shifting is not shown in the preview. Note: For Z-Image, the dynamic shifting parameters are likely wrong and unknown. Use with care or set your own, fixed shift.", wide_tooltip=True)
         components.switch(frame, 6, 1, self.ui_state, "dynamic_timestep_shifting")
 
 

--- a/modules/ui/TrainingTab.py
+++ b/modules/ui/TrainingTab.py
@@ -700,7 +700,7 @@ class TrainingTab:
         if supports_dynamic_timestep_shifting:
             # dynamic timestep shifting
             components.label(frame, 9, 0, "Dynamic Timestep Shifting",
-                             tooltip="Dynamically shift the timestep distribution based on resolution. If enabled, the shifting parameters are taken from the model's scheduler configuration and Timestep Shift is ignored. Note: For Z-Image and Flux2, the dynamic shifting parameters are likely wrong and unknown. Use with care or set your own, fixed shift.", wide_tooltip=True)
+                             tooltip="Dynamically shift the timestep distribution based on resolution. If enabled, the shifting parameters are taken from the model's scheduler configuration and Timestep Shift is ignored. Note: For Z-Image, the dynamic shifting parameters are likely wrong and unknown. Use with care or set your own, fixed shift.", wide_tooltip=True)
             components.switch(frame, 9, 1, self.ui_state, "dynamic_timestep_shifting")
 
 

--- a/training_presets/#flux LoRA.json
+++ b/training_presets/#flux LoRA.json
@@ -25,5 +25,5 @@
     },
     "train_dtype": "BFLOAT_16",
     "timestep_distribution": "LOGIT_NORMAL",
-    "dynamic_timestep_shifting": false
+    "dynamic_timestep_shifting": true
 }

--- a/training_presets/#flux2 Finetune 16GB.json
+++ b/training_presets/#flux2 Finetune 16GB.json
@@ -24,6 +24,7 @@
         "layer_filter_preset": "blocks"
     },
     "timestep_distribution": "LOGIT_NORMAL",
+    "dynamic_timestep_shifting": true,
     "dataloader_threads": 1,
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.6,

--- a/training_presets/#flux2 Finetune 24GB.json
+++ b/training_presets/#flux2 Finetune 24GB.json
@@ -24,6 +24,7 @@
         "layer_filter_preset": "blocks"
     },
     "timestep_distribution": "LOGIT_NORMAL",
+    "dynamic_timestep_shifting": true,
     "dataloader_threads": 1,
     "optimizer": {
         "optimizer": "ADAFACTOR"

--- a/training_presets/#flux2 LoRA 16GB.json
+++ b/training_presets/#flux2 LoRA 16GB.json
@@ -26,5 +26,6 @@
         "layer_filter_preset": "blocks"
     },
     "timestep_distribution": "LOGIT_NORMAL",
+    "dynamic_timestep_shifting": true,
     "dataloader_threads": 1
 }

--- a/training_presets/#flux2 LoRA 8GB.json
+++ b/training_presets/#flux2 LoRA 8GB.json
@@ -26,6 +26,7 @@
         "layer_filter_preset": "blocks"
     },
     "timestep_distribution": "LOGIT_NORMAL",
+    "dynamic_timestep_shifting": true,
     "dataloader_threads": 1,
     "gradient_checkpointing": "CPU_OFFLOADED",
     "layer_offload_fraction": 0.7


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

BFL confirmed both Flux 1 and Flux 2 were trained with dynamic timestep shifting with the scheduler-derived parameters. Change presetes, and remove the "likely wrong and unknown" caveat for Flux2 from the tooltips, keeping it for Z-Image only.
Flux2 uses a higher, "empirical" shift for inference. During training, the same shifting parameters as for Flux1 were used.

It's likely that other similar models (Ernie, Z-Image, ...) were trained the same way. But we don't know, so keeping it off for other models for now.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
