### PR TITLE
Bump safetensors pin to 0.8.0 final release

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -16,7 +16,7 @@ setuptools==81.0.0
 
 # pytorch
 accelerate==1.12.0
-safetensors==0.8.0rc0
+safetensors==0.8.0
 tensorboard==2.20.0
 
 # diffusion models


### PR DESCRIPTION
## Summary
- PR #1569 bumped the diffusers pin, which now requires `safetensors>=0.8.0`.
- The `safetensors==0.8.0rc0` pre-release pin no longer satisfies that constraint now that `0.8.0` final has been released.
- Bumps the pin in `requirements-global.txt` to `safetensors==0.8.0`.

Drafted by Claude