### PR TITLE
Make expected outcome field optional in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you saw!
     validations:
-      required: true
+      required: false
   - type: textarea
     id: logs
     attributes:


### PR DESCRIPTION
It's often redundant. When you describe a bug, the expected behaviour is that the bug doesn't happen
