### PR TITLE
Add console visibility for torch.compile compiles and recompiles

### DIFF
--- a/modules/util/compile_util.py
+++ b/modules/util/compile_util.py
@@ -75,10 +75,7 @@ def init_compile():
 def _on_compile_start(args: "torch._dynamo.callback.CallbackArgs") -> None:
     frame_id, _, frame_compile_id = args.compile_id.partition("/")
     direction = "backward" if args.callback_trigger == torch._dynamo.callback.CallbackTrigger.LAZY_BACKWARD else "forward"
-    if frame_compile_id in ("", "0"):
-        tqdm.write(f"[torch.compile] compiling kernel {frame_id} ({direction})...")
-    else:
-        tqdm.write(f"[torch.compile] recompiling kernel {frame_id} (compile #{int(frame_compile_id) + 1} {direction})...")
+    tqdm.write(f"[torch.compile] compiling kernel {frame_id} {direction} (variant #{frame_compile_id or 0})...")
 
 
 torch._dynamo.callback.on_compile_start(_on_compile_start)

--- a/modules/util/compile_util.py
+++ b/modules/util/compile_util.py
@@ -1,7 +1,9 @@
 import torch
+import torch._dynamo.callback
 import torch.utils._sympy.functions
 
 from sympy import S
+from tqdm import tqdm
 
 
 #code from https://github.com/pytorch/pytorch/blob/ed82d5fcfd80110565f69130f286c7bfec6db2dc/torch/utils/_sympy/functions.py#L481
@@ -69,5 +71,16 @@ def init_compile():
     # modules during the backward pass.
     torch._dynamo.config.cache_size_limit = 8192
 
+
+def _on_compile_start(args: "torch._dynamo.callback.CallbackArgs") -> None:
+    frame_id, _, frame_compile_id = args.compile_id.partition("/")
+    direction = "backward" if args.callback_trigger == torch._dynamo.callback.CallbackTrigger.LAZY_BACKWARD else "forward"
+    if frame_compile_id in ("", "0"):
+        tqdm.write(f"[torch.compile] compiling kernel {frame_id} ({direction})...")
+    else:
+        tqdm.write(f"[torch.compile] recompiling kernel {frame_id} (compile #{int(frame_compile_id) + 1} {direction})...")
+
+
+torch._dynamo.callback.on_compile_start(_on_compile_start)
 
 torch.utils._sympy.functions.Mod.eval = Mod_patched_eval


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

torch.compile can silently block training for a long time on the first compile and on recompiles, with no console indication. Hook torch._dynamo's private compile-start callback to print which kernel (frame) is compiling or recompiling and whether it's the forward or backward graph.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
