### PR TITLE
Add preset smoke-test scripts, including LoRA load checks (diffusers + ComfyUI)

### DIFF
--- a/modules/ui/TopBar.py
+++ b/modules/ui/TopBar.py
@@ -230,10 +230,8 @@ class TopBar:
             with open(filename, "r") as f:
                 loaded_dict = json.load(f)
                 default_config = TrainConfig.default_values()
-                if is_built_in_preset:
-                    # always assume built-in configs are saved in the most recent version
-                    loaded_dict["__version"] = default_config.config_version
-                loaded_config = default_config.from_dict(loaded_dict).to_unpacked_config()
+                # built-in configs are always saved in the most recent version, so migration can be skipped
+                loaded_config = default_config.from_dict(loaded_dict, migrate=not is_built_in_preset).to_unpacked_config()
 
             with suppress(FileNotFoundError), open("secrets.json", "r") as f:
                 secrets_dict=json.load(f)

--- a/modules/util/args/TrainArgs.py
+++ b/modules/util/args/TrainArgs.py
@@ -5,8 +5,10 @@ from modules.util.args.BaseArgs import BaseArgs
 
 
 class TrainArgs(BaseArgs):
+    preset_path: str
     config_path: str
     secrets_path: str
+    config_values: list[str]
 
     def __init__(self, data: list[(str, Any, type, bool)]):
         super().__init__(data)
@@ -17,8 +19,10 @@ class TrainArgs(BaseArgs):
 
         # @formatter:off
 
+        parser.add_argument("--preset-path", type=str, required=False, dest="preset_path", help="The path to a built-in preset file, applied before --config-path. When set, config migration is skipped for both files, so both the preset and the config must be in the current format.")
         parser.add_argument("--config-path", type=str, required=True, dest="config_path", help="The path to the config file")
         parser.add_argument("--secrets-path", type=str, required=False, dest="secrets_path", help="The path to the secrets file")
+        parser.add_argument("--config-value", type=str, required=False, dest="config_values", action="append", help="Override a single config value, as KEY=VALUE. Applied after --preset-path and --config-path. KEY may use dot notation to reach nested config objects (e.g. ema.decay). Can be passed multiple times.")
         parser.add_argument("--callback-path", type=str, required=False, dest="callback_path", help="The path to the callback pickle file")
         parser.add_argument("--command-path", type=str, required=False, dest="command_path", help="The path to the command pickle file")
 
@@ -33,8 +37,10 @@ class TrainArgs(BaseArgs):
         data = []
 
         # name, default value, data type, nullable
+        data.append(("preset_path", None, str, True))
         data.append(("config_path", None, str, True))
         data.append(("secrets_path", None, str, True))
+        data.append(("config_values", None, list[str], True))
         data.append(("callback_path", None, str, True))
         data.append(("command_path", None, str, True))
 

--- a/modules/util/config/BaseConfig.py
+++ b/modules/util/config/BaseConfig.py
@@ -63,19 +63,20 @@ class BaseConfig:
 
         return data
 
-    def from_dict(self, data: dict) -> 'BaseConfig':
-        version = 0
-        if '__version' in data:
-            version = data['__version']
+    def from_dict(self, data: dict, migrate: bool = True) -> 'BaseConfig':
+        if migrate:
+            version = 0
+            if '__version' in data:
+                version = data['__version']
 
-        while version in self.config_migrations:
-            data = self.config_migrations[version](data)
-            version += 1
+            while version in self.config_migrations:
+                data = self.config_migrations[version](data)
+                version += 1
 
         for name in self.types:
             try:
                 if issubclass_safe(self.types[name], BaseConfig):
-                    getattr(self, name).from_dict(data[name])
+                    getattr(self, name).from_dict(data[name], migrate=migrate)
                 elif self.types[name] is list or get_origin(self.types[name]) is list:
                     if len(get_args(self.types[name])) > 0 and issubclass_safe(get_args(self.types[name])[0], BaseConfig):
                         list_type = get_args(self.types[name])[0]
@@ -85,9 +86,9 @@ class BaseConfig:
                             value = []
                             for i in range(len(data[name])):
                                 if i < len(old_value) and i < len(data[name]):
-                                    value.append(old_value[i].from_dict(data[name][i]))
+                                    value.append(old_value[i].from_dict(data[name][i], migrate=migrate))
                                 else:
-                                    value.append(list_type.default_values().from_dict(data[name][i]))
+                                    value.append(list_type.default_values().from_dict(data[name][i], migrate=migrate))
                         else:
                             value = None
                         setattr(self, name, value)
@@ -98,7 +99,7 @@ class BaseConfig:
                         dict_type = get_args(self.types[name])[1]
                         value = {}
                         for dict_key, dict_value in data[name].items():
-                            value[dict_key] = dict_type.default_values().from_dict(dict_value)
+                            value[dict_key] = dict_type.default_values().from_dict(dict_value, migrate=migrate)
                         setattr(self, name, value)
                     else:
                         setattr(self, name, data[name])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@
 # NOTE: It's a user-wide tool installed outside venv. Don't pin exact versions.
 # SEE: https://pre-commit.com/
 pre-commit>=4.0.1
+
+# Required by test/smoke_load_diffusers.py to load LoRAs via diffusers' PEFT backend.
+peft

--- a/resources/test/logo.txt
+++ b/resources/test/logo.txt
@@ -1,0 +1,1 @@
+OneTrainer logo

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,8 +18,23 @@ def main():
     commands = TrainCommands()
 
     train_config = TrainConfig.default_values()
+
+    if args.preset_path is not None:
+        with open(args.preset_path, "r") as f:
+            train_config.from_dict(json.load(f), migrate=False)
+
     with open(args.config_path, "r") as f:
-        train_config.from_dict(json.load(f))
+        train_config.from_dict(json.load(f), migrate=args.preset_path is None)
+
+    for config_value in args.config_values or []:
+        key, _, value = config_value.partition("=")
+        *parent_keys, leaf_key = key.split(".")
+        target = train_config
+        for parent_key in parent_keys:
+            target = getattr(target, parent_key)
+        if target.types[leaf_key] is bool:
+            value = value.lower() in ("true", "1", "yes")
+        target.from_dict({leaf_key: value}, migrate=False)
 
     try:
         with open("secrets.json" if args.secrets_path is None else args.secrets_path, "r") as f:

--- a/test/download_comfy_smoke_models.py
+++ b/test/download_comfy_smoke_models.py
@@ -1,0 +1,113 @@
+import argparse
+import os
+
+from huggingface_hub import hf_hub_download
+
+# Comfy-format files needed per OT model_type to run smoke_load_comfy.py.
+# First entry under "files" is always the unet/checkpoint; any further entries
+# are text-encoder files, in the order smoke_load_comfy.py expects them.
+# Sources verified against the actual HF repo file listings and, where available,
+# against the "Model Links" MarkdownNote baked into ComfyUI's own workflow templates
+# (comfyui_workflow_templates_media_image/templates/*.json) - not guessed from memory.
+MODELS = {
+    "CHROMA_1": {
+        "files": [
+            ("Comfy-Org/Chroma1-HD_repackaged", "split_files/diffusion_models/Chroma1-HD-fp8mixed.safetensors"),
+            ("comfyanonymous/flux_text_encoders", "t5xxl_fp8_e4m3fn_scaled.safetensors"),
+        ],
+    },
+    "ERNIE": {
+        "files": [
+            ("Comfy-Org/ERNIE-Image", "diffusion_models/ernie-image.safetensors"),
+            ("Comfy-Org/ERNIE-Image", "text_encoders/ministral-3-3b.safetensors"),
+        ],
+    },
+    "FLUX_DEV_1": {
+        "files": [
+            ("Comfy-Org/flux1-dev", "flux1-dev-fp8.safetensors"),
+            ("comfyanonymous/flux_text_encoders", "clip_l.safetensors"),
+            ("comfyanonymous/flux_text_encoders", "t5xxl_fp8_e4m3fn_scaled.safetensors"),
+        ],
+    },
+    "FLUX_2": {
+        "files": [
+            ("black-forest-labs/FLUX.2-klein-base-9b-fp8", "flux-2-klein-base-9b-fp8.safetensors"),
+            ("Comfy-Org/flux2-klein-9B", "split_files/text_encoders/qwen_3_8b_fp8mixed.safetensors"),
+        ],
+    },
+    "HI_DREAM_FULL": {
+        "files": [
+            ("Comfy-Org/HiDream-I1_ComfyUI", "split_files/diffusion_models/hidream_i1_full_fp8.safetensors"),
+            ("Comfy-Org/HiDream-I1_ComfyUI", "split_files/text_encoders/clip_l_hidream.safetensors"),
+            ("Comfy-Org/HiDream-I1_ComfyUI", "split_files/text_encoders/clip_g_hidream.safetensors"),
+            ("Comfy-Org/HiDream-I1_ComfyUI", "split_files/text_encoders/t5xxl_fp8_e4m3fn_scaled.safetensors"),
+            ("Comfy-Org/HiDream-I1_ComfyUI", "split_files/text_encoders/llama_3.1_8b_instruct_fp8_scaled.safetensors"),
+        ],
+    },
+    "HUNYUAN_VIDEO": {
+        "files": [
+            ("Comfy-Org/HunyuanVideo_repackaged", "split_files/diffusion_models/hunyuan_video_t2v_720p_bf16.safetensors"),
+            ("Comfy-Org/HunyuanVideo_repackaged", "split_files/text_encoders/clip_l.safetensors"),
+            ("Comfy-Org/HunyuanVideo_repackaged", "split_files/text_encoders/llava_llama3_fp8_scaled.safetensors"),
+        ],
+    },
+    "PIXART_SIGMA": {
+        "files": [
+            ("HDiffusion/Pixart-Sigma-Safetensors", "PixArt-Sigma-XL-2-1024-MS.safetensors"),
+            ("comfyanonymous/flux_text_encoders", "t5xxl_fp16.safetensors"),
+        ],
+    },
+    "QWEN": {
+        "files": [
+            ("Comfy-Org/Qwen-Image_ComfyUI", "split_files/diffusion_models/qwen_image_fp8_e4m3fn.safetensors"),
+            ("Comfy-Org/Qwen-Image_ComfyUI", "split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors"),
+        ],
+    },
+    "STABLE_DIFFUSION_15": {
+        "files": [
+            ("stable-diffusion-v1-5/stable-diffusion-v1-5", "v1-5-pruned-emaonly.safetensors"),
+        ],
+    },
+    "STABLE_DIFFUSION_21": {
+        "files": [
+            ("sd2-community/stable-diffusion-2-1", "v2-1_768-ema-pruned.safetensors"),
+        ],
+    },
+    "STABLE_DIFFUSION_3": {
+        "files": [
+            ("stabilityai/stable-diffusion-3-medium", "sd3_medium_incl_clips_t5xxlfp8.safetensors"),
+        ],
+    },
+    "STABLE_DIFFUSION_XL_10_BASE": {
+        "files": [
+            ("stabilityai/stable-diffusion-xl-base-1.0", "sd_xl_base_1.0.safetensors"),
+        ],
+    },
+    "Z_IMAGE": {
+        "files": [
+            ("Comfy-Org/z_image_turbo", "split_files/diffusion_models/z_image_turbo_bf16.safetensors"),
+            ("Comfy-Org/z_image_turbo", "split_files/text_encoders/qwen_3_4b.safetensors"),
+        ],
+    },
+    # WUERSTCHEN_2 is intentionally omitted: ComfyUI only supports Stable Cascade,
+    # an architecturally different model from the Wuerstchen v2 that OT trains.
+}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_type", choices=MODELS.keys())
+    parser.add_argument("--dest-dir", default="models/comfy_smoke")
+    args = parser.parse_args()
+
+    files = MODELS[args.model_type]["files"]
+    dest_dir = os.path.join(args.dest_dir, args.model_type)
+    os.makedirs(dest_dir, exist_ok=True)
+
+    for repo_id, filename in files:
+        path = hf_hub_download(repo_id=repo_id, filename=filename, local_dir=dest_dir)
+        print(path)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/lora_presets_common.sh
+++ b/test/lora_presets_common.sh
@@ -1,0 +1,42 @@
+CONFIG="test/minimal.json"
+LOG_DIR="test"
+ERROR_LOG="$LOG_DIR/errors.log"
+LORA_DIR="models/lora_smoke"
+
+presets=(
+    "training_presets/#chroma LoRA 16GB.json"
+    "training_presets/#ernie LoRA 16GB.json"
+    "training_presets/#flux2 LoRA 16GB.json"
+    "training_presets/#flux LoRA.json"
+    "training_presets/#hidream LoRA.json"
+    "training_presets/#hunyuan video LoRA.json"
+    "training_presets/#pixart sigma 1.0 LoRA.json"
+    "training_presets/#qwen LoRA 16GB.json"
+    "training_presets/#sd 1.5 LoRA.json"
+    "training_presets/#sd 2.1 LoRA.json"
+    "training_presets/#sd 3 LoRA.json"
+    "training_presets/#sdxl 1.0 LoRA.json"
+    "training_presets/#wuerstchen 2.0 LoRA.json"
+    "training_presets/#z-image DeTurbo LoRA 16GB.json"
+    "training_presets/#z-image LoRA 16GB.json"
+)
+
+# ComfyUI only supports Stable Cascade, an architecturally different model from
+# the Wuerstchen v2 that OT trains, so there is no Comfy smoke test for it.
+comfy_unsupported=("WUERSTCHEN_2")
+
+preset_name() {
+    basename "$1" .json
+}
+
+preset_logfile() {
+    local name
+    name=$(preset_name "$1")
+    echo "$LOG_DIR/${name#\#}.log"
+}
+
+preset_lora_path() {
+    local name
+    name=$(preset_name "$1")
+    echo "$LORA_DIR/${name#\#}/model.safetensors"
+}

--- a/test/minimal.json
+++ b/test/minimal.json
@@ -1,0 +1,23 @@
+{
+    "epochs": 2,
+    "batch_size": 2,
+    "tensorboard": false,
+    "concepts": [
+        {
+            "path": "resources/icons",
+            "text": {
+                "prompt_source": "concept",
+                "prompt_path": "resources/test/logo.txt"
+            }
+        }
+    ],
+    "samples": [
+        {
+            "prompt": "a mouse eating the OneTrainer logo",
+            "width": 512,
+            "height": 512,
+            "cfg_scale": 3.0,
+            "diffusion_steps": 20
+        }
+    ]
+}

--- a/test/run_comfy_smoke.sh
+++ b/test/run_comfy_smoke.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -o pipefail
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <comfyui-path>" >&2
+    exit 1
+fi
+COMFYUI_PATH="$1"
+COMFYUI_PYTHON="$COMFYUI_PATH/venv/bin/python3"
+
+source "$(dirname "$0")/lora_presets_common.sh"
+
+failed=0
+
+for preset in "${presets[@]}"; do
+    name=$(preset_name "$preset")
+    logfile=$(preset_logfile "$preset")
+    lora_path=$(preset_lora_path "$preset")
+
+    if [ ! -f "$lora_path" ]; then
+        echo "SKIPPED comfy smoke test for $name (no LoRA found at $lora_path, training did not produce one)" | tee -a "$logfile"
+        echo "FAILED (comfy load): $name" | tee -a "$ERROR_LOG"
+        failed=1
+        continue
+    fi
+
+    model_type=$(jq -r .model_type "$preset")
+    if printf '%s\n' "${comfy_unsupported[@]}" | grep -qx "$model_type"; then
+        echo "SKIPPED comfy smoke test for $name ($model_type not supported by ComfyUI)" | tee -a "$logfile"
+        echo "OK (comfy load): $name" | tee -a "$ERROR_LOG"
+        continue
+    fi
+
+    if ! comfy_files=$(venv/bin/python3 test/download_comfy_smoke_models.py "$model_type" 2>>"$logfile"); then
+        echo "FAILED (comfy model download): $name" | tee -a "$ERROR_LOG"
+        failed=1
+        continue
+    fi
+
+    if ! "$COMFYUI_PYTHON" test/smoke_load_comfy.py "$COMFYUI_PATH" "$model_type" "$lora_path" $comfy_files 2>&1 | tee -a "$logfile"; then
+        echo "FAILED (comfy load): $name" | tee -a "$ERROR_LOG"
+        failed=1
+        continue
+    fi
+
+    echo "OK (comfy load): $name" | tee -a "$ERROR_LOG"
+done
+
+exit $failed

--- a/test/run_diffusers_smoke.sh
+++ b/test/run_diffusers_smoke.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o pipefail
+
+source "$(dirname "$0")/lora_presets_common.sh"
+
+failed=0
+
+for preset in "${presets[@]}"; do
+    name=$(preset_name "$preset")
+    logfile=$(preset_logfile "$preset")
+    lora_path=$(preset_lora_path "$preset")
+
+    if [ ! -f "$lora_path" ]; then
+        echo "SKIPPED diffusers smoke test for $name (no LoRA found at $lora_path, training did not produce one)" | tee -a "$logfile"
+        echo "FAILED (diffusers load): $name" | tee -a "$ERROR_LOG"
+        failed=1
+        continue
+    fi
+
+    if ! venv/bin/python3 test/smoke_load_diffusers.py "$preset" "$lora_path" 2>&1 | tee -a "$logfile"; then
+        echo "FAILED (diffusers load): $name" | tee -a "$ERROR_LOG"
+        failed=1
+        continue
+    fi
+
+    echo "OK (diffusers load): $name" | tee -a "$ERROR_LOG"
+done
+
+exit $failed

--- a/test/run_embedding_presets.sh
+++ b/test/run_embedding_presets.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o pipefail
+
+CONFIG="test/minimal.json"
+LOG_DIR="test"
+ERROR_LOG="$LOG_DIR/errors.log"
+
+> "$ERROR_LOG"
+
+presets=(
+    "training_presets/#sd 1.5 embedding.json"
+    "training_presets/#sd 2.1 embedding.json"
+    "training_presets/#sdxl 1.0 embedding.json"
+    "training_presets/#wuerstchen 2.0 embedding.json"
+)
+
+failed=0
+
+for preset in "${presets[@]}"; do
+    name=$(basename "$preset" .json)
+    logfile="$LOG_DIR/${name#\#}.log"
+    echo "=== $name ===" | tee "$logfile"
+    if ./run-cmd.sh train --preset-path "$preset" --config-path "$CONFIG" 2>&1 | tee -a "$logfile" && ! grep -q "Error during sampling" "$logfile"; then
+        echo "OK: $name" | tee -a "$ERROR_LOG"
+    else
+        echo "FAILED: $name" | tee -a "$ERROR_LOG"
+        failed=1
+    fi
+done
+
+exit $failed

--- a/test/run_lora_presets.sh
+++ b/test/run_lora_presets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o pipefail
+
+source "$(dirname "$0")/lora_presets_common.sh"
+
+> "$ERROR_LOG"
+
+failed=0
+
+for preset in "${presets[@]}"; do
+    name=$(preset_name "$preset")
+    logfile=$(preset_logfile "$preset")
+    lora_path=$(preset_lora_path "$preset")
+    echo "=== $name ===" | tee "$logfile"
+
+    if ! ./run-cmd.sh train --preset-path "$preset" --config-path "$CONFIG" --config-value "output_model_destination=$lora_path" 2>&1 | tee -a "$logfile" || grep -q "Error during sampling" "$logfile"; then
+        echo "FAILED (train): $name" | tee -a "$ERROR_LOG"
+        failed=1
+    else
+        echo "OK (train): $name" | tee -a "$ERROR_LOG"
+    fi
+done
+
+exit $failed

--- a/test/smoke_load_comfy.py
+++ b/test/smoke_load_comfy.py
@@ -1,0 +1,80 @@
+import argparse
+import logging
+import sys
+
+# Loader to use, and (for "split") the comfy.sd.CLIPType to pass to load_clip.
+# clip_type is None where Comfy auto-detects the text encoder from its weights
+# (ERNIE, Z_IMAGE) or where the checkpoint loader handles clip internally.
+MODEL_CONFIG = {
+    "CHROMA_1": ("split", "CHROMA"),
+    "ERNIE": ("split", None),
+    "FLUX_DEV_1": ("split", "FLUX"),
+    "FLUX_2": ("split", "FLUX2"),
+    "HI_DREAM_FULL": ("split", "HIDREAM"),
+    "HUNYUAN_VIDEO": ("split", "HUNYUAN_VIDEO"),
+    "PIXART_SIGMA": ("split", "PIXART"),
+    "QWEN": ("split", "QWEN_IMAGE"),
+    "STABLE_DIFFUSION_15": ("checkpoint", None),
+    "STABLE_DIFFUSION_21": ("checkpoint", None),
+    "STABLE_DIFFUSION_3": ("checkpoint", None),
+    "STABLE_DIFFUSION_XL_10_BASE": ("checkpoint", None),
+    "Z_IMAGE": ("split", None),
+}
+
+
+class RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record.getMessage())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("comfyui_path", help="Path to the ComfyUI checkout (for importing the comfy package)")
+    parser.add_argument("model_type", choices=MODEL_CONFIG.keys())
+    parser.add_argument("lora_path")
+    parser.add_argument(
+        "model_files", nargs="+",
+        help="unet/checkpoint path, followed by any text-encoder paths (split loader only)",
+    )
+    args = parser.parse_args()
+
+    loader, clip_type_name = MODEL_CONFIG[args.model_type]
+
+    sys.path.insert(0, args.comfyui_path)
+
+    import comfy.cli_args
+    comfy.cli_args.args.cpu = True
+
+    import comfy.sd
+    import comfy.utils
+
+    handler = RecordingHandler()
+    logging.getLogger().addHandler(handler)
+
+    if loader == "checkpoint":
+        model, clip, _vae = comfy.sd.load_checkpoint_guess_config(args.model_files[0], output_clipvision=False)[:3]
+    else:
+        clip_type = getattr(comfy.sd.CLIPType, clip_type_name) if clip_type_name else comfy.sd.CLIPType.STABLE_DIFFUSION
+        model = comfy.sd.load_diffusion_model(args.model_files[0])
+        clip = comfy.sd.load_clip(ckpt_paths=args.model_files[1:], clip_type=clip_type)
+
+    lora_sd = comfy.utils.load_torch_file(args.lora_path, safe_load=True)
+
+    comfy.sd.load_lora_for_models(model, clip, lora_sd, 1.0, 1.0)
+
+    not_loaded = [m for m in handler.records if "lora key not loaded" in m]
+
+    if not_loaded:
+        for m in not_loaded:
+            print(f"FAIL: {m}", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: LoRA loaded onto Comfy model/clip with no unmatched keys.")
+
+
+if __name__ == '__main__':
+    main()

--- a/test/smoke_load_diffusers.py
+++ b/test/smoke_load_diffusers.py
@@ -1,0 +1,65 @@
+import argparse
+import json
+import logging
+import sys
+
+import torch
+
+from diffusers import DiffusionPipeline
+
+# Stable substrings emitted by diffusers on key mismatches:
+# - peft adapter loader (diffusers/utils/peft_utils.py:_maybe_warn_for_unhandled_keys)
+# - state-dict format converters (diffusers/loaders/lora_conversion_utils.py), which
+#   silently drop any key they can't map to a known format
+UNEXPECTED_KEYS_MARKER = "led to unexpected keys found in the model"
+MISSING_KEYS_MARKER = "led to missing keys in the model"
+UNSUPPORTED_KEYS_MARKER = "Unsupported keys for"
+# Emitted by diffusers/loaders/peft.py when a LoRA prefix matched zero keys in the
+# state dict - i.e. that component's LoRA was silently a no-op. Benign for the
+# text_encoder(_2) prefixes (OT presets often don't train a text-encoder LoRA), but
+# the main denoiser (transformer/unet) getting zero keys means the LoRA didn't load at
+# all, which would otherwise pass this script's checks above since no key name mismatch
+# is reported in that case.
+NO_KEYS_DENOISER_MARKERS = ("found with the prefix='transformer'", "found with the prefix='unet'")
+
+
+class RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record.getMessage())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("preset_path")
+    parser.add_argument("lora_path")
+    args = parser.parse_args()
+
+    with open(args.preset_path, "r") as f:
+        preset = json.load(f)
+    base_model_name = preset["base_model_name"]
+
+    handler = RecordingHandler()
+    logging.getLogger("diffusers").addHandler(handler)
+
+    pipe = DiffusionPipeline.from_pretrained(base_model_name, torch_dtype=torch.bfloat16)
+    pipe.load_lora_weights(args.lora_path)
+
+    unexpected = [m for m in handler.records if UNEXPECTED_KEYS_MARKER in m]
+    missing = [m for m in handler.records if MISSING_KEYS_MARKER in m]
+    unsupported = [m for m in handler.records if UNSUPPORTED_KEYS_MARKER in m]
+    no_keys_denoiser = [m for m in handler.records if any(marker in m for marker in NO_KEYS_DENOISER_MARKERS)]
+
+    if unexpected or missing or unsupported or no_keys_denoiser:
+        for m in unexpected + missing + unsupported + no_keys_denoiser:
+            print(f"FAIL: {m}", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: LoRA loaded into diffusers pipeline with no unexpected/missing adapter keys.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Builds on #1531 (the `--preset-path`/`--config-value` CLI overrides).

Adds `test/run_lora_presets.sh` and `test/run_embedding_presets.sh` to train every built-in preset against a small shared `test/minimal.json` config, plus two new load-only smoke tests run against each trained LoRA:

- `test/smoke_load_diffusers.py` - loads the LoRA into a vanilla diffusers pipeline via `load_lora_weights`, to catch real-world LoRA key-name mismatches outside of OT's own loading code.
- `test/smoke_load_comfy.py` - same, but against ComfyUI's own loader (`comfy.sd.load_lora_for_models`).

Both are CPU-only, load-only (no sampling). Training is decoupled from the two load checks via `--config-value` (from #1531), so each of the three stages (train / diffusers-load / comfy-load) can be rerun independently against already-saved LoRAs in `models/lora_smoke/<preset>/model.safetensors`.

Initial results across all built-in model types are summarized in #1544.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: all built-in LoRA and embedding presets, trained and load-checked on a remote GPU box)

## AI assistance
Early AI prototype — opened for discussion, not ready for review

---
Drafted by Claude