### PR TITLE
Fix Ideogram VAE Override being silently ignored

### DIFF
--- a/modules/modelLoader/IdeogramModelLoader.py
+++ b/modules/modelLoader/IdeogramModelLoader.py
@@ -31,11 +31,12 @@ class IdeogramModelLoader(
             model_type: ModelType,
             weight_dtypes: ModelWeightDtypes,
             base_model_name: str,
+            vae_model_name: str,
             include_unconditional_transformer: bool,
             quantization: QuantizationConfig,
     ):
         if os.path.isfile(os.path.join(base_model_name, "meta.json")):
-            self.__load_diffusers(model, model_type, weight_dtypes, base_model_name, include_unconditional_transformer, quantization)
+            self.__load_diffusers(model, model_type, weight_dtypes, base_model_name, vae_model_name, include_unconditional_transformer, quantization)
         else:
             raise Exception("not an internal model")
 
@@ -45,6 +46,7 @@ class IdeogramModelLoader(
             model_type: ModelType,
             weight_dtypes: ModelWeightDtypes,
             base_model_name: str,
+            vae_model_name: str,
             include_unconditional_transformer: bool,
             quantization: QuantizationConfig,
     ):
@@ -89,13 +91,21 @@ class IdeogramModelLoader(
             subfolder="scheduler",
         )
 
-        vae = self._load_diffusers_sub_module(
-            AutoencoderKLFlux2,
-            weight_dtypes.vae,
-            weight_dtypes.train_dtype,
-            base_model_name,
-            "vae",
-        )
+        if vae_model_name:
+            vae = self._load_diffusers_sub_module(
+                AutoencoderKLFlux2,
+                weight_dtypes.vae,
+                weight_dtypes.train_dtype,
+                vae_model_name,
+            )
+        else:
+            vae = self._load_diffusers_sub_module(
+                AutoencoderKLFlux2,
+                weight_dtypes.vae,
+                weight_dtypes.train_dtype,
+                base_model_name,
+                "vae",
+            )
 
         model.model_type = model_type
         model.tokenizer = tokenizer
@@ -129,7 +139,7 @@ class IdeogramModelLoader(
 
         try:
             self.__load_internal(
-                model, model_type, weight_dtypes, model_names.base_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model,
                 model_names.include_unconditional_transformer, quantization,
             )
             return
@@ -138,7 +148,7 @@ class IdeogramModelLoader(
 
         try:
             self.__load_diffusers(
-                model, model_type, weight_dtypes, model_names.base_model,
+                model, model_type, weight_dtypes, model_names.base_model, model_names.vae_model,
                 model_names.include_unconditional_transformer, quantization,
             )
             return


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->
IDEOGRAM_4's model_parts() includes "vae", so the model tab renders the "VAE Override" field and stores the value in model_names.vae_model. But the Ideogram loader never read it: __load_diffusers hardcoded the base model's "vae" subfolder, so any override was silently dropped.

Thread model_names.vae_model through load() -> __load_internal/__load_diffusers and honor it, matching Flux2 (same model_parts, same AutoencoderKLFlux2).
## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes

won't test, consistency fix


## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
