### PR TITLE
Bump diffusers pin to latest upstream commit

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -20,7 +20,7 @@ safetensors==0.8.0rc0
 tensorboard==2.20.0
 
 # diffusion models
--e git+https://github.com/huggingface/diffusers.git@0f1abc4#egg=diffusers
+-e git+https://github.com/huggingface/diffusers.git@1ffa423#egg=diffusers
 gguf==0.17.1
 transformers==5.5.4 # pinned below 5.6, see https://github.com/Nerogar/OneTrainer/pull/1506
 sentencepiece==0.2.1 # transitive dependency of transformers for tokenizer loading


### PR DESCRIPTION
## Summary
- Updates the diffusers git pin in `requirements-global.txt` from `0f1abc4` to `1ffa423` (latest commit on huggingface/diffusers main).

Drafted by Claude