### PR TITLE
Fix SD3 LoRA preset: enable transformer training

### DIFF
--- a/training_presets/#sd 3 LoRA.json
+++ b/training_presets/#sd 3 LoRA.json
@@ -8,7 +8,7 @@
     "output_model_format": "SAFETENSORS",
     "resolution": "1024",
     "transformer": {
-        "train": false,
+        "train": true,
         "weight_dtype": "FLOAT_16"
     },
     "text_encoder": {

--- a/training_presets/#sd 3.json
+++ b/training_presets/#sd 3.json
@@ -5,6 +5,7 @@
     "output_model_destination": "models/model.safetensors",
     "output_model_format": "SAFETENSORS",
     "transformer": {
+        "train": true,
         "weight_dtype": "FLOAT_32"
     },
     "resolution": "1024",


### PR DESCRIPTION
## Summary
- The built-in `#sd 3 LoRA` preset had `transformer.train` set to `false`, a side effect of #1167. Since `transformer_lora`'s `requires_grad` is gated by `config.transformer.train`, this left it `False`, producing zero trainable parameters and a crash on startup (`ValueError: optimizer got an empty parameter list`).
- Sets `transformer.train` back to `true`, matching every other built-in LoRA preset (e.g. Flux LoRA).

Fixes #1534

Drafted by Claude