### PR TITLE
fix: missing commit for #1518

### DIFF
--- a/modules/modelSaver/chroma/ChromaModelSaver.py
+++ b/modules/modelSaver/chroma/ChromaModelSaver.py
@@ -28,7 +28,7 @@ class ChromaModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         text_encoder = save_pipeline.text_encoder
         if text_encoder is not None:

--- a/modules/modelSaver/ernie/ErnieModelSaver.py
+++ b/modules/modelSaver/ernie/ErnieModelSaver.py
@@ -24,7 +24,7 @@ class ErnieModelSaver(
     ):
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/flux/FluxModelSaver.py
+++ b/modules/modelSaver/flux/FluxModelSaver.py
@@ -28,7 +28,7 @@ class FluxModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_2",))
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer_2)
 
         text_encoder_2 = save_pipeline.text_encoder_2
         if text_encoder_2 is not None:

--- a/modules/modelSaver/flux2/Flux2ModelSaver.py
+++ b/modules/modelSaver/flux2/Flux2ModelSaver.py
@@ -26,7 +26,7 @@ class Flux2ModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/hidream/HiDreamModelSaver.py
+++ b/modules/modelSaver/hidream/HiDreamModelSaver.py
@@ -25,7 +25,7 @@ class HiDreamModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_3", "tokenizer_4"))
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer_3, pipeline.tokenizer_4)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/hunyuanVideo/HunyuanVideoModelSaver.py
+++ b/modules/modelSaver/hunyuanVideo/HunyuanVideoModelSaver.py
@@ -28,7 +28,7 @@ class HunyuanVideoModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         text_encoder_1 = save_pipeline.text_encoder
         if text_encoder_1 is not None:

--- a/modules/modelSaver/mixin/DtypeModelSaverMixin.py
+++ b/modules/modelSaver/mixin/DtypeModelSaverMixin.py
@@ -46,14 +46,13 @@ class DtypeModelSaverMixin:
             self,
             pipeline,
             dtype: torch.dtype | None,
-            tokenizer_attrs: tuple[str, ...] = ("tokenizer",),
+            *tokenizers,
     ):
         if dtype is None:
             return pipeline
 
         # replace the tokenizers' __deepcopy__ before calling deepcopy, to prevent a copy being made.
         # the tokenizers try to reload from the file system otherwise
-        tokenizers = [getattr(pipeline, attr) for attr in tokenizer_attrs]
         for tokenizer in tokenizers:
             tokenizer.__deepcopy__ = lambda memo, tokenizer=tokenizer: tokenizer
 

--- a/modules/modelSaver/pixartAlpha/PixArtAlphaModelSaver.py
+++ b/modules/modelSaver/pixartAlpha/PixArtAlphaModelSaver.py
@@ -27,7 +27,7 @@ class PixArtAlphaModelSaver(
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
 
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/qwen/QwenModelSaver.py
+++ b/modules/modelSaver/qwen/QwenModelSaver.py
@@ -25,7 +25,7 @@ class QwenModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/sana/SanaModelSaver.py
+++ b/modules/modelSaver/sana/SanaModelSaver.py
@@ -24,7 +24,7 @@ class SanaModelSaver(
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
 
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)

--- a/modules/modelSaver/stableDiffusion3/StableDiffusion3ModelSaver.py
+++ b/modules/modelSaver/stableDiffusion3/StableDiffusion3ModelSaver.py
@@ -28,7 +28,7 @@ class StableDiffusion3ModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline(use_original_tokenizers=True)
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, tokenizer_attrs=("tokenizer_3",))
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer_3)
 
         text_encoder_3 = save_pipeline.text_encoder_3
         if text_encoder_3 is not None:

--- a/modules/modelSaver/zImage/ZImageModelSaver.py
+++ b/modules/modelSaver/zImage/ZImageModelSaver.py
@@ -25,7 +25,7 @@ class ZImageModelSaver(
         # Copy the model to cpu by first moving the original model to cpu. This preserves some VRAM.
         pipeline = model.create_pipeline()
         pipeline.to("cpu")
-        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype)
+        save_pipeline = self._copy_pipeline_to_dtype(pipeline, dtype, pipeline.tokenizer)
 
         os.makedirs(Path(destination).absolute(), exist_ok=True)
         save_pipeline.save_pretrained(destination)


### PR DESCRIPTION
## Summary

Follow-up to #1518: `_copy_pipeline_to_dtype` took a `tokenizer_attrs` tuple of attribute-name strings, with a default of `("tokenizer",)`. This fix passes the tokenizer objects directly instead, and drops the default so every caller states explicitly which tokenizers it protects.

This addresses review feedback that came in on #1518 after it was already merged.

## Test plan

- [x] `pre-commit run --all-files` passes

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change

Drafted by Claude