### PR TITLE
Fix SD1.5 fine-tune model spec pointing at SD3 spec files

### DIFF
--- a/modules/modelLoader/StableDiffusionFineTuneModelLoader.py
+++ b/modules/modelLoader/StableDiffusionFineTuneModelLoader.py
@@ -7,8 +7,8 @@ from modules.util.enum.TrainingMethod import TrainingMethod
 
 StableDiffusionFineTuneModelLoader = make_fine_tune_model_loader(
     model_spec_map={
-        ModelType.STABLE_DIFFUSION_15: "resources/sd_model_spec/sd_3_2b_1.0.json",
-        ModelType.STABLE_DIFFUSION_15_INPAINTING: "resources/sd_model_spec/sd_3.5_1.0.json",
+        ModelType.STABLE_DIFFUSION_15: "resources/sd_model_spec/sd_1.5.json",
+        ModelType.STABLE_DIFFUSION_15_INPAINTING: "resources/sd_model_spec/sd_1.5_inpainting.json",
         ModelType.STABLE_DIFFUSION_20: "resources/sd_model_spec/sd_2.0.json",
         ModelType.STABLE_DIFFUSION_20_BASE: "resources/sd_model_spec/sd_2.0.json",
         ModelType.STABLE_DIFFUSION_20_INPAINTING: "resources/sd_model_spec/sd_2.0_inpainting.json",


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->
STABLE_DIFFUSION_15 and STABLE_DIFFUSION_15_INPAINTING in StableDiffusionFineTuneModelLoader's model_spec_map pointed at the SD3 spec JSONs instead of the SD1.5 ones, mislabeling fine-tuned SD1.5/SD1.5-inpainting checkpoints as SD3 in their modelspec.json.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
won't test - consistency fix

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
