### PR TITLE
Presets for Krea, Ideogram, and change dataloader threads

### DIFF
--- a/training_presets/Anima/#anima Finetune.json
+++ b/training_presets/Anima/#anima Finetune.json
@@ -6,7 +6,6 @@
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
     "compile": true,
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16"

--- a/training_presets/Anima/#anima LoRA.json
+++ b/training_presets/Anima/#anima LoRA.json
@@ -6,7 +6,6 @@
     "output_model_format": "KOHYA_LORA",
     "resolution": "512",
     "compile": true,
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "INT_W8A8"

--- a/training_presets/Chroma/#chroma Finetune 16GB.json
+++ b/training_presets/Chroma/#chroma Finetune 16GB.json
@@ -4,7 +4,6 @@
     "learning_rate": 1e-5,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/Chroma/#chroma Finetune 8GB.json
+++ b/training_presets/Chroma/#chroma Finetune 8GB.json
@@ -4,7 +4,6 @@
     "learning_rate": 1e-5,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/Chroma/#chroma LoRA 8GB.json
+++ b/training_presets/Chroma/#chroma LoRA 8GB.json
@@ -4,7 +4,6 @@
     "learning_rate": 0.0003,
     "model_type": "CHROMA_1",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8",

--- a/training_presets/Ernie Image/#ernie LoRA 16GB.json
+++ b/training_presets/Ernie Image/#ernie LoRA 16GB.json
@@ -26,6 +26,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "timestep_distribution": "LOGIT_NORMAL",
-    "dataloader_threads": 1
+    "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Ernie Image/#ernie LoRA 8GB.json
+++ b/training_presets/Ernie Image/#ernie LoRA 8GB.json
@@ -27,6 +27,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "timestep_distribution": "LOGIT_NORMAL",
-    "dataloader_threads": 1
+    "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Flux 2/#flux2 Finetune 16GB.json
+++ b/training_presets/Flux 2/#flux2 Finetune 16GB.json
@@ -27,7 +27,6 @@
     },
     "timestep_distribution": "LOGIT_NORMAL",
     "dynamic_timestep_shifting": true,
-    "dataloader_threads": 1,
     "optimizer": {
         "optimizer": "ADAFACTOR"
     },

--- a/training_presets/Flux 2/#flux2 Finetune 24GB.json
+++ b/training_presets/Flux 2/#flux2 Finetune 24GB.json
@@ -26,7 +26,6 @@
     },
     "timestep_distribution": "LOGIT_NORMAL",
     "dynamic_timestep_shifting": true,
-    "dataloader_threads": 1,
     "optimizer": {
         "optimizer": "ADAFACTOR"
     },

--- a/training_presets/Flux 2/#flux2 LoRA 16GB.json
+++ b/training_presets/Flux 2/#flux2 LoRA 16GB.json
@@ -27,6 +27,5 @@
         "layer_filter_preset": "blocks"
     },
     "timestep_distribution": "LOGIT_NORMAL",
-    "dynamic_timestep_shifting": true,
-    "dataloader_threads": 1
+    "dynamic_timestep_shifting": true
 }

--- a/training_presets/Ideogram 4/#ideogram Finetune 16GB.json
+++ b/training_presets/Ideogram 4/#ideogram Finetune 16GB.json
@@ -6,7 +6,6 @@
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
     "compile": true,
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/Ideogram 4/#ideogram Finetune 24GB.json
+++ b/training_presets/Ideogram 4/#ideogram Finetune 24GB.json
@@ -6,7 +6,6 @@
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
     "compile": true,
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/Ideogram 4/#ideogram Finetune 24GB.json
+++ b/training_presets/Ideogram 4/#ideogram Finetune 24GB.json
@@ -1,0 +1,55 @@
+{
+    "base_model_name": "CalamitousFelicitousness/Ideogram-4-bf16-Diffusers",
+    "batch_size": 2,
+    "learning_rate": 1e-5,
+    "model_type": "IDEOGRAM_4",
+    "output_model_format": "ORIGINAL_TRANSFORMER",
+    "resolution": "512",
+    "compile": true,
+    "dataloader_threads": 1,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "BFLOAT_16",
+        "offload_fraction": 0.25
+    },
+    "unconditional_transformer": {
+        "weight_dtype": "NFLOAT_4",
+        "offload_fraction": 1.0
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "NFLOAT_4"
+    },
+    "training_method": "FINE_TUNE",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "layer_filter": "layers",
+    "layer_filter_preset": "blocks",
+    "quantization": {
+        "layer_filter": "layers",
+        "layer_filter_preset": "blocks"
+    },
+    "timestep_distribution": "LOGIT_NORMAL",
+    "optimizer": {
+        "optimizer": "ADAFACTOR"
+    },
+    "optimizer_defaults": {
+        "ADAFACTOR": {
+            "optimizer": "ADAFACTOR",
+            "fused_back_pass": true,
+            "beta1": null,
+            "clip_threshold": 1.0,
+            "decay_rate": -0.8,
+            "eps": 1e-30,
+            "eps2": 0.001,
+            "relative_step": false,
+            "scale_parameter": false,
+            "stochastic_rounding": true,
+            "warmup_init": false,
+            "weight_decay": 0.0
+        }
+    }
+}

--- a/training_presets/Ideogram 4/#ideogram LoRA 16GB.json
+++ b/training_presets/Ideogram 4/#ideogram LoRA 16GB.json
@@ -3,7 +3,7 @@
     "batch_size": 2,
     "learning_rate": 5e-5,
     "model_type": "IDEOGRAM_4",
-    "output_model_format": "DIFFUSERS_LORA",
+    "output_model_format": "COMFY_LORA",
     "resolution": "512",
     "compile": true,
     "transformer": {

--- a/training_presets/Ideogram 4/#ideogram LoRA 16GB.json
+++ b/training_presets/Ideogram 4/#ideogram LoRA 16GB.json
@@ -31,6 +31,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "timestep_distribution": "LOGIT_NORMAL",
-    "dataloader_threads": 1
+    "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
+++ b/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
@@ -3,7 +3,7 @@
     "batch_size": 2,
     "learning_rate": 5e-5,
     "model_type": "IDEOGRAM_4",
-    "output_model_format": "DIFFUSERS_LORA",
+    "output_model_format": "COMFY_LORA",
     "resolution": "512",
     "compile": true,
     "transformer": {

--- a/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
+++ b/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
@@ -1,0 +1,35 @@
+{
+    "base_model_name": "CalamitousFelicitousness/Ideogram-4-bf16-Diffusers",
+    "batch_size": 2,
+    "learning_rate": 5e-5,
+    "model_type": "IDEOGRAM_4",
+    "output_model_format": "DIFFUSERS_LORA",
+    "resolution": "512",
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "INT_W8A8"
+    },
+    "unconditional_transformer": {
+        "weight_dtype": "NFLOAT_4",
+        "offload_fraction": 1.0
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "NFLOAT_4"
+    },
+    "training_method": "LORA",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "layer_filter": "attention,feed_forward",
+    "layer_filter_preset": "attn-mlp",
+    "quantization": {
+        "layer_filter": "layers",
+        "layer_filter_preset": "blocks"
+    },
+    "timestep_distribution": "LOGIT_NORMAL",
+    "dataloader_threads": 1
+}

--- a/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
+++ b/training_presets/Ideogram 4/#ideogram LoRA 24GB.json
@@ -30,6 +30,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "timestep_distribution": "LOGIT_NORMAL",
-    "dataloader_threads": 1
+    "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Krea 2/#krea2 Finetune 16GB.json
+++ b/training_presets/Krea 2/#krea2 Finetune 16GB.json
@@ -1,0 +1,53 @@
+{
+    "base_model_name": "krea/Krea-2-Raw",
+    "batch_size": 2,
+    "learning_rate": 1e-5,
+    "model_type": "KREA_2",
+    "output_model_format": "ORIGINAL_TRANSFORMER",
+    "resolution": "512",
+    "attention_mechanism": "CUDNN",
+    "dataloader_threads": 1,
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "BFLOAT_16",
+        "offload_fraction": 0.8
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "FINE_TUNE",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "weight_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "timestep_distribution": "LOGIT_NORMAL",
+    "layer_filter": "transformer_blocks",
+    "layer_filter_preset": "blocks",
+    "quantization": {
+        "layer_filter": "transformer_blocks",
+        "layer_filter_preset": "blocks"
+    },
+    "optimizer": {
+        "optimizer": "ADAFACTOR"
+    },
+    "optimizer_defaults": {
+        "ADAFACTOR": {
+            "optimizer": "ADAFACTOR",
+            "fused_back_pass": true,
+            "beta1": null,
+            "clip_threshold": 1.0,
+            "decay_rate": -0.8,
+            "eps": 1e-30,
+            "eps2": 0.001,
+            "relative_step": false,
+            "scale_parameter": false,
+            "stochastic_rounding": true,
+            "warmup_init": false,
+            "weight_decay": 0.0
+        }
+    }
+}

--- a/training_presets/Krea 2/#krea2 Finetune 16GB.json
+++ b/training_presets/Krea 2/#krea2 Finetune 16GB.json
@@ -6,7 +6,6 @@
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
     "attention_mechanism": "CUDNN",
-    "dataloader_threads": 1,
     "compile": true,
     "transformer": {
         "train": true,

--- a/training_presets/Krea 2/#krea2 Finetune 24GB.json
+++ b/training_presets/Krea 2/#krea2 Finetune 24GB.json
@@ -6,7 +6,6 @@
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
     "attention_mechanism": "CUDNN",
-    "dataloader_threads": 1,
     "compile": true,
     "transformer": {
         "train": true,

--- a/training_presets/Krea 2/#krea2 Finetune 24GB.json
+++ b/training_presets/Krea 2/#krea2 Finetune 24GB.json
@@ -1,0 +1,53 @@
+{
+    "base_model_name": "krea/Krea-2-Raw",
+    "batch_size": 2,
+    "learning_rate": 1e-5,
+    "model_type": "KREA_2",
+    "output_model_format": "ORIGINAL_TRANSFORMER",
+    "resolution": "512",
+    "attention_mechanism": "CUDNN",
+    "dataloader_threads": 1,
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "BFLOAT_16",
+        "offload_fraction": 0.3
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "FINE_TUNE",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "weight_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "timestep_distribution": "LOGIT_NORMAL",
+    "layer_filter": "transformer_blocks",
+    "layer_filter_preset": "blocks",
+    "quantization": {
+        "layer_filter": "transformer_blocks",
+        "layer_filter_preset": "blocks"
+    },
+    "optimizer": {
+        "optimizer": "ADAFACTOR"
+    },
+    "optimizer_defaults": {
+        "ADAFACTOR": {
+            "optimizer": "ADAFACTOR",
+            "fused_back_pass": true,
+            "beta1": null,
+            "clip_threshold": 1.0,
+            "decay_rate": -0.8,
+            "eps": 1e-30,
+            "eps2": 0.001,
+            "relative_step": false,
+            "scale_parameter": false,
+            "stochastic_rounding": true,
+            "warmup_init": false,
+            "weight_decay": 0.0
+        }
+    }
+}

--- a/training_presets/Krea 2/#krea2 Finetune 24GB.json
+++ b/training_presets/Krea 2/#krea2 Finetune 24GB.json
@@ -10,7 +10,7 @@
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",
-        "offload_fraction": 0.3
+        "offload_fraction": 0.5
     },
     "text_encoder": {
         "train": false,

--- a/training_presets/Krea 2/#krea2 LoRA 16GB.json
+++ b/training_presets/Krea 2/#krea2 LoRA 16GB.json
@@ -6,7 +6,6 @@
     "output_model_format": "DIFFUSERS_LORA",
     "resolution": "512",
     "attention_mechanism": "CUDNN",
-    "dataloader_threads": 1,
     "compile": true,
     "transformer": {
         "train": true,

--- a/training_presets/Krea 2/#krea2 LoRA 24GB.json
+++ b/training_presets/Krea 2/#krea2 LoRA 24GB.json
@@ -1,0 +1,32 @@
+{
+    "base_model_name": "krea/Krea-2-Raw",
+    "batch_size": 2,
+    "learning_rate": 0.0003,
+    "model_type": "KREA_2",
+    "output_model_format": "DIFFUSERS_LORA",
+    "resolution": "512",
+    "attention_mechanism": "CUDNN",
+    "compile": true,
+    "transformer": {
+        "train": true,
+        "weight_dtype": "INT_W8A8"
+    },
+    "text_encoder": {
+        "train": false,
+        "weight_dtype": "FLOAT_8"
+    },
+    "training_method": "LORA",
+    "vae": {
+        "weight_dtype": "FLOAT_32"
+    },
+    "train_dtype": "BFLOAT_16",
+    "weight_dtype": "BFLOAT_16",
+    "output_dtype": "BFLOAT_16",
+    "timestep_distribution": "LOGIT_NORMAL",
+    "layer_filter": "attn,ff",
+    "layer_filter_preset": "attn-mlp",
+    "quantization": {
+        "layer_filter": "attn,ff",
+        "layer_filter_preset": "attn-mlp"
+    }
+}

--- a/training_presets/QwenImage/#qwen Finetune 16GB.json
+++ b/training_presets/QwenImage/#qwen Finetune 16GB.json
@@ -5,7 +5,6 @@
     "model_type": "QWEN",
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/QwenImage/#qwen Finetune 24GB.json
+++ b/training_presets/QwenImage/#qwen Finetune 24GB.json
@@ -5,7 +5,6 @@
     "model_type": "QWEN",
     "output_model_format": "ORIGINAL_TRANSFORMER",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "BFLOAT_16",

--- a/training_presets/QwenImage/#qwen LoRA 16GB.json
+++ b/training_presets/QwenImage/#qwen LoRA 16GB.json
@@ -5,7 +5,6 @@
     "model_type": "QWEN",
     "output_model_format": "DIFFUSERS_LORA",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8",

--- a/training_presets/QwenImage/#qwen LoRA 24GB.json
+++ b/training_presets/QwenImage/#qwen LoRA 24GB.json
@@ -5,7 +5,6 @@
     "model_type": "QWEN",
     "output_model_format": "DIFFUSERS_LORA",
     "resolution": "512",
-    "dataloader_threads": 1,
     "transformer": {
         "train": true,
         "weight_dtype": "FLOAT_8",

--- a/training_presets/Z-Image/#z-image DeTurbo LoRA 16GB.json
+++ b/training_presets/Z-Image/#z-image DeTurbo LoRA 16GB.json
@@ -29,6 +29,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Z-Image/#z-image DeTurbo LoRA 8GB.json
+++ b/training_presets/Z-Image/#z-image DeTurbo LoRA 8GB.json
@@ -30,6 +30,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Z-Image/#z-image Finetune 16GB.json
+++ b/training_presets/Z-Image/#z-image Finetune 16GB.json
@@ -21,7 +21,6 @@
     },
     "train_dtype": "BFLOAT_16",
     "output_dtype": "BFLOAT_16",
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL",
     "optimizer": {
         "optimizer": "ADAFACTOR"

--- a/training_presets/Z-Image/#z-image Finetune 24GB.json
+++ b/training_presets/Z-Image/#z-image Finetune 24GB.json
@@ -20,7 +20,6 @@
     },
     "train_dtype": "BFLOAT_16",
     "output_dtype": "BFLOAT_16",
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL",
     "optimizer": {
         "optimizer": "ADAFACTOR"

--- a/training_presets/Z-Image/#z-image LoRA 16GB.json
+++ b/training_presets/Z-Image/#z-image LoRA 16GB.json
@@ -28,6 +28,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL"
 }

--- a/training_presets/Z-Image/#z-image LoRA 8GB.json
+++ b/training_presets/Z-Image/#z-image LoRA 8GB.json
@@ -29,6 +29,5 @@
         "layer_filter": "layers",
         "layer_filter_preset": "blocks"
     },
-    "dataloader_threads": 1,
     "timestep_distribution": "LOGIT_NORMAL"
 }


### PR DESCRIPTION
## Summary

Rounds out the preset matrix so LoRA and full finetune presets exist for both 16GB and 24GB, for both Krea 2 and Ideogram 4:

- **Krea 2 LoRA 24GB**: same as 16GB, with GPU offloading and the reduced dataloader thread count both disabled (more VRAM/RAM headroom available).
- **Krea 2 Finetune 16GB/24GB**: new full finetune presets. Offload fractions are estimates based on the LoRA preset's requirements and other models' finetune presets of comparable size (Krea 2's transformer is ~12.8B params, vs. e.g. Ideogram 4's ~9.3B).
- **Ideogram 4 LoRA 24GB**: same as 16GB, with the (already small) transformer offload fraction dropped.
- **Ideogram 4 Finetune 24GB**: same as 16GB, with a lower but non-zero transformer offload fraction, since full finetuning is memory-heavy enough that some offloading is likely still needed at 24GB.
- Dropped the `dataloader_threads: 1` override from all presets (new and pre-existing) where no text encoder part has `offload_fraction > 0`. `create_data_loader()` only requires `dataloader_threads == 1` when a text encoder is offloaded (layer offloading uses a non-thread-safe conductor, and only text encoders run inside the caching dataloader's worker threads) — transformer offloading is irrelevant to this constraint, so the override was unnecessary on these presets.
- Switched the Ideogram 4 LoRA presets from `DIFFUSERS_LORA` to `COMFY_LORA`: Ideogram4's transformer uses a fused qkv projection, and ComfyUI has no per-arch fuse-on-load mapping for it, so the `DIFFUSERS_LORA` (split q/k/v) output fails to load there. `COMFY_LORA` matches Ideogram4's native fused layout and is also the only format diffusers itself can currently import for Ideogram4 LoRAs (diffusers has no Ideogram4 kohya converter — see huggingface/diffusers#14088).

Offload fractions for the new presets are estimates based on related presets and model sizes, not benchmarked on real 16GB/24GB hardware.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

All presets validated by loading through `TrainConfig` (matching the app's actual preset-loading path, `migrate=False`) and confirming none trigger the `dataloader_threads`/text-encoder-offload `RuntimeError`. Not tested end-to-end on real 16GB/24GB hardware.



---
Drafted by Claude