### PR TITLE
Fix HiDream checkpointing/offloading: match block ModuleLists directly

### DIFF
--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -12,10 +12,6 @@ from torch import nn
 
 from diffusers.models.attention import BasicTransformerBlock, JointTransformerBlock
 from diffusers.models.transformers.sana_transformer import SanaTransformerBlock
-from diffusers.models.transformers.transformer_hidream_image import (
-    HiDreamImageSingleTransformerBlock,
-    HiDreamImageTransformerBlock,
-)
 from diffusers.models.transformers.transformer_hunyuan_video import (
     HunyuanVideoIndividualTokenRefinerBlock,
     HunyuanVideoSingleTransformerBlock,
@@ -411,8 +407,8 @@ def enable_checkpointing_for_hi_dream_transformer(
         config: TrainConfig,
 ) -> LayerOffloadConductor:
     return enable_checkpointing(model, config, config.compile, [
-        (HiDreamImageTransformerBlock,       ["hidden_states", "encoder_hidden_states"]),
-        (HiDreamImageSingleTransformerBlock, ["hidden_states"                         ]),
+        (model.double_stream_blocks, ["hidden_states", "encoder_hidden_states"]),
+        (model.single_stream_blocks, ["hidden_states"                         ]),
     ])
 
 def enable_checkpointing_for_ernie_transformer(


### PR DESCRIPTION
## Summary

`enable_checkpointing_for_hi_dream_transformer` matched blocks by their inner type
(`HiDreamImageTransformerBlock` / `HiDreamImageSingleTransformerBlock`), but diffusers
wraps each block in an outer `HiDreamBlock`, so the matcher never found a `ModuleList`
and no layers were registered for checkpointing/offloading. This made
`LayerOffloadConductor`/`LayerOffloadStrategy` initialization call `max()` over an
empty sequence, crashing on startup whenever gradient checkpointing is enabled
(e.g. the default HiDream LoRA preset).

Fix: target `model.double_stream_blocks` / `model.single_stream_blocks` directly
instead of searching by inner block type, matching the pattern already used for
other transformers in this file.

Fixes #1532

Drafted by Claude