### PR TITLE
Disable LoRA rank check (false positive on LoHA backup/loading)

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -990,7 +990,8 @@ class LoRAModuleWrapper:
         # create a copy, so the modules can pop states
         state_dict = {k: v for (k, v) in state_dict.items() if k.startswith(self.prefix)}
 
-        self._check_rank_matches(state_dict)
+        # FIXME: disabled rank check, false positive on Flux2 LoHA loading
+        # self._check_rank_matches(state_dict)
 
         try:
             for module in self.lora_modules.values():


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Disables rank check for now, because it breaks backups when training a LoHA
Fixes #1340 by disabling the rank check for now
@O-J1 until you have time for https://github.com/Nerogar/OneTrainer/pull/1300#discussion_r3416297105

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
