### PR TITLE
Fix full-finetune save crash when checkpointing + layer offloading are enabled + diffusers output format

### DIFF
--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -614,13 +614,6 @@ class LayerOffloadConductor:
 
         self.__config = config
 
-    def __deepcopy__(self, memo):
-        # the conductor holds torch.cuda.Stream/Event objects that cannot be deep-copied or pickled.
-        # deepcopy only happens at save time to build a dtype-converted CPU copy of the pipeline, where
-        # the conductor is never invoked, so share the existing instance instead of copying it.
-        memo[id(self)] = self
-        return self
-
     def offload_activated(self) -> bool:
         return self.__offload_activations or self.__offload_layers
 

--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -614,6 +614,13 @@ class LayerOffloadConductor:
 
         self.__config = config
 
+    def __deepcopy__(self, memo):
+        # the conductor holds torch.cuda.Stream/Event objects that cannot be deep-copied or pickled.
+        # deepcopy only happens at save time to build a dtype-converted CPU copy of the pipeline, where
+        # the conductor is never invoked, so share the existing instance instead of copying it.
+        memo[id(self)] = self
+        return self
+
     def offload_activated(self) -> bool:
         return self.__offload_activations or self.__offload_layers
 

--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 from collections.abc import Callable
 from typing import Any
@@ -105,6 +106,17 @@ class OffloadCheckpointLayer(BaseCheckpointLayer):
         self.dummy = torch.zeros((1,), device=train_device, requires_grad=True)
         self.conductor = conductor
         self.layer_index = layer_index
+
+    def __deepcopy__(self, memo):
+        # conductor holds torch.cuda.Stream/Event objects that cannot be deep-copied or pickled.
+        # deepcopy is only used at save time to build a dtype-converted CPU copy of the pipeline,
+        # where the conductor is never invoked, so share the existing instance instead of copying it.
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for key, value in self.__dict__.items():
+            result.__dict__[key] = value if key == "conductor" else copy.deepcopy(value, memo)
+        return result
 
     def __checkpointing_forward(self, dummy: torch.Tensor, call_id: int, *args):
         init_compile()  # workaround for https://github.com/pytorch/pytorch/issues/186537


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

- full finetunes create a deepcopy of the entire model before saving, so they can modify the output dtype
- this is an issue with offloading because it attempts to copy OffloadingCheckpointerLayers which refer to an OffloadConductor - cannot be copied
- prevent that

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Krea2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
