### PR TITLE
Workaround for torch.compile limit when using fused backpass

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -587,7 +587,7 @@ class GenericTrainer(BaseTrainer):
                             tensor.grad = None
 
                     def __grad_hook(tensor: Tensor, param_group=param_group, i=i):
-                        init_compile()
+                        init_compile()  # workaround for https://github.com/pytorch/pytorch/issues/186537
                         if self.__is_update_step(self.model.train_progress):
                             if fused_reduce:
                                 multi.reduce_grads_mean(

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -587,6 +587,7 @@ class GenericTrainer(BaseTrainer):
                             tensor.grad = None
 
                     def __grad_hook(tensor: Tensor, param_group=param_group, i=i):
+                        init_compile()
                         if self.__is_update_step(self.model.train_progress):
                             if fused_reduce:
                                 multi.reduce_grads_mean(

--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -112,9 +112,7 @@ class OffloadCheckpointLayer(BaseCheckpointLayer):
         self.layer_index = layer_index
 
     def __checkpointing_forward(self, dummy: torch.Tensor, call_id: int, *args):
-        # during the backward pass, this runs on an autograd worker thread, which needs its own
-        # dynamo config initialization (see init_compile)
-        init_compile()
+        init_compile()  # workaround for https://github.com/pytorch/pytorch/issues/186537
         if self.layer_index == 0 and not torch.is_grad_enabled():
             self.conductor.start_forward(True)
 


### PR DESCRIPTION
Workaround when using `torch.compile` and `fused backpass` which https://github.com/Nerogar/OneTrainer/pull/1511 didn't cover.