### PR TITLE
Fix PixArt Sigma presets: update base model to PixArt-alpha org

### DIFF
--- a/training_presets/#pixart sigma 1.0 LoRA.json
+++ b/training_presets/#pixart sigma 1.0 LoRA.json
@@ -1,5 +1,5 @@
 {
-    "base_model_name": "PixArt-sigma/PixArt-XL-2-1024-MS",
+    "base_model_name": "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS",
     "batch_size": 4,
     "model_type": "PIXART_SIGMA",
     "epochs": 50,

--- a/training_presets/#pixart sigma 1.0.json
+++ b/training_presets/#pixart sigma 1.0.json
@@ -1,5 +1,5 @@
 {
-    "base_model_name": "PixArt-sigma/PixArt-XL-2-1024-MS",
+    "base_model_name": "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS",
     "batch_size": 8,
     "model_type": "PIXART_SIGMA",
     "epochs": 100,


### PR DESCRIPTION
`PixArt-sigma/PixArt-XL-2-1024-MS` returns 404. The canonical model per the [upstream GitHub README](https://github.com/PixArt-alpha/PixArt-sigma) is `PixArt-alpha/PixArt-Sigma-XL-2-1024-MS`.

Updates both sigma presets (`#pixart sigma 1.0.json` and `#pixart sigma 1.0 LoRA.json`).

Closes #1533.

Drafted by Claude