### PR TITLE
Fix frozen-text-encoder training crash for Würstchen / Stable Cascade

### DIFF
--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -239,7 +239,8 @@ class BaseWuerstchenSetup(
                 text_encoder_output=batch[
                     'text_encoder_hidden_state'] if not config.train_text_encoder_or_embedding() else None,
                 pooled_text_encoder_output=batch[
-                    'pooled_text_encoder_output'] if not config.train_text_encoder_or_embedding() else None,
+                    'pooled_text_encoder_output'] if not config.train_text_encoder_or_embedding()
+                    and 'pooled_text_encoder_output' in batch else None,
                 text_encoder_dropout_probability=config.text_encoder.dropout_probability if not deterministic else None,
             )
 

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -358,7 +358,7 @@ class BaseWuerstchenSetup(
         model.to(self.temp_device)
 
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.prior_text_encoder_to(self.train_device)
 
         model.eval()
         torch_gc()

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -238,6 +238,7 @@ class BaseWuerstchenSetup(
                 text_encoder_layer_skip=config.text_encoder_layer_skip,
                 text_encoder_output=batch[
                     'text_encoder_hidden_state'] if not config.train_text_encoder_or_embedding() else None,
+                # the dataloader only caches a pooled output for Stable Cascade, Wuerstchen v2 has none
                 pooled_text_encoder_output=batch[
                     'pooled_text_encoder_output'] if not config.train_text_encoder_or_embedding()
                     and 'pooled_text_encoder_output' in batch else None,


### PR DESCRIPTION
When training a Würstchen v2 or Stable Cascade model with the text encoder frozen, training crashes during text-embedding caching:

```
AttributeError: 'WuerstchenModel' object has no attribute 'text_encoder_to'
```

`BaseWuerstchenSetup.prepare_text_caching` calls `model.text_encoder_to(...)` on the frozen-TE path (`if not config.train_text_encoder_or_embedding()`), but `WuerstchenModel` defines `prior_text_encoder_to` / `decoder_text_encoder_to` / `effnet_encoder_to` and has no `text_encoder_to`. The call moves the (prior) text encoder to the train device for caching, so the intended method is `prior_text_encoder_to`.

This affects both `WUERSTCHEN_2` and `STABLE_CASCADE_1`, which share `BaseWuerstchenSetup`.

Drafted by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)