### PR TITLE
Qt thread safety

### DIFF
--- a/modules/ui/BaseTrainUIView.py
+++ b/modules/ui/BaseTrainUIView.py
@@ -53,7 +53,10 @@ class BaseTrainUIView(ABC):
     def connect_window_closed(self, window, callback): pass
 
     def sync_cloud_secrets(self):
-        self.ui_state.get_var("secrets.cloud").update(self.controller.train_config.secrets.cloud)
+        # Called from training thread — defer to main thread
+        self.schedule_on_main_thread(
+            lambda: self.ui_state.get_var("secrets.cloud").update(self.controller.train_config.secrets.cloud)
+        )
 
     def start_training(self):
         self.controller.start_training()

--- a/modules/ui/PySide6VideoToolUIView.py
+++ b/modules/ui/PySide6VideoToolUIView.py
@@ -6,7 +6,7 @@ from modules.util.ui.pyside6_util import QtABCMeta
 from modules.util.ui.PySide6UIState import PySide6UIState
 
 from PIL.ImageQt import ImageQt
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
     QDialog,
@@ -112,14 +112,22 @@ class PySide6VideoToolUIView(BaseVideoToolUIView, QDialog, metaclass=QtABCMeta):
         widget.textChanged.connect(lambda: var.set(widget.toPlainText()))
         return widget
 
+    def schedule_on_main_thread(self, fn):
+        QTimer.singleShot(0, self, fn)
+
     def update_status(self, status_text: str):
-        self._status_box.append(status_text)
+        # Called from the video tool's worker thread — defer to main thread
+        self.schedule_on_main_thread(lambda: self._status_box.append(status_text))
 
     def clear_status(self):
         self._status_box.clear()
 
     def update_preview(self, preview_image, label_text: str):
+        # Called from the video tool's worker thread — defer to main thread
         pixmap = QPixmap.fromImage(ImageQt(preview_image.convert("RGBA")))
+        self.schedule_on_main_thread(lambda: self._do_update_preview(pixmap, label_text))
+
+    def _do_update_preview(self, pixmap: QPixmap, label_text: str):
         self._preview_label.setPixmap(
             pixmap.scaled(150, 150, Qt.KeepAspectRatio, Qt.SmoothTransformation)
         )


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Qt is stricter that Ctk with regards to thread safety. Do all UI calls only from the main thread, not from the training thread (and not from the video tool worker thread CC @efhosci)

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
