### PR TITLE
Fix Ideogram4 full-model save: apply diffusers-to-original qkv fusion

### DIFF
--- a/modules/modelSaver/ideogram/IdeogramModelSaver.py
+++ b/modules/modelSaver/ideogram/IdeogramModelSaver.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from modules.model.IdeogramModel import IdeogramModel
 from modules.modelSaver.mixin.DtypeModelSaverMixin import DtypeModelSaverMixin
+from modules.util.convert_util import convert
 from modules.util.enum.ModelFormat import ModelFormat
 
 import torch
@@ -38,7 +39,7 @@ class IdeogramModelSaver(
             destination: str,
             dtype: torch.dtype | None,
     ):
-        state_dict = model.transformer.state_dict()
+        state_dict = convert(model.transformer.state_dict(), model.checkpoint_diffusers_to_original())
 
         save_state_dict = self._convert_state_dict_dtype(state_dict, dtype)
         self._convert_state_dict_to_contiguous(save_state_dict)


### PR DESCRIPTION
## Summary
- `IdeogramModelSaver.__save_safetensors` saved the raw diffusers-split `model.transformer.state_dict()` directly, instead of routing it through `model.checkpoint_diffusers_to_original()` like every other fusing model's saver does (Flux, Flux2, Chroma, HunyuanVideo, PixArt-Alpha, SD3, Krea2, Anima).
- Ideogram4's native/ComfyUI checkpoint format uses a fused `qkv` `nn.Linear` per block — this isn't a Comfy-only quirk (unlike Z-Image, where fused qkv really is Comfy-side convenience); the real upstream `ideogram-oss/ideogram4` architecture has a genuine fused `self.qkv`, and diffusers is the one that re-expresses it as split `to_q/to_k/to_v` for its own API. `IdeogramModel` already declares `fusion_groups()` and `diffusers_to_original()` correctly — the saver just never applied them.
- Symptom: a saved `ORIGINAL_TRANSFORMER` full-finetune checkpoint failed to load in ComfyUI:
  ```
  unet missing: ['layers.0.attention.qkv.weight', 'layers.0.attention.o.weight', ...]
  unet unexpected: ['layers.0.attention.to_q.weight', 'layers.0.attention.to_out.0.weight', ...]
  ```

## Test plan
- Loaded the previously-saved (broken) full-finetune checkpoint and ran it through `model.checkpoint_diffusers_to_original()` + `convert()`: confirmed the output has fused `attention.qkv`/`attention.o` keys for all 34 blocks and zero remaining split `to_q/to_k/to_v/to_out` keys.

Drafted by Claude