### PR TITLE
Fix circular imports

### DIFF
--- a/modules/util/optimizer_util.py
+++ b/modules/util/optimizer_util.py
@@ -1,6 +1,5 @@
 import modules.util.multi_gpu_util as multi
 from modules.model.BaseModel import BaseModel
-from modules.util import create
 from modules.util.config.TrainConfig import TrainConfig, TrainOptimizerConfig
 from modules.util.enum.Optimizer import Optimizer
 from modules.util.NamedParameterGroup import NamedParameterGroupCollection
@@ -63,6 +62,8 @@ def init_model_parameters(
     if model.train_config.optimizer.MuonWithAuxAdam:
         print("INFO: Creating layer keys for MuonWithAuxAdam.")
         layer_key_fn = build_muon_adam_key_fn(model, model.train_config)
+
+    from modules.util import create
 
     model.optimizer = create.create_optimizer(
         parameters, model.optimizer_state_dict, model.train_config, layer_key_fn

--- a/modules/util/quantization_util.py
+++ b/modules/util/quantization_util.py
@@ -76,12 +76,6 @@ def dequantize(q: Tensor, scale: float | Tensor) -> Tensor:
     return q.float() * scale
 
 
-from modules.module.quantized.LinearFp8 import LinearFp8
-from modules.module.quantized.LinearGGUFA8 import LinearGGUFA8
-from modules.module.quantized.LinearSVD import BaseLinearSVD, make_svd_linear
-from modules.module.quantized.LinearW8A8 import LinearW8A8
-
-
 def __create_linear_layer(construct_fn, module: nn.Linear, copy_parameters: bool) -> nn.Module:
     bias = module.bias is not None
 
@@ -173,6 +167,11 @@ def replace_linear_with_quantized_layers(
         quantization: QuantizationConfig | None = None,
         copy_parameters: bool = False,
 ):
+    from modules.module.quantized.LinearFp8 import LinearFp8
+    from modules.module.quantized.LinearGGUFA8 import LinearGGUFA8
+    from modules.module.quantized.LinearSVD import make_svd_linear
+    from modules.module.quantized.LinearW8A8 import LinearW8A8
+
     kwargs = {}
     if dtype.quantize_nf4():
         linear_class = LinearNf4
@@ -235,6 +234,10 @@ def is_quantized_parameter(
         module: nn.Module,
         parameter_name: str,
 ) -> bool:
+    from modules.module.quantized.LinearFp8 import LinearFp8
+    from modules.module.quantized.LinearSVD import BaseLinearSVD
+    from modules.module.quantized.LinearW8A8 import LinearW8A8
+
     if isinstance(module, BaseLinearSVD):
         if parameter_name in ["svd_up", "svd_down"]:
             return True
@@ -283,6 +286,8 @@ def get_weight_shape(module: nn.Linear) -> torch.Size:
     return torch.Size((module.out_features, module.in_features))
 
 def get_offload_tensors(module: nn.Module) -> list[torch.Tensor]:
+    from modules.module.quantized.LinearSVD import BaseLinearSVD
+
     tensors = []
 
     if bnb is not None:


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

This PR avoids circular imports that Claude routinely stumbles over, because it tries to unit-test imports. In the regular OneTrainer startup this doesn't happen, but it's still good to fix so Claude throws less false alarms.

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
