### PR TITLE
Fix Stable Cascade checkpointing crash by using native diffusers checkpointing

### DIFF
--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -11,10 +11,7 @@ from modules.modelSetup.mixin.ModelSetupEmbeddingMixin import ModelSetupEmbeddin
 from modules.modelSetup.mixin.ModelSetupNoiseMixin import ModelSetupNoiseMixin
 from modules.modelSetup.mixin.ModelSetupText2ImageMixin import ModelSetupText2ImageMixin
 from modules.module.AdditionalEmbeddingWrapper import AdditionalEmbeddingWrapper
-from modules.util.checkpointing_util import (
-    enable_checkpointing_for_clip_encoder_layers,
-    enable_checkpointing_for_stable_cascade_blocks,
-)
+from modules.util.checkpointing_util import enable_checkpointing_for_clip_encoder_layers
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import (
@@ -58,12 +55,8 @@ class BaseWuerstchenSetup(
             config: TrainConfig,
     ):
         if config.gradient_checkpointing.enabled():
-            if model.model_type.is_wuerstchen_v2():
-                model.prior_prior.enable_gradient_checkpointing()
-                enable_checkpointing_for_clip_encoder_layers(model.prior_text_encoder, config)
-            elif model.model_type.is_stable_cascade():
-                enable_checkpointing_for_stable_cascade_blocks(model.prior_prior, config)
-                enable_checkpointing_for_clip_encoder_layers(model.prior_text_encoder, config)
+            model.prior_prior.enable_gradient_checkpointing()
+            enable_checkpointing_for_clip_encoder_layers(model.prior_text_encoder, config)
 
         if config.force_circular_padding:
             apply_circular_padding_to_conv2d(model.decoder_vqgan)

--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -21,7 +21,6 @@ from diffusers.models.transformers.transformer_hunyuan_video import (
     HunyuanVideoSingleTransformerBlock,
     HunyuanVideoTransformerBlock,
 )
-from diffusers.models.unets.unet_stable_cascade import SDCascadeAttnBlock, SDCascadeResBlock, SDCascadeTimestepBlock
 from transformers.models.clip.modeling_clip import CLIPEncoderLayer
 from transformers.models.gemma2.modeling_gemma2 import Gemma2DecoderLayer
 from transformers.models.llama.modeling_llama import LlamaDecoderLayer
@@ -268,16 +267,6 @@ def enable_checkpointing_for_clip_encoder_layers(
 ):
     return enable_checkpointing(model, config, False, [
         (CLIPEncoderLayer, []), # No activation offloading for text encoders, because the output might be taken from the middle of the network
-    ])
-
-def enable_checkpointing_for_stable_cascade_blocks(
-        model: nn.Module,
-        config: TrainConfig,
-) -> LayerOffloadConductor:
-    return enable_checkpointing(model, config, config.compile, [
-        (SDCascadeResBlock, []),
-        (SDCascadeAttnBlock, []),
-        (SDCascadeTimestepBlock, []),
     ])
 
 def enable_checkpointing_for_t5_encoder_layers(


### PR DESCRIPTION
## Summary

`enable_checkpointing_for_stable_cascade_blocks` searched for a homogeneous
`nn.ModuleList` of a single block type (`SDCascadeResBlock` / `SDCascadeAttnBlock` /
`SDCascadeTimestepBlock`), but `StableCascadeUNet`'s `down_blocks`/`up_blocks`
interleave all three block types within the same list by design. The matcher's
`assert all(isinstance(m, t) for m in child_module)` therefore always failed once
it found the first matching list, crashing on startup whenever checkpointing was
enabled for the prior.

This workaround predates diffusers' own gradient-checkpointing support for Stable
Cascade (it was written when the model still relied on the older Wuerstchen pipeline
code without `enable_gradient_checkpointing()`). diffusers' `StableCascadeUNet` now
supports native gradient checkpointing with correct per-block-type dispatch
internally, so this switches to `model.prior_prior.enable_gradient_checkpointing()`,
the same call already used for Wuerstchen v2, and removes the now-unused custom
matcher function.

Fixes #1529

Drafted by Claude