### PR TITLE
Fix Qt combo boxes scrolling while closed and merely hovered

### DIFF
--- a/modules/ui/PySide6ConceptTabView.py
+++ b/modules/ui/PySide6ConceptTabView.py
@@ -8,7 +8,7 @@ from modules.util.ui.QtVar import QtVar
 
 from PIL.ImageQt import ImageQt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QLineEdit, QPushButton, QWidget
+from PySide6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QLineEdit, QPushButton, QWidget
 
 
 class PySide6ConceptTabView(PySide6ConfigListView, BaseConceptTabView):
@@ -59,7 +59,7 @@ class PySide6ConceptTabView(PySide6ConfigListView, BaseConceptTabView):
         self.search_var._bind_widget(lambda v: search_entry.setText(v))
 
         self.filter_var = QtVar("ALL")
-        filter_combo = QComboBox(toolbar)
+        filter_combo = pyside6_components.NoScrollComboBox(toolbar)
         filter_combo.addItems(self._FILTER_TYPES)
         filter_combo.setFixedWidth(150)
         row_lo.addWidget(QLabel("Type:", toolbar))

--- a/modules/util/ui/pyside6_components.py
+++ b/modules/util/ui/pyside6_components.py
@@ -11,7 +11,7 @@ from modules.util.ui.pyside6_validation import PySide6FieldValidator, PySide6Pat
 from modules.util.ui.UIState import BaseUIState
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QPixmap, QWheelEvent
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -524,6 +524,16 @@ def preset_menu_button(
 # Bound widgets
 # ---------------------------------------------------------------------------
 
+class NoScrollComboBox(QComboBox):
+    # scrolling over a closed combo box is an easy way to accidentally change
+    # its value while just scrolling the surrounding page; only scroll while open
+    def wheelEvent(self, event: QWheelEvent):
+        if self.view().isVisible():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
+
+
 def options(
         master: QWidget,
         row: int,
@@ -534,7 +544,7 @@ def options(
         command: Callable[[str], None] | None = None,
 ) -> QComboBox:
     var = ui_state.get_var(var_name)
-    combo = QComboBox(master)
+    combo = NoScrollComboBox(master)
     combo.addItems(values)
     combo.setCurrentText(str(var.get()))
 
@@ -641,7 +651,7 @@ def options_kv(
                 break
         _updating = False
 
-    combo = QComboBox(master)
+    combo = NoScrollComboBox(master)
     combo.addItems(keys)
     # set initial display from current var value
     for k, v in values:


### PR DESCRIPTION
## Summary
- `QComboBox` forwards mouse wheel events even while closed, so scrolling past a combo box while reading the page can silently change its value.
- Added `NoScrollComboBox`, used by both `options()` and `options_kv()` in `modules/util/ui/pyside6_components.py`, which only forwards wheel events while the dropdown popup is open.

Fixes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)