### PR TITLE
Restore scripts/train_ui.py as a compat shim for external launchers

### DIFF
--- a/scripts/train_ui.py
+++ b/scripts/train_ui.py
@@ -1,0 +1,6 @@
+# Kept for backwards compatibility with external launchers (e.g. Stability
+# Matrix) that invoke this file directly instead of start-ui.bat/.sh.
+from train_ui_qt import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- #1446 split `scripts/train_ui.py` into `train_ui_qt.py`/`train_ui_ctk.py`, but some third-party launchers (e.g. Stability Matrix) invoke `scripts/train_ui.py` directly instead of `start-ui.bat`/`.sh`, which now fails with a missing-file error.
- Adds back `scripts/train_ui.py` as a thin shim that forwards to `train_ui_qt.main()`, so those launchers keep working while `start-ui.bat`/`.sh` remain the recommended entry point.

Drafted by Claude