### PR TITLE
Transformers fix

### DIFF
--- a/modules/model/WuerstchenModel.py
+++ b/modules/model/WuerstchenModel.py
@@ -244,7 +244,7 @@ class WuerstchenModel(BaseModel):
                 return_dict=True,
             )
             if self.model_type.is_wuerstchen_v2():
-                final_layer_norm = self.prior_text_encoder.text_model.final_layer_norm
+                final_layer_norm = self.prior_text_encoder.final_layer_norm
                 pooled_text_encoder_output = None
                 text_encoder_output = final_layer_norm(
                     text_encoder_output.hidden_states[-(1 + text_encoder_layer_skip)]

--- a/modules/model/util/clip_util.py
+++ b/modules/model/util/clip_util.py
@@ -37,7 +37,7 @@ def encode_clip(
         text_encoder_output = text_encoder_output.hidden_states[default_layer - layer_skip] if add_output else None
 
         if add_layer_norm and text_encoder_output is not None:
-            final_layer_norm = text_encoder.text_model.final_layer_norm
+            final_layer_norm = text_encoder.text_model.final_layer_norm if hasattr(text_encoder, 'text_model') else text_encoder.final_layer_norm
             text_encoder_output = final_layer_norm(text_encoder_output)
 
     return text_encoder_output, pooled_text_encoder_output

--- a/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
+++ b/modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py
@@ -162,7 +162,7 @@ class StableDiffusionXLModelLoader(
             )
 
         text_encoder_1 = pipeline.text_encoder.to(dtype=weight_dtypes.text_encoder.torch_dtype())
-        text_encoder_1.text_model.embeddings.to(dtype=weight_dtypes.text_encoder.torch_dtype(False))
+        text_encoder_1.embeddings.to(dtype=weight_dtypes.text_encoder.torch_dtype(False))
         text_encoder_2 = pipeline.text_encoder_2.to(dtype=weight_dtypes.text_encoder_2.torch_dtype())
         text_encoder_2.text_model.embeddings.to(dtype=weight_dtypes.text_encoder_2.torch_dtype(False))
         vae = pipeline.vae.to(dtype=weight_dtypes.vae.torch_dtype())

--- a/modules/modelSampler/WuerstchenSampler.py
+++ b/modules/modelSampler/WuerstchenSampler.py
@@ -180,7 +180,7 @@ class WuerstchenSampler(BaseModelSampler):
             return_dict=True,
             output_hidden_states=True,
         )
-        final_layer_norm = decoder_text_encoder.text_model.final_layer_norm
+        final_layer_norm = decoder_text_encoder.final_layer_norm
         prompt_embedding = final_layer_norm(
             text_encoder_output.hidden_states[-(1 + text_encoder_layer_skip)]
         )

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -141,7 +141,7 @@ class BaseFluxSetup(
         if model.tokenizer_1 is not None and model.text_encoder_1 is not None:
             model.embedding_wrapper_1 = AdditionalEmbeddingWrapper(
                 tokenizer=model.tokenizer_1,
-                orig_module=model.text_encoder_1.text_model.embeddings.token_embedding,
+                orig_module=model.text_encoder_1.embeddings.token_embedding,
                 embeddings=model.all_text_encoder_1_embeddings(),
             )
         if model.tokenizer_2 is not None and model.text_encoder_2 is not None:

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -148,7 +148,7 @@ class BaseHunyuanVideoSetup(
         if model.tokenizer_2 is not None and model.text_encoder_2 is not None:
             model.embedding_wrapper_2 = AdditionalEmbeddingWrapper(
                 tokenizer=model.tokenizer_2,
-                orig_module=model.text_encoder_2.text_model.embeddings.token_embedding,
+                orig_module=model.text_encoder_2.embeddings.token_embedding,
                 embeddings=model.all_text_encoder_2_embeddings(),
             )
 

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -119,7 +119,7 @@ class BaseStableDiffusionSetup(
     ):
         model.embedding_wrapper = AdditionalEmbeddingWrapper(
             tokenizer=model.tokenizer,
-            orig_module=model.text_encoder.text_model.embeddings.token_embedding,
+            orig_module=model.text_encoder.embeddings.token_embedding,
             embeddings=model.all_text_encoder_embeddings(),
         )
         model.embedding_wrapper.hook_to_module()

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -142,7 +142,7 @@ class BaseStableDiffusionXLSetup(
     ):
         model.embedding_wrapper_1 = AdditionalEmbeddingWrapper(
             tokenizer=model.tokenizer_1,
-            orig_module=model.text_encoder_1.text_model.embeddings.token_embedding,
+            orig_module=model.text_encoder_1.embeddings.token_embedding,
             embeddings=model.all_text_encoder_1_embeddings(),
         )
         model.embedding_wrapper_2 = AdditionalEmbeddingWrapper(

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -149,7 +149,7 @@ class BaseWuerstchenSetup(
     ):
         model.prior_embedding_wrapper = AdditionalEmbeddingWrapper(
             tokenizer=model.prior_tokenizer,
-            orig_module=model.prior_text_encoder.text_model.embeddings.token_embedding,
+            orig_module=model.prior_text_encoder.embeddings.token_embedding,
             embeddings=model.all_prior_text_encoder_embeddings(),
         )
         model.prior_embedding_wrapper.hook_to_module()


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'CLIPTextModel' object has no attribute 'text_model'` caused by
transformers >= 5.9 restructuring `CLIPTextModel` internals.

In newer transformers releases, `embeddings`, `encoder`, and `final_layer_norm` moved
from a nested `text_model` submodule directly onto `CLIPTextModel`.
`CLIPTextModelWithProjection` is unaffected — it still wraps an inner `CLIPTextModel`
via `.text_model`.

**9 files changed (9 edits):**

* `modules/modelSetup/BaseStableDiffusionSetup.py` — `.text_model.embeddings` → `.embeddings`
* `modules/modelSetup/BaseStableDiffusionXLSetup.py` — `.text_model.embeddings` → `.embeddings` (te1 only)
* `modules/modelSetup/BaseFluxSetup.py` — `.text_model.embeddings` → `.embeddings` (te1 only)
* `modules/modelSetup/BaseHunyuanVideoSetup.py` — `.text_model.embeddings` → `.embeddings` (te2 only)
* `modules/modelSetup/BaseWuerstchenSetup.py` — `.text_model.embeddings` → `.embeddings` (prior)
* `modules/modelLoader/stableDiffusionXL/StableDiffusionXLModelLoader.py` — `.text_model.embeddings` → `.embeddings` (ckpt path)
* `modules/model/WuerstchenModel.py` — `.text_model.final_layer_norm` → `.final_layer_norm`
* `modules/modelSampler/WuerstchenSampler.py` — `.text_model.final_layer_norm` → `.final_layer_norm`
* `modules/model/util/clip_util.py` — added `hasattr(text_encoder, 'text_model')` guard

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: SDXL lora)

## AI assistance

- AI-assisted to find the cause of the bug.