### PR TITLE
Timestamp step memory/profiler dump filenames (dev tooling)

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -727,8 +727,8 @@ class GenericTrainer(BaseTrainer):
                 self.callbacks.on_update_status("Training ...")
 
                 with (
-                    TorchMemoryRecorder(enabled=False, filename=f"memory-step{train_progress.global_step}.pickle"),
-                    TorchProfiler      (enabled=False, filename=f"profile-step{train_progress.global_step}.json"),
+                    TorchMemoryRecorder(enabled=False, filename=f"memory-step{train_progress.global_step}-{get_string_timestamp()}.pickle"),
+                    TorchProfiler      (enabled=False, filename=f"profile-step{train_progress.global_step}-{get_string_timestamp()}.json"),
                 ):
                     step_seed = train_progress.global_step
                     bf16_stochastic_rounding_set_seed(step_seed, train_device)

--- a/modules/util/profiling_util.py
+++ b/modules/util/profiling_util.py
@@ -10,7 +10,11 @@ class TorchMemoryRecorder:
 
     def __enter__(self):
         if self.enabled:
-            torch.cuda.memory._record_memory_history()
+            # stacks="python" attributes each allocation to the python call site and is far cheaper than the
+            # default C++ unwinding, which stalls badly under torch.compile. max_entries is a ring buffer: once
+            # full, new alloc/free events overwrite the oldest ones rather than stopping collection, so this
+            # keeps the most recent 100k events, bounding host RAM use on a long/heavy step.
+            torch.cuda.memory._record_memory_history(context="all", stacks="python", max_entries=100_000)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.enabled:


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Add get_string_timestamp() to the TorchMemoryRecorder / TorchProfiler dump filenames so re-running training no longer overwrites a previous run's same-step snapshots.

Tune TorchMemoryRecorder to use stacks="python", which attributes each allocation to its call site and avoids the default C++ unwinding's stall under torch.compile, and to bound history via max_entries so a long/heavy run can't blow up host RAM.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
