### PR TITLE
Fix PySide6 param dialogs leaking field validators after close

### DIFF
--- a/modules/ui/PySide6MuonAdamWindowView.py
+++ b/modules/ui/PySide6MuonAdamWindowView.py
@@ -10,6 +10,9 @@ class PySide6MuonAdamWindowView(BaseMuonAdamWindowView, QDialog):
         QDialog.__init__(self, parent)
         BaseMuonAdamWindowView.__init__(self, pyside6_components)
 
+        # delete on close so entry widgets and the field validators they register globally are freed, not leaked
+        self.finished.connect(self.deleteLater)
+
         self.setWindowTitle(controller.get_title())
         self.resize(800, 500)
 

--- a/modules/ui/PySide6OffloadingWindowView.py
+++ b/modules/ui/PySide6OffloadingWindowView.py
@@ -10,6 +10,9 @@ class PySide6OffloadingWindowView(BaseOffloadingWindowView, QDialog):
         QDialog.__init__(self, parent)
         BaseOffloadingWindowView.__init__(self, pyside6_components)
 
+        # delete on close so entry widgets and the field validators they register globally are freed, not leaked
+        self.finished.connect(self.deleteLater)
+
         self.setWindowTitle("Offloading")
         self.resize(800, 400)
 

--- a/modules/ui/PySide6OptimizerParamsWindowView.py
+++ b/modules/ui/PySide6OptimizerParamsWindowView.py
@@ -13,6 +13,11 @@ class PySide6OptimizerParamsWindowView(BaseOptimizerParamsWindowView, QDialog):
         QDialog.__init__(self, parent)
         BaseOptimizerParamsWindowView.__init__(self, pyside6_components)
 
+        # delete on close so the entry widgets, and the field validators they register in the global
+        # _active_validators set, are destroyed instead of lingering on the parent and being re-checked
+        # at training start (a parented QDialog is otherwise kept alive after exec() returns).
+        self.finished.connect(self.deleteLater)
+
         self.controller = controller
         self.ui_state = ui_state
         self.optimizer_ui_state = ui_state.get_var("optimizer")

--- a/modules/ui/PySide6SchedulerParamsWindowView.py
+++ b/modules/ui/PySide6SchedulerParamsWindowView.py
@@ -64,6 +64,9 @@ class PySide6SchedulerParamsWindowView(BaseSchedulerParamsWindowView, QDialog):
         QDialog.__init__(self, parent)
         BaseSchedulerParamsWindowView.__init__(self, pyside6_components)
 
+        # delete on close so entry widgets and the field validators they register globally are freed, not leaked
+        self.finished.connect(self.deleteLater)
+
         self.setWindowTitle("Learning Rate Scheduler Settings")
         self.resize(800, 500)
 

--- a/modules/ui/PySide6TimestepDistributionWindowView.py
+++ b/modules/ui/PySide6TimestepDistributionWindowView.py
@@ -12,6 +12,9 @@ class PySide6TimestepDistributionWindowView(BaseTimestepDistributionWindowView, 
         QDialog.__init__(self, parent)
         BaseTimestepDistributionWindowView.__init__(self, pyside6_components)
 
+        # delete on close so entry widgets and the field validators they register globally are freed, not leaked
+        self.finished.connect(self.deleteLater)
+
         self.setWindowTitle("Timestep Distribution")
         self.resize(900, 600)
         self._controller = controller


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Minor fix to the new Qt UI:

  - The optimizer/scheduler/offloading/timestep/muon-adam settings dialogs are parented QDialogs created inline and shown with exec(). A parented dialog is
  kept alive by its parent after exec() returns, so its entry widgets are never destroyed and the field validators they register in the global
  _active_validators set are never detached.
  - Leaked validators linger and get re-checked by flush_and_validate_all() at training start (e.g. Adafactor's negative decay_rate spuriously failing the
  non-negative float check), and each re-open of a dialog leaks another set.
  - Fix: connect each dialog's finished signal to deleteLater so closing it destroys the entry widgets, firing their destroyed signals and detaching the
  validators.


## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
