### PR TITLE
Force Fusion style for PySide6 UI

### DIFF
--- a/export_debug.bat
+++ b/export_debug.bat
@@ -4,8 +4,8 @@ REM Avoid footgun by explictly navigating to the directory containing the batch 
 cd /d "%~dp0"
 
 REM Verify that OneTrainer is our current working directory
-if not exist "scripts\train_ui.py" (
-    echo Error: train_ui.py does not exist, you have done something very wrong. Reclone the repository.
+if not exist "scripts\train_ui_qt.py" (
+    echo Error: train_ui_qt.py does not exist, you have done something very wrong. Reclone the repository.
     goto :end
 )
 

--- a/modules/util/ui/pyside6_util.py
+++ b/modules/util/ui/pyside6_util.py
@@ -4,7 +4,7 @@ from abc import ABCMeta
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPalette
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QStyleFactory, QWidget
 
 
 class QtABCMeta(type(QWidget), ABCMeta):
@@ -20,6 +20,10 @@ def create_application() -> QApplication:
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     app = QApplication(sys.argv)
+    # Force Fusion everywhere: native styles (e.g. windowsvista) draw standard
+    # controls via OS theme APIs, which breaks once an application stylesheet
+    # is set, producing a flatter look than Fusion's own stylesheet-aware painting.
+    app.setStyle(QStyleFactory.create("Fusion"))
     app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
     palette = app.palette()

--- a/update.bat
+++ b/update.bat
@@ -5,8 +5,8 @@ REM Avoid footgun by explictly navigating to the directory containing the batch 
 cd /d "%~dp0"
 
 REM Verify that OneTrainer is our current working directory
-if not exist "scripts\train_ui.py" (
-    echo Error: train_ui.py does not exist, you have done something very wrong. Reclone the repository.
+if not exist "scripts\train_ui_qt.py" (
+    echo Error: train_ui_qt.py does not exist, you have done something very wrong. Reclone the repository.
     goto :end
 )
 


### PR DESCRIPTION
## Summary

The PySide6 UI looks noticeably flatter on Windows than on Linux (washed-out checkboxes/buttons, no accent color on progress bars). `create_application()` in `modules/util/ui/pyside6_util.py` never calls `QApplication.setStyle(...)`, so Qt falls back to the native platform style (`windowsvista` on Windows, effectively `Fusion` on Linux). Once an application-wide stylesheet is set (as this code does), native styles like `windowsvista` can no longer fully delegate painting of standard controls to the OS theme APIs, so they render with a generic, flat fallback. `Fusion` is Qt's own cross-platform style and paints correctly regardless of stylesheets, which is why Linux already looks fine. This PR forces `Fusion` on all platforms so the UI looks the same everywhere.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

Verified on Linux (no visible regression, matches prior appearance). Not yet verified on Windows — opening as a draft for discussion/testing since I don't have a Windows machine to confirm the fix visually.

## AI assistance

- Early AI prototype — opened for discussion, **not ready for review**

---
Drafted by Claude