### PR TITLE
Model saver code deduplication

### DIFF
--- a/modules/modelSaver/chroma/ChromaModelSaver.py
+++ b/modules/modelSaver/chroma/ChromaModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -29,18 +28,7 @@ class ChromaModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         text_encoder = save_pipeline.text_encoder
         if text_encoder is not None:

--- a/modules/modelSaver/ernie/ErnieModelSaver.py
+++ b/modules/modelSaver/ernie/ErnieModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -25,16 +24,7 @@ class ErnieModelSaver(
     ):
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/flux/FluxModelSaver.py
+++ b/modules/modelSaver/flux/FluxModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -29,18 +28,7 @@ class FluxModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer_2 = pipeline.tokenizer_2
-            tokenizer_2.__deepcopy__ = lambda memo: tokenizer_2
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer_2, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_2",))
 
         text_encoder_2 = save_pipeline.text_encoder_2
         if text_encoder_2 is not None:

--- a/modules/modelSaver/flux2/Flux2ModelSaver.py
+++ b/modules/modelSaver/flux2/Flux2ModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -27,18 +26,7 @@ class Flux2ModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None: #TODO necessary?
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/hidream/HiDreamModelSaver.py
+++ b/modules/modelSaver/hidream/HiDreamModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -26,21 +25,7 @@ class HiDreamModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_modules=True)
         pipeline.to("cpu")
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer_3 = pipeline.tokenizer_3
-            tokenizer_3.__deepcopy__ = lambda memo: tokenizer_3
-            tokenizer_4 = pipeline.tokenizer_4
-            tokenizer_4.__deepcopy__ = lambda memo: tokenizer_4
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer_3, '__deepcopy__')
-            delattr(tokenizer_4, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_3", "tokenizer_4"))
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/hunyuanVideo/HunyuanVideoModelSaver.py
+++ b/modules/modelSaver/hunyuanVideo/HunyuanVideoModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -29,18 +28,7 @@ class HunyuanVideoModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_modules=True)
         pipeline.to("cpu")
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer_1 = pipeline.tokenizer
-            tokenizer_1.__deepcopy__ = lambda memo: tokenizer_1
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer_1, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         text_encoder_1 = save_pipeline.text_encoder
         if text_encoder_1 is not None:

--- a/modules/modelSaver/mixin/DtypeModelSaverMixin.py
+++ b/modules/modelSaver/mixin/DtypeModelSaverMixin.py
@@ -42,6 +42,26 @@ class DtypeModelSaverMixin:
             else:
                 state_dict[key] = value.contiguous()
 
+    def _copy_pipeline_to_dtype(
+            self,
+            pipeline,
+            dtype: torch.dtype | None,
+    ):
+        if dtype is None:
+            return pipeline
+
+        # replace the tokenizer's __deepcopy__ before calling deepcopy, to prevent a copy being made.
+        # the tokenizer tries to reload from the file system otherwise
+        tokenizer = pipeline.tokenizer
+        tokenizer.__deepcopy__ = lambda memo: tokenizer
+
+        save_pipeline = copy.deepcopy(pipeline)
+        save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
+
+        delattr(tokenizer, '__deepcopy__')
+
+        return save_pipeline
+
     def __calculate_safetensors_hash(
             self,
             state_dict: dict[str, Tensor] | None = None,

--- a/modules/modelSaver/mixin/DtypeModelSaverMixin.py
+++ b/modules/modelSaver/mixin/DtypeModelSaverMixin.py
@@ -46,19 +46,22 @@ class DtypeModelSaverMixin:
             self,
             pipeline,
             dtype: torch.dtype | None,
+            tokenizer_attrs: tuple[str, ...] = ("tokenizer",),
     ):
         if dtype is None:
             return pipeline
 
-        # replace the tokenizer's __deepcopy__ before calling deepcopy, to prevent a copy being made.
-        # the tokenizer tries to reload from the file system otherwise
-        tokenizer = pipeline.tokenizer
-        tokenizer.__deepcopy__ = lambda memo: tokenizer
+        # replace the tokenizers' __deepcopy__ before calling deepcopy, to prevent a copy being made.
+        # the tokenizers try to reload from the file system otherwise
+        tokenizers = [getattr(pipeline, attr) for attr in tokenizer_attrs]
+        for tokenizer in tokenizers:
+            tokenizer.__deepcopy__ = lambda memo, tokenizer=tokenizer: tokenizer
 
         save_pipeline = copy.deepcopy(pipeline)
         save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
 
-        delattr(tokenizer, '__deepcopy__')
+        for tokenizer in tokenizers:
+            delattr(tokenizer, '__deepcopy__')
 
         return save_pipeline
 

--- a/modules/modelSaver/pixartAlpha/PixArtAlphaModelSaver.py
+++ b/modules/modelSaver/pixartAlpha/PixArtAlphaModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -28,18 +27,7 @@ class PixArtAlphaModelSaver(
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
 
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/qwen/QwenModelSaver.py
+++ b/modules/modelSaver/qwen/QwenModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -26,19 +25,7 @@ class QwenModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            #TODO is this code necessary for all models? in that case, share code
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/sana/SanaModelSaver.py
+++ b/modules/modelSaver/sana/SanaModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -25,18 +24,7 @@ class SanaModelSaver(
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
 
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/stableDiffusion3/StableDiffusion3ModelSaver.py
+++ b/modules/modelSaver/stableDiffusion3/StableDiffusion3ModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -29,18 +28,7 @@ class StableDiffusion3ModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer_3 = pipeline.tokenizer_3
-            tokenizer_3.__deepcopy__ = lambda memo: tokenizer_3
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer_3, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_3",))
 
         text_encoder_3 = save_pipeline.text_encoder_3
         if text_encoder_3 is not None:

--- a/modules/modelSaver/zImage/ZImageModelSaver.py
+++ b/modules/modelSaver/zImage/ZImageModelSaver.py
@@ -1,4 +1,3 @@
-import copy
 import os.path
 from pathlib import Path
 
@@ -26,19 +25,7 @@ class ZImageModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        if dtype is not None:
-            #TODO is this code necessary for all models? in that case, share code
-            # replace the tokenizers __deepcopy__ before calling deepcopy, to prevent a copy being made.
-            # the tokenizer tries to reload from the file system otherwise
-            tokenizer = pipeline.tokenizer
-            tokenizer.__deepcopy__ = lambda memo: tokenizer
-
-            save_pipeline = copy.deepcopy(pipeline)
-            save_pipeline.to(device="cpu", dtype=dtype, silence_dtype_warnings=True)
-
-            delattr(tokenizer, '__deepcopy__')
-        else:
-            save_pipeline = pipeline
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Minor code deduplication, to avoid having to copy this from model-to-new-model

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->

part of https://github.com/Nerogar/OneTrainer/issues/1203