### PR TITLE
Add required fields to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name="OneTrainer"
+version="1.0.0"
 requires-python = ">=3.10"
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+name="OneTrainer"
 requires-python = ">=3.10"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

`uv` will complain (and for some commands will outright fail) if the project.name and project.version is not set.

The warning/error given is usually: 
```
pyproject.toml is using the `[project]` table, but the required `project.name` field is not set
```

This change aims to fix that.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

No regression testing needed as it is merely a DevEx change.

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- No AI involvement

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
