### PR TITLE
Optimize W8A8 Triton backward matmul

### DIFF
--- a/modules/module/quantized/LinearW8A8.py
+++ b/modules/module/quantized/LinearW8A8.py
@@ -1,7 +1,7 @@
 
 from modules.module.quantized.mixin.QuantizedLinearMixin import QuantizedLinearMixin
 from modules.module.quantized.mixin.QuantizedModuleMixin import QuantizedModuleMixin
-from modules.util.mm_8bit import mm_8bit as mm_8bit
+from modules.util.mm_8bit import mm_8bit, mm_8bit_scaled
 from modules.util.quantization_util import (
     dequantize,
     quantize_fp8_axiswise,
@@ -37,14 +37,13 @@ def fp8_forward_tokenwise(x: Tensor, weight: Tensor, weight_scale: Tensor, bias:
 def int8_backward_axiswise(output: Tensor, weight: Tensor, weight_scale: Tensor) -> Tensor:
     output_8, output_scale = quantize_int8_axiswise(output, dim=-1)
     #almost always, grad outputs are already contiguous and this is a no-op. But there are some grad outputs from SDXL that are non-contiguous:
-    mm_res = mm_8bit(output_8.contiguous(), weight)
-    return mm_res.float().mul_(weight_scale * output_scale).to(output.dtype)
+    #the dequantization scales are fused into the matmul epilogue:
+    return mm_8bit_scaled(output_8.contiguous(), weight, output_scale, weight_scale, output.dtype)
 
 @torch.no_grad()
 def fp8_backward_axiswise(output: Tensor, weight: Tensor, weight_scale: Tensor) -> Tensor:
     output_8, output_scale = quantize_fp8_axiswise(output, dim=-1)
-    mm_res = mm_8bit(output_8.contiguous(), weight)
-    return mm_res.float().mul_(weight_scale * output_scale).to(output.dtype)
+    return mm_8bit_scaled(output_8.contiguous(), weight, output_scale, weight_scale, output.dtype)
 
 
 class LinearInt8Function(torch.autograd.Function):

--- a/modules/util/mm_8bit.py
+++ b/modules/util/mm_8bit.py
@@ -1,5 +1,5 @@
 try:
-    from modules.util.triton_mm_8bit import mm_8bit
+    from modules.util.triton_mm_8bit import mm_8bit, mm_8bit_scaled
 except ImportError as e:
     print(str(e) + ", continuing without triton")
     import torch
@@ -13,3 +13,10 @@ except ImportError as e:
         else:
             one = torch.ones(1, device=a.device)
             return torch._scaled_mm(a, b.T.contiguous().T, scale_a=one, scale_b=one)
+
+    def mm_8bit_scaled(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor,
+                       out_dtype: torch.dtype) -> torch.Tensor:
+        assert scale_a.numel() == a.shape[0], "scale_a must be one scale per row of A"
+        assert scale_b.numel() == 1, "scale_b must be a single-element tensor"
+        res = mm_8bit(a, b)
+        return res.float().mul_(scale_b.float() * scale_a.view(-1, 1)).to(out_dtype)

--- a/modules/util/triton_mm_8bit.py
+++ b/modules/util/triton_mm_8bit.py
@@ -31,6 +31,7 @@ import triton.language as tl
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N':  64, 'BLOCK_SIZE_K': 128}, num_stages=4,num_warps=4),
         triton.Config({'BLOCK_SIZE_M':  32, 'BLOCK_SIZE_N':  64, 'BLOCK_SIZE_K':  32}, num_stages=5,num_warps=2),
         triton.Config({'BLOCK_SIZE_M':  64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K':  32}, num_stages=4,num_warps=4),
+        triton.Config({'BLOCK_SIZE_M':  64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K':  64}, num_stages=3,num_warps=4),
         triton.Config({'BLOCK_SIZE_M':  64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K':  64}, num_stages=4,num_warps=4),
         triton.Config({'BLOCK_SIZE_M':  64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 128}, num_stages=4,num_warps=4),
         triton.Config({'BLOCK_SIZE_M':  64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K':  32}, num_stages=4,num_warps=4),
@@ -49,6 +50,7 @@ import triton.language as tl
 @triton.jit
 def _mm_kernel(
         a_ptr, b_ptr, c_ptr,
+        scale_a_ptr, scale_b_ptr,
         M, N, K,
         stride_am, stride_ak,
         stride_bk, stride_bn,
@@ -79,10 +81,12 @@ def _mm_kernel(
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32 if FLOAT else tl.int32)
 
     for k in range(tl.cdiv(K, BLOCK_SIZE_K)):
-        a_mask = (offs_am[:, None] < M) & (offs_k[None, :] < K - k*BLOCK_SIZE_K)
-        b_mask = (offs_bn[None, :] < N) & (offs_k[:, None] < K - k*BLOCK_SIZE_K)
-        a = tl.load(a_ptrs, mask=a_mask, other=0.0)
-        b = tl.load(b_ptrs, mask=b_mask, other=0.0)
+        # offs_am/offs_bn are taken mod M/N, so they are always in range; only the
+        # K dimension needs masking here. Out-of-range rows/cols (from the wrap) are
+        # discarded by c_mask at the store.
+        k_mask = offs_k < K - k*BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=k_mask[None, :], other=0.0)
+        b = tl.load(b_ptrs, mask=k_mask[:, None], other=0.0)
 
         accumulator = tl.dot(a, b, accumulator, out_dtype=tl.float32 if FLOAT else tl.int32)
 
@@ -93,29 +97,55 @@ def _mm_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    tl.store(c_ptrs, accumulator, mask=c_mask)
+    if scale_a_ptr is not None:
+        # fused dequant epilogue: scale each row by scale_a[row] * scale_b and store
+        # directly in c's dtype, avoiding a full-size int32/fp32 intermediate that
+        # would otherwise be written, re-read, scaled and converted by a second kernel
+        scale = tl.load(scale_a_ptr + offs_cm, mask=offs_cm < M, other=0.0).to(tl.float32) \
+              * tl.load(scale_b_ptr).to(tl.float32)
+        result = accumulator.to(tl.float32) * scale[:, None]
+        tl.store(c_ptrs, result.to(c_ptr.dtype.element_ty), mask=c_mask)
+    else:
+        tl.store(c_ptrs, accumulator, mask=c_mask)
 
-def mm_8bit(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+def _mm_8bit_launch(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor,
+                    scale_a: torch.Tensor | None, scale_b: torch.Tensor | None):
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.is_contiguous(), "Matrix A must be contiguous"
     assert a.dtype == b.dtype, "Incompatible dtypes"
     assert a.dtype in [torch.int8, torch.float8_e4m3fn]
 
-    FLOAT = (a.dtype == torch.float8_e4m3fn)
-
     M, K = a.shape
     K, N = b.shape
-    c = torch.empty((M, N), device=a.device, dtype=torch.float32 if FLOAT else torch.int32)
 
     def grid(META):
         return (triton.cdiv(N, META['BLOCK_SIZE_N']) , triton.cdiv(M, META['BLOCK_SIZE_M']), )
     _mm_kernel[grid](
         a, b, c,
+        scale_a, scale_b,
         M, N, K,
         a.stride(0), a.stride(1),
         b.stride(0), b.stride(1),
         c.stride(0), c.stride(1),
         QUANTIZED_M = M // 64,
-        FLOAT = FLOAT
+        FLOAT = (a.dtype == torch.float8_e4m3fn),
     )
     return c
+
+def mm_8bit(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    FLOAT = (a.dtype == torch.float8_e4m3fn)
+    c = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float32 if FLOAT else torch.int32)
+    return _mm_8bit_launch(a, b, c, None, None)
+
+def mm_8bit_scaled(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor,
+                   out_dtype: torch.dtype) -> torch.Tensor:
+    """(a @ b) * scale_a[:, None] * scale_b, stored directly as out_dtype.
+
+    Fuses the row-wise dequantization into the matmul epilogue, avoiding a
+    full-size int32/fp32 intermediate plus a separate scaling kernel.
+    scale_a: per-row scales with a.shape[0] elements, scale_b: a single-element scale.
+    """
+    assert scale_a.numel() == a.shape[0] and scale_a.is_contiguous(), "scale_a must be one contiguous scale per row of A"
+    assert scale_b.numel() == 1, "scale_b must be a single-element tensor"
+    c = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=out_dtype)
+    return _mm_8bit_launch(a, b, c, scale_a, scale_b)


### PR DESCRIPTION
## Summary

- fuse row-wise activation and weight dequantization scales into the W8A8 Triton matmul epilogue
- store directly in the requested output dtype, avoiding the full INT32/FP32 intermediate and a second pointwise CUDA kernel
- add a faster 3-stage autotune candidate for the row-major backward layout
- retain a functionally equivalent non-Triton fallback

## Performance

Measured on an NVIDIA RTX PRO 6000 Blackwell with the repository-root venv (`torch 2.12.0+cu130`, Triton 3.7.0), using the benchmark shape `M=2098, K=3072, N=3088`.

Baseline and final implementations ran in the same process against identical resident tensors. Both were precompiled/autotuned, measurement order alternated over 7 rounds, and each sample contained 1,000 launches timed with CUDA events. Values below are medians.

| Path | Baseline | Final | Improvement |
|---|---:|---:|---:|
| INT8 raw forward | 82.474 us | 82.419 us | +0.07% |
| INT8 raw backward | 106.072 us | 99.274 us | +6.85% |
| INT8 complete backward | 121.638 us | 108.499 us | +12.11% |
| FP8 raw forward | 81.987 us | 82.285 us | -0.36% |
| FP8 raw backward | 107.642 us | 100.085 us | +7.55% |
| FP8 complete backward | 123.958 us | 114.634 us | +8.13% |

`complete backward` includes activation quantization, matmul, scale/dequantization, and output conversion under `torch.compile(fullgraph=True)`.

A CUDA profiler check confirmed that the previous compiled path launches `_mm_kernel` followed by an Inductor pointwise scale/cast kernel. The fused path launches only `_mm_kernel`.

## Validation

- `ruff check` on all three changed Python files
- in-memory syntax compilation
- INT8 exact-reference checks
- FP8 reference checks within expected tolerance
- irregular matrix shape (`73 x 96 @ 96 x 80`) covering masked edge tiles

## Disclaimer
AI assistance was used to author the code (both Claude Code and Codex).