### PR TITLE
materialize() / evict() API

### DIFF
--- a/modules/dataLoader/AnimaBaseDataLoader.py
+++ b/modules/dataLoader/AnimaBaseDataLoader.py
@@ -109,7 +109,7 @@ class AnimaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/AnimaBaseDataLoader.py
+++ b/modules/dataLoader/AnimaBaseDataLoader.py
@@ -109,7 +109,7 @@ class AnimaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ChromaBaseDataLoader.py
+++ b/modules/dataLoader/ChromaBaseDataLoader.py
@@ -120,7 +120,7 @@ class ChromaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ChromaBaseDataLoader.py
+++ b/modules/dataLoader/ChromaBaseDataLoader.py
@@ -120,7 +120,7 @@ class ChromaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ChromaBaseDataLoader.py
+++ b/modules/dataLoader/ChromaBaseDataLoader.py
@@ -120,7 +120,7 @@ class ChromaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ErnieBaseDataLoader.py
+++ b/modules/dataLoader/ErnieBaseDataLoader.py
@@ -110,7 +110,7 @@ class ErnieBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ErnieBaseDataLoader.py
+++ b/modules/dataLoader/ErnieBaseDataLoader.py
@@ -110,7 +110,7 @@ class ErnieBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ErnieBaseDataLoader.py
+++ b/modules/dataLoader/ErnieBaseDataLoader.py
@@ -110,7 +110,7 @@ class ErnieBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Flux2BaseDataLoader.py
+++ b/modules/dataLoader/Flux2BaseDataLoader.py
@@ -117,7 +117,7 @@ class Flux2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Flux2BaseDataLoader.py
+++ b/modules/dataLoader/Flux2BaseDataLoader.py
@@ -117,7 +117,7 @@ class Flux2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Flux2BaseDataLoader.py
+++ b/modules/dataLoader/Flux2BaseDataLoader.py
@@ -117,7 +117,7 @@ class Flux2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/FluxBaseDataLoader.py
+++ b/modules/dataLoader/FluxBaseDataLoader.py
@@ -143,7 +143,7 @@ class FluxBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/FluxBaseDataLoader.py
+++ b/modules/dataLoader/FluxBaseDataLoader.py
@@ -143,7 +143,7 @@ class FluxBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/FluxBaseDataLoader.py
+++ b/modules/dataLoader/FluxBaseDataLoader.py
@@ -143,7 +143,7 @@ class FluxBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/HiDreamBaseDataLoader.py
+++ b/modules/dataLoader/HiDreamBaseDataLoader.py
@@ -180,7 +180,7 @@ class HiDreamBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/HiDreamBaseDataLoader.py
+++ b/modules/dataLoader/HiDreamBaseDataLoader.py
@@ -180,7 +180,7 @@ class HiDreamBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/HiDreamBaseDataLoader.py
+++ b/modules/dataLoader/HiDreamBaseDataLoader.py
@@ -180,7 +180,7 @@ class HiDreamBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/HunyuanVideoBaseDataLoader.py
+++ b/modules/dataLoader/HunyuanVideoBaseDataLoader.py
@@ -136,7 +136,7 @@ class HunyuanVideoBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/HunyuanVideoBaseDataLoader.py
+++ b/modules/dataLoader/HunyuanVideoBaseDataLoader.py
@@ -136,7 +136,7 @@ class HunyuanVideoBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/HunyuanVideoBaseDataLoader.py
+++ b/modules/dataLoader/HunyuanVideoBaseDataLoader.py
@@ -136,7 +136,7 @@ class HunyuanVideoBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/IdeogramBaseDataLoader.py
+++ b/modules/dataLoader/IdeogramBaseDataLoader.py
@@ -122,7 +122,7 @@ class IdeogramBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/IdeogramBaseDataLoader.py
+++ b/modules/dataLoader/IdeogramBaseDataLoader.py
@@ -122,7 +122,7 @@ class IdeogramBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/IdeogramBaseDataLoader.py
+++ b/modules/dataLoader/IdeogramBaseDataLoader.py
@@ -122,7 +122,7 @@ class IdeogramBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Krea2BaseDataLoader.py
+++ b/modules/dataLoader/Krea2BaseDataLoader.py
@@ -131,7 +131,7 @@ class Krea2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Krea2BaseDataLoader.py
+++ b/modules/dataLoader/Krea2BaseDataLoader.py
@@ -131,7 +131,7 @@ class Krea2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/Krea2BaseDataLoader.py
+++ b/modules/dataLoader/Krea2BaseDataLoader.py
@@ -131,7 +131,7 @@ class Krea2BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/PixArtAlphaBaseDataLoader.py
+++ b/modules/dataLoader/PixArtAlphaBaseDataLoader.py
@@ -121,7 +121,7 @@ class PixArtAlphaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/PixArtAlphaBaseDataLoader.py
+++ b/modules/dataLoader/PixArtAlphaBaseDataLoader.py
@@ -121,7 +121,7 @@ class PixArtAlphaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/PixArtAlphaBaseDataLoader.py
+++ b/modules/dataLoader/PixArtAlphaBaseDataLoader.py
@@ -121,7 +121,7 @@ class PixArtAlphaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/QwenBaseDataLoader.py
+++ b/modules/dataLoader/QwenBaseDataLoader.py
@@ -124,7 +124,7 @@ class QwenBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/QwenBaseDataLoader.py
+++ b/modules/dataLoader/QwenBaseDataLoader.py
@@ -124,7 +124,7 @@ class QwenBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/QwenBaseDataLoader.py
+++ b/modules/dataLoader/QwenBaseDataLoader.py
@@ -124,7 +124,7 @@ class QwenBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/SanaBaseDataLoader.py
+++ b/modules/dataLoader/SanaBaseDataLoader.py
@@ -113,7 +113,7 @@ class SanaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/SanaBaseDataLoader.py
+++ b/modules/dataLoader/SanaBaseDataLoader.py
@@ -113,7 +113,7 @@ class SanaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/SanaBaseDataLoader.py
+++ b/modules/dataLoader/SanaBaseDataLoader.py
@@ -113,7 +113,7 @@ class SanaBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusion3BaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusion3BaseDataLoader.py
@@ -160,7 +160,7 @@ class StableDiffusion3BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusion3BaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusion3BaseDataLoader.py
@@ -160,7 +160,7 @@ class StableDiffusion3BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusion3BaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusion3BaseDataLoader.py
@@ -160,7 +160,7 @@ class StableDiffusion3BaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionBaseDataLoader.py
@@ -130,7 +130,7 @@ class StableDiffusionBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionBaseDataLoader.py
@@ -130,7 +130,7 @@ class StableDiffusionBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionBaseDataLoader.py
@@ -130,7 +130,7 @@ class StableDiffusionBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -8,7 +8,6 @@ from modules.util import factory, path_util
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.TrainingMethod import TrainingMethod
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.OutputPipelineModule import OutputPipelineModule
@@ -55,12 +54,9 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
             temp_device: torch.device,
             config: TrainConfig,
     ):
-        model.to(self.temp_device)
-
-        model.vae_to(train_device)
+        model.materialize_only("vae")
 
         model.eval()
-        torch_gc()
 
     def __enumerate_input_modules(self, config: TrainConfig) -> list:
         supported_extensions = path_util.supported_image_extensions()
@@ -248,7 +244,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae)
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -244,7 +244,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae)
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
+++ b/modules/dataLoader/StableDiffusionFineTuneVaeDataLoader.py
@@ -244,7 +244,7 @@ class StableDiffusionFineTuneVaeDataLoader(BaseDataLoader):
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae)
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
@@ -138,7 +138,7 @@ class StableDiffusionXLBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
@@ -138,7 +138,7 @@ class StableDiffusionXLBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())

--- a/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
+++ b/modules/dataLoader/StableDiffusionXLBaseDataLoader.py
@@ -138,7 +138,7 @@ class StableDiffusionXLBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())
         decode_conditioning_image = DecodeVAE(in_name='latent_conditioning_image', out_name='decoded_conditioning_image', vae=model.vae, autocast_contexts=[model.autocast_context, model.vae_autocast_context], dtype=model.vae_train_dtype.torch_dtype())

--- a/modules/dataLoader/WuerstchenBaseDataLoader.py
+++ b/modules/dataLoader/WuerstchenBaseDataLoader.py
@@ -10,7 +10,6 @@ from modules.modelSetup.BaseWuerstchenSetup import BaseWuerstchenSetup
 from modules.util import factory
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.ModelType import ModelType
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.pipelineModules.DecodeTokens import DecodeTokens
@@ -74,10 +73,8 @@ class WuerstchenBaseDataLoader(
         ]
 
         def before_cache_image_fun():
-            model.to(self.temp_device)
-            model.effnet_encoder_to(self.train_device)
+            model.materialize_only("effnet_encoder")
             model.eval()
-            torch_gc()
 
         return self._cache_modules_from_names(
             model, model_setup,
@@ -109,10 +106,8 @@ class WuerstchenBaseDataLoader(
                 output_names.append('pooled_text_encoder_output')
 
         def before_cache_image_fun():
-            model.to(self.temp_device)
-            model.effnet_encoder_to(self.train_device)
+            model.materialize_only("effnet_encoder")
             model.eval()
-            torch_gc()
 
         return self._output_modules_from_out_names(
             model, model_setup,

--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -116,7 +116,7 @@ class ZImageBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.vae_to(self.train_device)
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -116,7 +116,7 @@ class ZImageBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize("vae")
+            model.materialize_only("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/ZImageBaseDataLoader.py
+++ b/modules/dataLoader/ZImageBaseDataLoader.py
@@ -116,7 +116,7 @@ class ZImageBaseDataLoader(
         debug_dir = os.path.join(config.debug_dir, "dataloader")
 
         def before_save_fun():
-            model.materialize_only("vae")
+            model.materialize("vae")
 
         decode_image = DecodeVAE(in_name='latent_image', out_name='decoded_image', vae=model.vae, autocast_contexts=[model.autocast_context], dtype=model.train_dtype.torch_dtype())
         upscale_mask = ScaleImage(in_name='latent_mask', out_name='decoded_mask', factor=8)

--- a/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
+++ b/modules/dataLoader/mixin/DataLoaderText2ImageMixin.py
@@ -10,7 +10,6 @@ from modules.modelSetup.mixin.ModelSetupText2ImageMixin import ModelSetupText2Im
 from modules.util import path_util
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.DataType import DataType
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 from mgds.OutputPipelineModule import OutputPipelineModule
@@ -274,10 +273,8 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
     ):
         if before_cache_image_fun is None:
             def prepare_vae():
-                model.to(self.temp_device)
-                model.vae_to(self.train_device)
+                model.materialize_only("vae")
                 model.eval()
-                torch_gc()
             before_cache_image_fun = prepare_vae
 
         sort_names = output_names + ['concept']
@@ -340,10 +337,8 @@ class DataLoaderText2ImageMixin(metaclass=ABCMeta):
 
         if before_cache_image_fun is None:
             def prepare_vae():
-                model.to(self.temp_device)
-                model.vae_to(self.train_device)
+                model.materialize_only("vae")
                 model.eval()
-                torch_gc()
             before_cache_image_fun = prepare_vae
 
         def before_cache_text_fun():

--- a/modules/model/AnimaModel.py
+++ b/modules/model/AnimaModel.py
@@ -72,11 +72,6 @@ class AnimaModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
     def _diffusers_to_dit(self) -> list:
         # the netless diffusers CosmosTransformer3DModel -> Anima DiT rename (the inverse of diffusers'
         # scripts/convert_anima_to_diffusers.py transformer rename). These are the bare module names kohya-ss
@@ -130,35 +125,22 @@ class AnimaModel(BaseModel):
         # kohya-ss loads the DiT with the net. wrapper stripped -> the netless body.
         return self._diffusers_to_dit()
 
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
+    def materialize(self, *parts: str):
+        super().materialize(*parts)
+        # text_conditioner isn't in ModelType.model_parts(); it always travels with text_encoder.
+        if "text_encoder" in parts:
+            self.text_conditioner.to(device=self.train_device)
 
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-        self.text_conditioner.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
+    def evict(self, *parts: str):
+        super().evict(*parts)
+        # evict() with no parts means "evict all", which includes text_encoder.
+        if not parts or "text_encoder" in parts:
+            self.text_conditioner.to(device=self.temp_device)
 
     def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
+        super().eval()
+        # text_conditioner isn't in ModelType.model_parts(); it always travels with text_encoder.
         self.text_conditioner.eval()
-        self.transformer.eval()
 
     def create_pipeline(self):
         pipe = AnimaAutoBlocks().init_pipeline()

--- a/modules/model/BaseModel.py
+++ b/modules/model/BaseModel.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from contextlib import nullcontext
 from uuid import uuid4
 
@@ -11,6 +11,7 @@ from modules.util.enum.ModelFormat import ModelFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.modelSpec.ModelSpec import ModelSpec
 from modules.util.NamedParameterGroup import NamedParameterGroupCollection
+from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -96,17 +97,79 @@ class BaseModel(metaclass=ABCMeta):
         self.autocast_context = nullcontext()
         self.train_dtype = DataType.FLOAT_32
 
-    @abstractmethod
-    def to(self, device: torch.device):
-        pass
+    @property
+    def train_device(self) -> torch.device:
+        return torch.device(self.train_config.train_device)
 
-    @abstractmethod
+    @property
+    def temp_device(self) -> torch.device:
+        return torch.device(self.train_config.temp_device)
+
+    def materialize(self, *parts: str):
+        # Move `parts` onto train_device.
+        for part in parts:
+            self._move_part(part, self.train_device)
+
+    def evict(self, *parts: str):
+        # Move `parts` onto temp_device. No parts given -> every component in ModelType.model_parts().
+        for part in parts or self.model_type.model_parts():
+            self._move_part(part, self.temp_device)
+        torch_gc()
+
+    def materialize_only(self, *parts: str):
+        # Materialize exactly `parts` on train_device; evict every other component in ModelType.model_parts()
+        # to temp_device. Lets a caller state what it needs now without tracking what to evict first.
+        # Evicts before materializing, so the two sets are never resident on train_device at once.
+        # Skipped (rather than passed as evict()) when empty, since evict() with no parts means "evict all".
+        to_evict = [part for part in self.model_type.model_parts() if part not in parts]
+        if to_evict:
+            self.evict(*to_evict)
+        self.materialize(*parts)
+
+    def materialize_only_text_encoders(self):
+        # Materialize all of this model's text encoders on train_device, evicting everything else. Samplers
+        # call this before encode_text, which reads every text encoder the model has.
+        self.materialize_only(*self.model_type.text_encoder_parts())
+
+    def _move_part(self, part: str, device: torch.device):
+        # The generic per-component move: `part` (or `part_1` for the first of several split text encoders),
+        # its LoRA (`{part}_lora`), and its layer-offload conductor (`{part}_offload_conductor`), if present.
+        stem = f"{part}_1" if hasattr(self, f"{part}_1") else part
+
+        conductor = getattr(self, f"{stem}_offload_conductor", None)
+        if conductor is not None:
+            conductor.to(device)
+        else:
+            component = getattr(self, stem)  # raises if `part` doesn't name a real attribute
+            # None when the part is excluded from training (e.g. a text encoder with include_text_encoder off):
+            # it stays in model_parts() but the loader never populated it, so there is nothing to move.
+            if component is not None:
+                component.to(device=device)
+
+        lora = getattr(self, f"{stem}_lora", None)
+        if lora is not None:
+            lora.to(device)
+
     def eval(self):
-        pass
+        # Put every present component on eval(); driven by the same part registry as materialize()/evict().
+        # A model whose component names diverge (Wuerstchen) or that has a component outside model_parts()
+        # (SD's depth_estimator, Anima's text_conditioner) overrides this.
+        for part in self.model_type.model_parts():
+            stem = f"{part}_1" if hasattr(self, f"{part}_1") else part
+            component = getattr(self, stem)
+            if component is not None:
+                component.eval()
 
-    @abstractmethod
     def adapters(self) -> list[LoRAModuleWrapper]:
-        pass
+        # Every LoRA adapter present on a model part, in model_parts() order. Parts without a LoRA
+        # (e.g. the vae, or an untrained component) contribute nothing.
+        result = []
+        for part in self.model_type.model_parts():
+            stem = f"{part}_1" if hasattr(self, f"{part}_1") else part
+            lora = getattr(self, f"{stem}_lora", None)
+            if lora is not None:
+                result.append(lora)
+        return result
 
     def diffusers_to_original(self) -> list | None:
         # the canonical(diffusers) -> native key-conversion BODY (rename only) for this model's denoising

--- a/modules/model/BaseModel.py
+++ b/modules/model/BaseModel.py
@@ -138,10 +138,11 @@ class BaseModel(metaclass=ABCMeta):
 
         conductor = getattr(self, f"{stem}_offload_conductor", None)
         if conductor is not None:
-            if device_equals(device, self.train_device):
-                conductor.materialize()
-            else:
+            if device_equals(device, self.temp_device):
                 conductor.evict()
+            else:
+                assert device_equals(device, self.train_device), f"unexpected device {device} for part {part}"
+                conductor.materialize()
         else:
             component = getattr(self, stem)  # raises if `part` doesn't name a real attribute
             # None when the part is excluded from training (e.g. a text encoder with include_text_encoder off):

--- a/modules/model/BaseModel.py
+++ b/modules/model/BaseModel.py
@@ -11,7 +11,7 @@ from modules.util.enum.ModelFormat import ModelFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.modelSpec.ModelSpec import ModelSpec
 from modules.util.NamedParameterGroup import NamedParameterGroupCollection
-from modules.util.torch_util import torch_gc
+from modules.util.torch_util import device_equals, torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -138,7 +138,10 @@ class BaseModel(metaclass=ABCMeta):
 
         conductor = getattr(self, f"{stem}_offload_conductor", None)
         if conductor is not None:
-            conductor.to(device)
+            if device_equals(device, self.train_device):
+                conductor.materialize()
+            else:
+                conductor.evict()
         else:
             component = getattr(self, stem)  # raises if `part` doesn't name a real attribute
             # None when the part is excluded from training (e.g. a text encoder with include_text_encoder off):

--- a/modules/model/ChromaModel.py
+++ b/modules/model/ChromaModel.py
@@ -95,12 +95,6 @@ class ChromaModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # Chroma is Flux-structured: double blocks fuse img q/k/v and txt q/k/v separately; single blocks
         # fuse q/k/v + mlp into one linear1.
@@ -163,37 +157,6 @@ class ChromaModel(BaseModel):
     def all_text_encoder_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-        if self.text_encoder_lora is not None:
-            self.text_encoder_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return ChromaPipeline(

--- a/modules/model/ErnieModel.py
+++ b/modules/model/ErnieModel.py
@@ -62,41 +62,6 @@ class ErnieModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder is not None:
-            if self.text_encoder_offload_conductor is not None:
-                self.text_encoder_offload_conductor.to(device)
-            else:
-                self.text_encoder.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder is not None:
-            self.text_encoder.eval()
-        self.transformer.eval()
-
     def create_pipeline(self) -> DiffusionPipeline:
         return ErnieImagePipeline(
             transformer=self.transformer,

--- a/modules/model/Flux2Model.py
+++ b/modules/model/Flux2Model.py
@@ -71,11 +71,6 @@ class Flux2Model(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # Only the two double-block qkv groups -- Flux2's single block is the already-fused attn.to_qkv_mlp_proj.
         # NOTE: the fused suffix (attn.qkv / attn.added_qkv) is OneTrainer's name for the fused module on the
@@ -125,36 +120,6 @@ class Flux2Model(BaseModel):
                 ("attn.norm_q.weight",   "norm.query_norm.scale"),
             ]),
         ]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder is not None:
-            if self.text_encoder_offload_conductor is not None:
-                self.text_encoder_offload_conductor.to(device)
-            else:
-                self.text_encoder.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder is not None:
-            self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self) -> DiffusionPipeline:
         klass = Flux2Pipeline if self.is_dev() else Flux2KleinPipeline

--- a/modules/model/FluxModel.py
+++ b/modules/model/FluxModel.py
@@ -116,13 +116,6 @@ class FluxModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_1_lora,
-            self.text_encoder_2_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # Flux fuses img qkv, txt qkv, and the single-block qkv+mlp (4 leaves -> linear1).
         return [
@@ -205,52 +198,6 @@ class FluxModel(BaseModel):
     def all_text_encoder_2_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_2_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_2_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder_1_to(device=device)
-        self.text_encoder_2_to(device=device)
-
-    def text_encoder_1_to(self, device: torch.device):
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-    def text_encoder_2_to(self, device: torch.device):
-        if self.text_encoder_2 is not None:
-            if self.text_encoder_2_offload_conductor is not None:
-                self.text_encoder_2_offload_conductor.to(device)
-            else:
-                self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.eval()
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return FluxPipeline(

--- a/modules/model/HiDreamModel.py
+++ b/modules/model/HiDreamModel.py
@@ -167,15 +167,6 @@ class HiDreamModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_1_lora,
-            self.text_encoder_2_lora,
-            self.text_encoder_3_lora,
-            self.text_encoder_4_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def lora_text_encoders(self) -> list[tuple[torch.nn.Module | None, dict[ModelFormat, str]]]:
         # HiDream's four TEs: clip_l + clip_g + t5xxl + llama (Comfy's HiDreamTEModel). Any can be absent, so
         # only the TEs actually present are declared.
@@ -225,75 +216,6 @@ class HiDreamModel(BaseModel):
     def all_text_encoder_4_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_4_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_4_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder_1_to(device=device)
-        self.text_encoder_2_to(device=device)
-        self.text_encoder_3_to(device=device)
-        self.text_encoder_4_to(device=device)
-
-    def text_encoder_1_to(self, device: torch.device):
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-    def text_encoder_2_to(self, device: torch.device):
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def text_encoder_3_to(self, device: torch.device):
-        if self.text_encoder_3 is not None:
-            if self.text_encoder_3_offload_conductor is not None:
-                self.text_encoder_3_offload_conductor.to(device)
-            else:
-                self.text_encoder_3.to(device=device)
-
-        if self.text_encoder_3_lora is not None:
-            self.text_encoder_3_lora.to(device)
-
-    def text_encoder_4_to(self, device: torch.device):
-        if self.text_encoder_4 is not None:
-            if self.text_encoder_4_offload_conductor is not None:
-                self.text_encoder_4_offload_conductor.to(device)
-            else:
-                self.text_encoder_4.to(device=device)
-
-        if self.text_encoder_4_lora is not None:
-            self.text_encoder_4_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.eval()
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.eval()
-        if self.text_encoder_3 is not None:
-            self.text_encoder_3.eval()
-        if self.text_encoder_4 is not None:
-            self.text_encoder_4.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return HiDreamImagePipeline(

--- a/modules/model/HunyuanVideoModel.py
+++ b/modules/model/HunyuanVideoModel.py
@@ -131,13 +131,6 @@ class HunyuanVideoModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_1_lora,
-            self.text_encoder_2_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # HunyuanVideo fuses qkv in three places: the context-embedder token-refiner blocks, the double
         # blocks (img + txt), and the single blocks (qkv+mlp).
@@ -229,52 +222,6 @@ class HunyuanVideoModel(BaseModel):
     def all_text_encoder_2_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_2_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_2_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder_1_to(device=device)
-        self.text_encoder_2_to(device=device)
-
-    def text_encoder_1_to(self, device: torch.device):
-        if self.text_encoder_1 is not None:
-            if self.text_encoder_1_offload_conductor is not None:
-                self.text_encoder_1_offload_conductor.to(device)
-            else:
-                self.text_encoder_1.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-    def text_encoder_2_to(self, device: torch.device):
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.eval()
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return HunyuanVideoPipeline(

--- a/modules/model/IdeogramModel.py
+++ b/modules/model/IdeogramModel.py
@@ -67,12 +67,6 @@ class IdeogramModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        # only the conditional transformer is trainable; the unconditional transformer never sees the concept
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # Ideogram4 fuses q/k/v into one qkv Linear per block; everything else in the transformer -- including
         # the output projection (to_out.0 -> o, see diffusers_to_original) -- already matches the original
@@ -90,44 +84,6 @@ class IdeogramModel(BaseModel):
             ("layers.{i}.attention.to_out.0", "layers.{i}.attention.o"),
             ("{path}", "{path}"),
         ]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def unconditional_transformer_to(self, device: torch.device):
-        if self.unconditional_transformer is not None:
-            if self.unconditional_transformer_offload_conductor is not None:
-                self.unconditional_transformer_offload_conductor.to(device)
-            else:
-                self.unconditional_transformer.to(device=device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-        self.unconditional_transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
-        if self.unconditional_transformer is not None:
-            self.unconditional_transformer.eval()
 
     def create_pipeline(self) -> DiffusionPipeline:
         return Ideogram4Pipeline(

--- a/modules/model/Krea2Model.py
+++ b/modules/model/Krea2Model.py
@@ -80,11 +80,6 @@ class Krea2Model(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
     def diffusers_to_original(self) -> list | None:
         # Krea 2's native checkpoint (krea/Krea-2-Raw's raw.safetensors) is a pure rename of the diffusers
         # Krea2Transformer2DModel state dict -- q/k/v are already split in both namespaces, so no qkv fusion
@@ -126,34 +121,6 @@ class Krea2Model(BaseModel):
                 ("scale_shift_table", "mod.lin", flatten_mod, table_mod),
             ]),
         ]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device): #TODO share more code between models
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self) -> DiffusionPipeline:
         return Krea2Pipeline(

--- a/modules/model/PixArtAlphaModel.py
+++ b/modules/model/PixArtAlphaModel.py
@@ -97,12 +97,6 @@ class PixArtAlphaModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # PixArt fuses TWO attentions differently: self-attention fuses q/k/v (3 leaves), while cross-attention
         # fuses ONLY k/v (2 leaves) into kv_linear.
@@ -157,37 +151,6 @@ class PixArtAlphaModel(BaseModel):
     def all_text_encoder_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-        if self.text_encoder_lora is not None:
-            self.text_encoder_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         tokenizer = self.orig_tokenizer if use_original_tokenizers else self.tokenizer

--- a/modules/model/QwenModel.py
+++ b/modules/model/QwenModel.py
@@ -71,12 +71,6 @@ class QwenModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def lora_text_encoders(self) -> list[tuple[torch.nn.Module | None, dict[ModelFormat, str]]]:
         # Single Qwen2.5-VL TE (Comfy's QwenImageTEModel is a single qwen25_7b).
         return [
@@ -86,37 +80,6 @@ class QwenModel(BaseModel):
                 ModelFormat.COMFY_LORA: "text_encoders.qwen25_7b.transformer",
             }),
         ]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device): #TODO share more code between models
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-        if self.text_encoder_lora is not None:
-            self.text_encoder_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self) -> DiffusionPipeline:
         return QwenImagePipeline(

--- a/modules/model/SanaModel.py
+++ b/modules/model/SanaModel.py
@@ -99,12 +99,6 @@ class SanaModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def lora_text_encoders(self) -> list[tuple[torch.nn.Module | None, dict[ModelFormat, str]]]:
         # Single Gemma2 TE. No COMFY_LORA name -- ComfyUI cannot load Sana, so the COMFY format refuses to
         # write its TE keys.
@@ -122,37 +116,6 @@ class SanaModel(BaseModel):
     def all_text_encoder_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        if self.text_encoder_offload_conductor is not None:
-            self.text_encoder_offload_conductor.to(device)
-        else:
-            self.text_encoder.to(device=device)
-
-        if self.text_encoder_lora is not None:
-            self.text_encoder_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return SanaPipeline(

--- a/modules/model/StableDiffusion3Model.py
+++ b/modules/model/StableDiffusion3Model.py
@@ -134,14 +134,6 @@ class StableDiffusion3Model(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_1_lora,
-            self.text_encoder_2_lora,
-            self.text_encoder_3_lora,
-            self.transformer_lora,
-        ] if a is not None]
-
     def fusion_groups(self) -> list | None:
         # SD3 fuses TWO joint streams (x_block + context_block) plus a dual-attention attn2 that only exists
         # in some SD3.5 blocks (the group fires per-block only where all its leaves are present).
@@ -230,62 +222,6 @@ class StableDiffusion3Model(BaseModel):
     def all_text_encoder_3_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_3_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_3_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder_1_to(device=device)
-        self.text_encoder_2_to(device=device)
-        self.text_encoder_3_to(device=device)
-
-    def text_encoder_1_to(self, device: torch.device):
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-    def text_encoder_2_to(self, device: torch.device):
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def text_encoder_3_to(self, device: torch.device):
-        if self.text_encoder_3 is not None:
-            if self.text_encoder_3_offload_conductor is not None:
-                self.text_encoder_3_offload_conductor.to(device)
-            else:
-                self.text_encoder_3.to(device=device)
-
-        if self.text_encoder_3_lora is not None:
-            self.text_encoder_3_lora.to(device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder_1 is not None:
-            self.text_encoder_1.eval()
-        if self.text_encoder_2 is not None:
-            self.text_encoder_2.eval()
-        if self.text_encoder_3 is not None:
-            self.text_encoder_3.eval()
-        self.transformer.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return StableDiffusion3Pipeline(

--- a/modules/model/StableDiffusionModel.py
+++ b/modules/model/StableDiffusionModel.py
@@ -104,12 +104,6 @@ class StableDiffusionModel(BaseModel):
         self.sd_config = None
         self.sd_config_filename = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_lora,
-            self.unet_lora,
-        ] if a is not None]
-
     def diffusers_to_original(self) -> list | None:
         # SD1.5/2.x UNet diffusers -> original/sgm key map, convert()-native (bare sgm names, no top prefix).
         # SD has NO qkv fusion and NO add_embedding, so this is a pure key rename. Spatial-transformer
@@ -181,37 +175,11 @@ class StableDiffusionModel(BaseModel):
         return [embedding.text_encoder_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_embedding] if self.embedding is not None else [])
 
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def depth_estimator_to(self, device: torch.device):
-        if self.depth_estimator is not None:
-            self.depth_estimator.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder.to(device=device)
-
-        if self.text_encoder_lora is not None:
-            self.text_encoder_lora.to(device)
-
-    def unet_to(self, device: torch.device):
-        self.unet.to(device=device)
-
-        if self.unet_lora is not None:
-            self.unet_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.depth_estimator_to(device)
-        self.text_encoder_to(device)
-        self.unet_to(device)
-
     def eval(self):
-        self.vae.eval()
+        super().eval()
+        # depth_estimator isn't in ModelType.model_parts(); only the depth model variants have it.
         if self.depth_estimator is not None:
             self.depth_estimator.eval()
-        self.text_encoder.eval()
-        self.unet.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         tokenizer = self.orig_tokenizer if use_original_tokenizers else self.tokenizer

--- a/modules/model/StableDiffusionXLModel.py
+++ b/modules/model/StableDiffusionXLModel.py
@@ -121,13 +121,6 @@ class StableDiffusionXLModel(BaseModel):
         self.sd_config = None
         self.sd_config_filename = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.text_encoder_1_lora,
-            self.text_encoder_2_lora,
-            self.unet_lora,
-        ] if a is not None]
-
     def diffusers_to_original(self) -> list | None:
         # SDXL UNet diffusers -> original/sgm key map, convert()-native (bare sgm names, no top prefix).
         # SDXL has NO qkv fusion, so this is a pure key rename. Spatial-transformer (attention) blocks have
@@ -198,48 +191,6 @@ class StableDiffusionXLModel(BaseModel):
     def all_text_encoder_2_embeddings(self) -> list[BaseModelEmbedding]:
         return [embedding.text_encoder_2_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.text_encoder_2_embedding] if self.embedding is not None else [])
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device):
-        self.text_encoder_1.to(device=device)
-        self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def text_encoder_1_to(self, device: torch.device):
-        self.text_encoder_1.to(device=device)
-
-        if self.text_encoder_1_lora is not None:
-            self.text_encoder_1_lora.to(device)
-
-    def text_encoder_2_to(self, device: torch.device):
-        self.text_encoder_2.to(device=device)
-
-        if self.text_encoder_2_lora is not None:
-            self.text_encoder_2_lora.to(device)
-
-    def unet_to(self, device: torch.device):
-        self.unet.to(device=device)
-
-        if self.unet_lora is not None:
-            self.unet_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.unet_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        self.text_encoder_1.eval()
-        self.text_encoder_2.eval()
-        self.unet.eval()
 
     def create_pipeline(self, use_original_tokenizers: bool = False) -> DiffusionPipeline:
         return StableDiffusionXLPipeline(

--- a/modules/model/WuerstchenModel.py
+++ b/modules/model/WuerstchenModel.py
@@ -174,38 +174,27 @@ class WuerstchenModel(BaseModel):
         return [embedding.text_encoder_embedding for embedding in self.additional_embeddings] \
                + ([self.embedding.prior_text_encoder_embedding] if self.embedding is not None else [])
 
-    def decoder_text_encoder_to(self, device: torch.device):
-        self.decoder_text_encoder.to(device=device)
+    def materialize(self, *parts: str):
+        super().materialize(*self._translate_parts(parts))
 
-    def decoder_decoder_to(self, device: torch.device):
-        self.decoder_decoder.to(device=device)
+    def evict(self, *parts: str):
+        # evict() with no parts means "evict all"; translate against the model's own full part list.
+        super().evict(*self._translate_parts(parts or self.model_type.model_parts()))
 
-    def decoder_vqgan_to(self, device: torch.device):
-        self.decoder_vqgan.to(device=device)
-
-    def effnet_encoder_to(self, device: torch.device):
-        self.effnet_encoder.to(device=device)
-
-    def prior_text_encoder_to(self, device: torch.device):
-        self.prior_text_encoder.to(device=device)
-
-        if self.prior_text_encoder_lora is not None:
-            self.prior_text_encoder_lora.to(device)
-
-    def prior_prior_to(self, device: torch.device):
-        self.prior_prior.to(device=device)
-
-        if self.prior_prior_lora is not None:
-            self.prior_prior_lora.to(device)
-
-    def to(self, device: torch.device):
-        if self.model_type.is_wuerstchen_v2():
-            self.decoder_text_encoder_to(device)
-        self.decoder_decoder_to(device)
-        self.decoder_vqgan_to(device)
-        self.effnet_encoder_to(device)
-        self.prior_text_encoder_to(device)
-        self.prior_prior_to(device)
+    def _translate_parts(self, parts: tuple[str, ...]) -> tuple[str, ...]:
+        # The prior stage's own diffusion module and the decoder stage's own diffusion module are each
+        # named after their stage, and the main text encoder belongs to the prior stage.
+        translated = []
+        for part in parts:
+            if part == "prior":
+                translated.append("prior_prior")
+            elif part == "decoder":
+                translated.append("decoder_decoder")
+            elif part == "text_encoder":
+                translated.append("prior_text_encoder")
+            else:
+                translated.append(part)
+        return tuple(translated)
 
     def eval(self):
         if self.model_type.is_wuerstchen_v2():

--- a/modules/model/ZImageModel.py
+++ b/modules/model/ZImageModel.py
@@ -74,11 +74,6 @@ class ZImageModel(BaseModel):
         self.transformer_lora = None
         self.lora_state_dict = None
 
-    def adapters(self) -> list[LoRAModuleWrapper]:
-        return [a for a in [
-            self.transformer_lora,
-        ] if a is not None]
-
     def checkpoint_diffusers_to_comfy(self) -> list | None:
         # Full-model COMFY_TRANSFORMER conversion: Z-Image is the one model whose Comfy checkpoint layout
         # diverges from diffusers/original (ComfyUI #12303). Only these keys change -- everything else passes
@@ -96,36 +91,6 @@ class ZImageModel(BaseModel):
             ("{p}.attention.norm_k.weight", "{p}.attention.k_norm.weight"),
             ("{p}.attention.to_out.0", "{p}.attention.out"),
         ]
-
-    def vae_to(self, device: torch.device):
-        self.vae.to(device=device)
-
-    def text_encoder_to(self, device: torch.device): #TODO share more code between models
-        if self.text_encoder is not None:
-            if self.text_encoder_offload_conductor is not None:
-                self.text_encoder_offload_conductor.to(device)
-            else:
-                self.text_encoder.to(device=device)
-
-    def transformer_to(self, device: torch.device):
-        if self.transformer_offload_conductor is not None:
-            self.transformer_offload_conductor.to(device)
-        else:
-            self.transformer.to(device=device)
-
-        if self.transformer_lora is not None:
-            self.transformer_lora.to(device)
-
-    def to(self, device: torch.device):
-        self.vae_to(device)
-        self.text_encoder_to(device)
-        self.transformer_to(device)
-
-    def eval(self):
-        self.vae.eval()
-        if self.text_encoder is not None:
-            self.text_encoder.eval()
-        self.transformer.eval()
 
     def create_pipeline(self) -> DiffusionPipeline:
         return ZImagePipeline(

--- a/modules/modelSampler/AnimaSampler.py
+++ b/modules/modelSampler/AnimaSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -66,7 +65,7 @@ class AnimaSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             batch_size = 2 if cfg_scale > 1.0 else 1
             combined_prompt_embedding = self.model.encode_text(
@@ -74,9 +73,6 @@ class AnimaSampler(BaseModelSampler):
                 batch_size=batch_size,
                 train_device=self.train_device,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -99,7 +95,7 @@ class AnimaSampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * batch_size)
                 expanded_timestep = timestep.expand(batch_size) / noise_scheduler.config.num_train_timesteps
@@ -121,11 +117,8 @@ class AnimaSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = self.model.unscale_latents(latent_image)
             image = vae.decode(latents, return_dict=False)[0][:, :, 0]
@@ -133,8 +126,7 @@ class AnimaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = self.image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/AnimaSampler.py
+++ b/modules/modelSampler/AnimaSampler.py
@@ -126,8 +126,6 @@ class AnimaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = self.image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/ChromaSampler.py
+++ b/modules/modelSampler/ChromaSampler.py
@@ -145,8 +145,6 @@ class ChromaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/ChromaSampler.py
+++ b/modules/modelSampler/ChromaSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -64,7 +63,7 @@ class ChromaSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             combined_prompt_embedding, text_attention_mask = self.model.encode_text(
                 text=[prompt, negative_prompt],
@@ -72,9 +71,6 @@ class ChromaSampler(BaseModelSampler):
                 train_device=self.train_device,
                 text_encoder_layer_skip=text_encoder_layer_skip,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -109,7 +105,7 @@ class ChromaSampler(BaseModelSampler):
             image_attention_mask = torch.full((2, image_seq_len), True, dtype=torch.bool, device=text_attention_mask.device)
             attention_mask = torch.cat([text_attention_mask, image_attention_mask], dim=1)
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 expanded_timestep = timestep.expand(2)
@@ -134,9 +130,6 @@ class ChromaSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             latent_image = self.model.unpack_latents(
                 latent_image,
                 height // vae_scale_factor,
@@ -144,7 +137,7 @@ class ChromaSampler(BaseModelSampler):
             )
 
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = (latent_image / vae.config.scaling_factor) + vae.config.shift_factor
             image = vae.decode(latents, return_dict=False)[0]
@@ -152,8 +145,7 @@ class ChromaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/ErnieSampler.py
+++ b/modules/modelSampler/ErnieSampler.py
@@ -11,7 +11,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -63,7 +62,7 @@ class ErnieSampler(BaseModelSampler):
             num_latent_channels = 32
 
             # encode text
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             batch_size = 2 if cfg_scale > 1.0 else 1
             text_bth, text_lens = self.model.encode_text(
@@ -71,9 +70,6 @@ class ErnieSampler(BaseModelSampler):
                 text=[prompt, negative_prompt] if batch_size == 2 else prompt,
             )
             dtype = self.model.train_dtype.torch_dtype()
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latents
             latent_image = torch.randn(
@@ -88,7 +84,7 @@ class ErnieSampler(BaseModelSampler):
             noise_scheduler.set_timesteps(sigmas=sigmas, device=self.train_device)
             timesteps = noise_scheduler.timesteps
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             transformer = self.pipeline.transformer
 
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
@@ -112,9 +108,7 @@ class ErnieSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             # unscale and unpatchify
             latents = self.model.unscale_latents(latent_image)
@@ -126,8 +120,7 @@ class ErnieSampler(BaseModelSampler):
             image = image.cpu().permute(0, 2, 3, 1).float().numpy()
             image = [PILImage.fromarray((img * 255).astype(np.uint8)) for img in image]
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/ErnieSampler.py
+++ b/modules/modelSampler/ErnieSampler.py
@@ -120,8 +120,6 @@ class ErnieSampler(BaseModelSampler):
             image = image.cpu().permute(0, 2, 3, 1).float().numpy()
             image = [PILImage.fromarray((img * 255).astype(np.uint8)) for img in image]
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/Flux2Sampler.py
+++ b/modules/modelSampler/Flux2Sampler.py
@@ -145,8 +145,6 @@ class Flux2Sampler(BaseModelSampler):
 
             image = image_processor.postprocess(image, output_type='pil')
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/Flux2Sampler.py
+++ b/modules/modelSampler/Flux2Sampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -69,7 +68,7 @@ class Flux2Sampler(BaseModelSampler):
             patch_size = 2
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             batch_size = 2 if cfg_scale > 1.0 and not transformer.config.guidance_embeds else 1
             prompt_embedding = self.model.encode_text(
@@ -77,9 +76,6 @@ class Flux2Sampler(BaseModelSampler):
                 train_device=self.train_device,
                 text_encoder_sequence_length=text_encoder_sequence_length,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -109,14 +105,12 @@ class Flux2Sampler(BaseModelSampler):
 
             text_ids = self.model.prepare_text_ids(prompt_embedding)
 
-
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             guidance = (torch.tensor([cfg_scale], device=self.train_device, dtype=self.model.train_dtype.torch_dtype())
                         if transformer.config.guidance_embeds else None)
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * batch_size)
                 expanded_timestep = timestep.expand(latent_model_input.shape[0])
-
 
                 noise_pred = transformer(
                     hidden_states=latent_model_input.to(dtype=self.model.train_dtype.torch_dtype()),
@@ -137,9 +131,7 @@ class Flux2Sampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = self.model.unpack_latents(
                 latent_image,
@@ -153,8 +145,7 @@ class Flux2Sampler(BaseModelSampler):
 
             image = image_processor.postprocess(image, output_type='pil')
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -158,8 +158,6 @@ class FluxSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0] #TODO remove and test, from Flux and other models. True is the default
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],
@@ -376,8 +374,6 @@ class FluxSampler(BaseModelSampler):
 
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
-
-            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/FluxSampler.py
+++ b/modules/modelSampler/FluxSampler.py
@@ -14,7 +14,6 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
 from modules.util.image_util import load_image
-from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
@@ -72,7 +71,7 @@ class FluxSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_prompt_embedding = self.model.encode_text(
                 text=prompt,
@@ -82,9 +81,6 @@ class FluxSampler(BaseModelSampler):
                 text_encoder_2_sequence_length=text_encoder_2_sequence_length,
                 apply_attention_mask=transformer_attention_mask,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -115,7 +111,7 @@ class FluxSampler(BaseModelSampler):
 
             text_ids = torch.zeros(prompt_embedding.shape[1], 3, device=self.train_device)
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image])
                 expanded_timestep = timestep.expand(latent_model_input.shape[0])
@@ -147,8 +143,6 @@ class FluxSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
             latent_image = self.model.unpack_latents(
                 latent_image,
                 height // vae_scale_factor,
@@ -156,7 +150,7 @@ class FluxSampler(BaseModelSampler):
             )
 
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = (latent_image / vae.config.scaling_factor) + vae.config.shift_factor
             image = vae.decode(latents, return_dict=False)[0]
@@ -164,8 +158,7 @@ class FluxSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0] #TODO remove and test, from Flux and other models. True is the default
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
@@ -222,7 +215,7 @@ class FluxSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare conditioning image
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             if sample_inpainting:
                 t = transforms.Compose([
@@ -296,7 +289,7 @@ class FluxSampler(BaseModelSampler):
                 )
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_prompt_embedding = self.model.encode_text(
                 text=prompt,
@@ -306,9 +299,6 @@ class FluxSampler(BaseModelSampler):
                 text_encoder_2_sequence_length=text_encoder_2_sequence_length,
                 apply_attention_mask=transformer_attention_mask,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -337,7 +327,7 @@ class FluxSampler(BaseModelSampler):
 
             text_ids = torch.zeros(prompt_embedding.shape[1], 3, device=self.train_device)
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image])
                 latent_model_input = torch.concat(
@@ -372,9 +362,6 @@ class FluxSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             latent_image = self.model.unpack_latents(
                 latent_image,
                 height // vae_scale_factor,
@@ -382,7 +369,7 @@ class FluxSampler(BaseModelSampler):
             )
 
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = (latent_image / vae.config.scaling_factor) + vae.config.shift_factor
             image = vae.decode(latents, return_dict=False)[0]
@@ -390,8 +377,7 @@ class FluxSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -65,7 +64,7 @@ class HiDreamSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             text_encoder_3_prompt_embedding, text_encoder_4_prompt_embedding, pooled_prompt_embedding = \
                 self.model.combine_text_encoder_output(
@@ -92,9 +91,6 @@ class HiDreamSampler(BaseModelSampler):
             combined_pooled_prompt_embedding = torch.cat(
                 [negative_pooled_prompt_embedding, pooled_prompt_embedding], dim=0)
 
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
-
             # prepare latent image
             latent_image = torch.randn(
                 size=(1, num_latent_channels, height // vae_scale_factor, width // vae_scale_factor),
@@ -111,7 +107,7 @@ class HiDreamSampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 expanded_timestep = timestep.expand(latent_model_input.shape[0])
@@ -142,11 +138,8 @@ class HiDreamSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = (latent_image / vae.config.scaling_factor) + vae.config.shift_factor
             image = vae.decode(latents, return_dict=False)[0]
@@ -154,8 +147,7 @@ class HiDreamSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/HiDreamSampler.py
+++ b/modules/modelSampler/HiDreamSampler.py
@@ -147,8 +147,6 @@ class HiDreamSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/HunyuanVideoSampler.py
+++ b/modules/modelSampler/HunyuanVideoSampler.py
@@ -143,8 +143,6 @@ class HunyuanVideoSampler(BaseModelSampler):
 
             image = video_processor.postprocess(image, output_type='pt')
 
-            self.model.evict()
-
             is_image = image.shape[2] == 1
             if is_image:
                 image = image.view((image.shape[0], image.shape[1], image.shape[3], image.shape[4]))

--- a/modules/modelSampler/HunyuanVideoSampler.py
+++ b/modules/modelSampler/HunyuanVideoSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -69,7 +68,7 @@ class HunyuanVideoSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_prompt_embedding, prompt_attention_mask = self.model.encode_text(
                 text=prompt,
@@ -77,9 +76,6 @@ class HunyuanVideoSampler(BaseModelSampler):
                 text_encoder_1_layer_skip=text_encoder_1_layer_skip,
                 text_encoder_2_layer_skip=text_encoder_2_layer_skip,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             num_latent_frames = (num_frames - 1) // vae_temporal_scale_factor + 1
@@ -108,7 +104,7 @@ class HunyuanVideoSampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image])
                 expanded_timestep = timestep.expand(latent_model_input.shape[0])
@@ -139,19 +135,15 @@ class HunyuanVideoSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = latent_image / vae.config.scaling_factor
             image = vae.decode(latents, return_dict=False)[0]
 
             image = video_processor.postprocess(image, output_type='pt')
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             is_image = image.shape[2] == 1
             if is_image:

--- a/modules/modelSampler/IdeogramSampler.py
+++ b/modules/modelSampler/IdeogramSampler.py
@@ -11,7 +11,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -92,7 +91,7 @@ class IdeogramSampler(BaseModelSampler):
                 return max_text_tokens, position_ids, segment_ids, indicator, llm_features, text_z_padding
 
             # encode text (conditional branch, and the empty-prompt negative branch if needed)
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
             text_features, text_lengths = self.model.encode_text(
                 train_device=self.train_device,
                 text=prompt,
@@ -111,8 +110,6 @@ class IdeogramSampler(BaseModelSampler):
                     neg_text_z_padding,
                 ) = pack_conditioning(neg_text_features, neg_text_lengths)
                 del neg_text_features
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             if use_unconditional_transformer:
                 # unconditional (image-only) branch: zeroed text features over the image-region slices of the layout
@@ -141,9 +138,8 @@ class IdeogramSampler(BaseModelSampler):
             timesteps = noise_scheduler.timesteps
             num_train_timesteps = noise_scheduler.config.num_train_timesteps
 
-            self.model.transformer_to(self.train_device)
-            if use_unconditional_transformer:
-                self.model.unconditional_transformer_to(self.train_device)
+            transformer_parts = ("transformer", "unconditional_transformer") if use_unconditional_transformer else ("transformer",)
+            self.model.materialize_only(*transformer_parts)
 
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 # scheduler stores num_train_timesteps-scaled timesteps; convert back to model time (0=noise, 1=data)
@@ -190,10 +186,7 @@ class IdeogramSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            self.model.unconditional_transformer_to(self.temp_device)
-            torch_gc()
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             # bn-denormalize the packed latents and unpatchify back to (B, C, H, W) before VAE decode
             latents = self.model.unscale_latents(latent_image)
@@ -205,8 +198,7 @@ class IdeogramSampler(BaseModelSampler):
             image = image.cpu().permute(0, 2, 3, 1).float().numpy()
             image = [PILImage.fromarray((img * 255).astype(np.uint8)) for img in image]
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/IdeogramSampler.py
+++ b/modules/modelSampler/IdeogramSampler.py
@@ -198,8 +198,6 @@ class IdeogramSampler(BaseModelSampler):
             image = image.cpu().permute(0, 2, 3, 1).float().numpy()
             image = [PILImage.fromarray((img * 255).astype(np.uint8)) for img in image]
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/Krea2Sampler.py
+++ b/modules/modelSampler/Krea2Sampler.py
@@ -135,8 +135,6 @@ class Krea2Sampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/Krea2Sampler.py
+++ b/modules/modelSampler/Krea2Sampler.py
@@ -13,7 +13,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -67,7 +66,7 @@ class Krea2Sampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             batch_size = 2 if cfg_scale > 1.0 else 1
             combined_prompt_embedding, text_attention_mask = self.model.encode_text(
@@ -75,9 +74,6 @@ class Krea2Sampler(BaseModelSampler):
                 batch_size=batch_size,
                 train_device=self.train_device,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -104,7 +100,7 @@ class Krea2Sampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * batch_size)
                 expanded_timestep = timestep.expand(batch_size)
@@ -125,16 +121,13 @@ class Krea2Sampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-
-            torch_gc()
             latent_image = self.model.unpack_latents(
                 latent_image,
                 height // vae_scale_factor,
                 width // vae_scale_factor,
             )
 
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = self.model.unscale_latents(latent_image)
             image = vae.decode(latents, return_dict=False)[0].squeeze(-3)
@@ -142,8 +135,7 @@ class Krea2Sampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/PixArtAlphaSampler.py
+++ b/modules/modelSampler/PixArtAlphaSampler.py
@@ -11,7 +11,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -63,7 +62,7 @@ class PixArtAlphaSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             prompt_embedding, tokens_attention_mask = self.model.encode_text(
                 text=prompt,
@@ -79,9 +78,6 @@ class PixArtAlphaSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding])
             combined_prompt_attention_mask = torch.cat([negative_tokens_attention_mask, tokens_attention_mask])
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -113,7 +109,7 @@ class PixArtAlphaSampler(BaseModelSampler):
             added_cond_kwargs = {"resolution": resolution, "aspect_ratio": aspect_ratio}
 
             # denoising loop
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 latent_model_input = noise_scheduler.scale_model_input(latent_model_input, timestep)
@@ -143,11 +139,8 @@ class PixArtAlphaSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=vae.dtype)
             image = vae.decode(latent_image / vae.config.scaling_factor, return_dict=False)[0]
@@ -155,8 +148,7 @@ class PixArtAlphaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/PixArtAlphaSampler.py
+++ b/modules/modelSampler/PixArtAlphaSampler.py
@@ -148,8 +148,6 @@ class PixArtAlphaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/QwenSampler.py
+++ b/modules/modelSampler/QwenSampler.py
@@ -145,8 +145,6 @@ class QwenSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/QwenSampler.py
+++ b/modules/modelSampler/QwenSampler.py
@@ -13,7 +13,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -65,7 +64,7 @@ class QwenSampler(BaseModelSampler):
             num_latent_channels = 16
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             #unlike other models, Qwen benefits from CFG but is still quite good at CFG 1. Optimize for that:
             batch_size = 2 if cfg_scale > 1.0 else 1
@@ -74,9 +73,6 @@ class QwenSampler(BaseModelSampler):
                 batch_size=batch_size,
                 train_device=self.train_device,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -110,7 +106,7 @@ class QwenSampler(BaseModelSampler):
             if torch.all(text_attention_mask):
                 text_attention_mask = None
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * batch_size)
                 expanded_timestep = timestep.expand(batch_size)
@@ -134,9 +130,6 @@ class QwenSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-
-            torch_gc()
             latent_image = self.model.unpack_latents(
                 latent_image,
                 height // vae_scale_factor,
@@ -144,7 +137,7 @@ class QwenSampler(BaseModelSampler):
             )
 
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = self.model.unscale_latents(latent_image)
             image = vae.decode(latents, return_dict=False)[0].squeeze(-3)
@@ -152,8 +145,7 @@ class QwenSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/SanaSampler.py
+++ b/modules/modelSampler/SanaSampler.py
@@ -133,8 +133,6 @@ class SanaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/SanaSampler.py
+++ b/modules/modelSampler/SanaSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -63,7 +62,7 @@ class SanaSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             prompt_embedding, tokens_attention_mask = self.model.encode_text(
                 text=prompt,
@@ -79,9 +78,6 @@ class SanaSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding])
             combined_prompt_attention_mask = torch.cat([negative_tokens_attention_mask, tokens_attention_mask])
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -102,7 +98,7 @@ class SanaSampler(BaseModelSampler):
                 extra_step_kwargs["generator"] = generator
 
             # denoising loop
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
 
@@ -127,11 +123,8 @@ class SanaSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=vae.dtype)
             with self.model.vae_autocast_context:
@@ -140,8 +133,7 @@ class SanaSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/StableDiffusion3Sampler.py
+++ b/modules/modelSampler/StableDiffusion3Sampler.py
@@ -145,8 +145,6 @@ class StableDiffusion3Sampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSampler/StableDiffusion3Sampler.py
+++ b/modules/modelSampler/StableDiffusion3Sampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -67,7 +66,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_prompt_embedding = self.model.combine_text_encoder_output(
                 *self.model.encode_text(
@@ -93,9 +92,6 @@ class StableDiffusion3Sampler(BaseModelSampler):
             combined_pooled_prompt_embedding = torch.cat(
                 [negative_pooled_prompt_embedding, pooled_prompt_embedding], dim=0)
 
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
-
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
             timesteps = noise_scheduler.timesteps
@@ -114,7 +110,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 expanded_timestep = timestep.expand(latent_model_input.shape[0])
@@ -140,11 +136,8 @@ class StableDiffusion3Sampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = (latent_image / vae.config.scaling_factor) + vae.config.shift_factor
             image = vae.decode(latents, return_dict=False)[0]
@@ -152,8 +145,7 @@ class StableDiffusion3Sampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
 from modules.util.image_util import load_image
-from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
@@ -74,7 +73,7 @@ class StableDiffusionSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             prompt_embedding = self.model.encode_text(
                 text=prompt,
@@ -89,9 +88,6 @@ class StableDiffusionSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding]) \
                 .to(dtype=self.model.train_dtype.torch_dtype())
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -121,7 +117,7 @@ class StableDiffusionSampler(BaseModelSampler):
                 extra_step_kwargs["generator"] = generator
 
             # denoising loop
-            self.model.unet_to(self.train_device)
+            self.model.materialize_only("unet")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 latent_model_input = noise_scheduler.scale_model_input(latent_model_input, timestep)
@@ -155,11 +151,8 @@ class StableDiffusionSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.unet_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=vae.dtype)
             image = vae.decode(latent_image / vae.config.scaling_factor, return_dict=False)[0]
@@ -167,8 +160,7 @@ class StableDiffusionSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
@@ -223,7 +215,7 @@ class StableDiffusionSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare conditioning image
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             if sample_inpainting:
                 t = transforms.Compose([
@@ -277,11 +269,8 @@ class StableDiffusionSampler(BaseModelSampler):
                     device=self.train_device
                 )
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
-
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             prompt_embedding = self.model.encode_text(
                 text=prompt,
@@ -296,9 +285,6 @@ class StableDiffusionSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding]) \
                 .to(dtype=self.model.train_dtype.torch_dtype())
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -328,7 +314,7 @@ class StableDiffusionSampler(BaseModelSampler):
                 extra_step_kwargs["generator"] = generator
 
             # denoising loop
-            self.model.unet_to(self.train_device)
+            self.model.materialize_only("unet")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = noise_scheduler.scale_model_input(latent_image, timestep)
                 latent_model_input = torch.concat(
@@ -365,11 +351,8 @@ class StableDiffusionSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.unet_to(self.temp_device)
-            torch_gc()
-
             #decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=vae.dtype)
             image = vae.decode(latent_image / vae.config.scaling_factor, return_dict=False)[0]
@@ -377,8 +360,7 @@ class StableDiffusionSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/StableDiffusionSampler.py
+++ b/modules/modelSampler/StableDiffusionSampler.py
@@ -160,8 +160,6 @@ class StableDiffusionSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],
@@ -359,8 +357,6 @@ class StableDiffusionSampler(BaseModelSampler):
 
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
-
-            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/StableDiffusionVaeSampler.py
+++ b/modules/modelSampler/StableDiffusionVaeSampler.py
@@ -63,13 +63,13 @@ class StableDiffusionVaeSampler(BaseModelSampler):
         image_tensor = t_in(image).to(device=self.train_device, dtype=self.model.vae.dtype)
         image_tensor = image_tensor * 2 - 1
 
-        self.model.materialize("vae")
+        self.model.materialize_only("vae")
 
         with torch.no_grad():
             latent_image_tensor = self.model.vae.encode(image_tensor.unsqueeze(0)).latent_dist.mean
             image_tensor = self.model.vae.decode(latent_image_tensor).sample.squeeze()
 
-        self.model.evict("vae")
+        self.model.evict()
 
         image_tensor = (image_tensor + 1) * 0.5
         image_tensor = image_tensor.clamp(0, 1)

--- a/modules/modelSampler/StableDiffusionVaeSampler.py
+++ b/modules/modelSampler/StableDiffusionVaeSampler.py
@@ -69,8 +69,6 @@ class StableDiffusionVaeSampler(BaseModelSampler):
             latent_image_tensor = self.model.vae.encode(image_tensor.unsqueeze(0)).latent_dist.mean
             image_tensor = self.model.vae.decode(latent_image_tensor).sample.squeeze()
 
-        self.model.evict()
-
         image_tensor = (image_tensor + 1) * 0.5
         image_tensor = image_tensor.clamp(0, 1)
 

--- a/modules/modelSampler/StableDiffusionVaeSampler.py
+++ b/modules/modelSampler/StableDiffusionVaeSampler.py
@@ -63,13 +63,13 @@ class StableDiffusionVaeSampler(BaseModelSampler):
         image_tensor = t_in(image).to(device=self.train_device, dtype=self.model.vae.dtype)
         image_tensor = image_tensor * 2 - 1
 
-        self.model.vae_to(self.train_device)
+        self.model.materialize("vae")
 
         with torch.no_grad():
             latent_image_tensor = self.model.vae.encode(image_tensor.unsqueeze(0)).latent_dist.mean
             image_tensor = self.model.vae.decode(latent_image_tensor).sample.squeeze()
 
-        self.model.vae_to(self.temp_device)
+        self.model.evict("vae")
 
         image_tensor = (image_tensor + 1) * 0.5
         image_tensor = image_tensor.clamp(0, 1)

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -183,8 +183,6 @@ class StableDiffusionXLSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],
@@ -423,8 +421,6 @@ class StableDiffusionXLSampler(BaseModelSampler):
 
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
-
-            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/StableDiffusionXLSampler.py
+++ b/modules/modelSampler/StableDiffusionXLSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
 from modules.util.image_util import load_image
-from modules.util.torch_util import torch_gc
 
 import torch
 from torch import nn
@@ -69,7 +68,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_text_encoder_2_output = self.model.combine_text_encoder_output(*self.model.encode_text(
                 text=prompt,
@@ -87,9 +86,6 @@ class StableDiffusionXLSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding]) \
                 .to(dtype=self.model.train_dtype.torch_dtype())
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -144,7 +140,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
                 extra_step_kwargs["generator"] = generator
 
             # denoising loop
-            self.model.unet_to(self.train_device)
+            self.model.materialize_only("unet")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = torch.cat([latent_image] * 2)
                 latent_model_input = noise_scheduler.scale_model_input(latent_model_input, timestep)
@@ -177,11 +173,8 @@ class StableDiffusionXLSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.unet_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=self.model.vae_train_dtype.torch_dtype())
             with self.model.vae_autocast_context:
@@ -190,8 +183,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
@@ -247,7 +239,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
             vae_scale_factor = self.pipeline.vae_scale_factor
 
             # prepare conditioning image
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             with self.model.vae_autocast_context:
                 if sample_inpainting:
@@ -303,11 +295,8 @@ class StableDiffusionXLSampler(BaseModelSampler):
                         device=self.train_device
                     )
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
-
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only_text_encoders()
 
             prompt_embedding, pooled_text_encoder_2_output = self.model.combine_text_encoder_output(
                 *self.model.encode_text(
@@ -327,9 +316,6 @@ class StableDiffusionXLSampler(BaseModelSampler):
 
             combined_prompt_embedding = torch.cat([negative_prompt_embedding, prompt_embedding]) \
                 .to(dtype=self.model.train_dtype.torch_dtype())
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare timesteps
             noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -392,7 +378,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
                 extra_step_kwargs["generator"] = generator
 
             # denoising loop
-            self.model.unet_to(self.train_device)
+            self.model.materialize_only("unet")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = noise_scheduler.scale_model_input(latent_image, timestep)
                 latent_model_input = torch.concat(
@@ -428,11 +414,8 @@ class StableDiffusionXLSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.unet_to(self.temp_device)
-            torch_gc()
-
             # decode
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latent_image = latent_image.to(dtype=self.model.vae_train_dtype.torch_dtype())
             with self.model.vae_autocast_context:
@@ -441,8 +424,7 @@ class StableDiffusionXLSampler(BaseModelSampler):
             do_denormalize = [True] * image.shape[0]
             image = image_processor.postprocess(image, output_type='pil', do_denormalize=do_denormalize)
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/WuerstchenSampler.py
+++ b/modules/modelSampler/WuerstchenSampler.py
@@ -313,8 +313,6 @@ class WuerstchenSampler(BaseModelSampler):
             image_array = image_tensor.permute(0, 2, 3, 1).cpu().squeeze().float().numpy()
             image_array = (image_array * 255).round().astype("uint8")
 
-            self.model.evict()
-
         return ModelSamplerOutput(
             file_type=FileType.IMAGE,
             data=Image.fromarray(image_array),

--- a/modules/modelSampler/WuerstchenSampler.py
+++ b/modules/modelSampler/WuerstchenSampler.py
@@ -11,7 +11,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -50,7 +49,7 @@ class WuerstchenSampler(BaseModelSampler):
             on_update_progress,
     ):
         # prepare prompt
-        self.model.prior_text_encoder_to(self.train_device)
+        self.model.materialize_only("text_encoder")
 
         prompt_embedding, pooled_prompt_embedding = self.model.encode_text(
             text=prompt,
@@ -69,9 +68,6 @@ class WuerstchenSampler(BaseModelSampler):
         if self.model_type.is_stable_cascade():
             combined_pooled_prompt_embedding = torch.cat([pooled_negative_prompt_embedding, pooled_prompt_embedding]) \
                 .to(dtype=self.model.prior_train_dtype.torch_dtype())
-
-        self.model.prior_text_encoder_to(self.temp_device)
-        torch_gc()
 
         # prepare timesteps
         prior_noise_scheduler.set_timesteps(diffusion_steps, device=self.train_device)
@@ -95,7 +91,7 @@ class WuerstchenSampler(BaseModelSampler):
 
         clip_img = torch.zeros(size=(2, 1, 768), dtype=self.model.prior_train_dtype.torch_dtype(), device=combined_prompt_embedding.device)
 
-        self.model.prior_prior_to(self.train_device)
+        self.model.materialize_only("prior")
         for i, timestep in enumerate(tqdm(timesteps[:-1], desc="sampling")):
             timestep = torch.stack([timestep]).to(dtype=self.model.prior_train_dtype.torch_dtype())
 
@@ -134,9 +130,6 @@ class WuerstchenSampler(BaseModelSampler):
 
             on_update_progress(i + 1, len(timesteps))
 
-        self.model.prior_prior_to(self.temp_device)
-        torch_gc()
-
         if self.model_type.is_wuerstchen_v2():
             latent_image = latent_image * 42.0 - 1.0
 
@@ -161,9 +154,9 @@ class WuerstchenSampler(BaseModelSampler):
     ):
         # prepare prompt
         if self.model_type.is_wuerstchen_v2():
-            self.model.decoder_text_encoder_to(self.train_device)
+            self.model.materialize_only("decoder_text_encoder")
         elif self.model_type.is_stable_cascade():
-            self.model.prior_text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
         tokenizer_output = decoder_tokenizer(
             prompt,
             padding='max_length',
@@ -188,12 +181,6 @@ class WuerstchenSampler(BaseModelSampler):
         if self.model_type.is_stable_cascade():
             prompt_embedding = text_encoder_output.text_embeds.unsqueeze(1)
 
-        if self.model_type.is_wuerstchen_v2():
-            self.model.decoder_text_encoder_to(self.temp_device)
-        elif self.model_type.is_stable_cascade():
-            self.model.prior_text_encoder_to(self.temp_device)
-        torch_gc()
-
         # prepare timesteps
         decoder_noise_scheduler.set_timesteps(10, device=self.train_device)
         timesteps = decoder_noise_scheduler.timesteps
@@ -214,7 +201,7 @@ class WuerstchenSampler(BaseModelSampler):
         if "generator" in set(inspect.signature(decoder_noise_scheduler.step).parameters.keys()):
             extra_step_kwargs["generator"] = generator
 
-        self.model.decoder_decoder_to(self.train_device)
+        self.model.materialize_only("decoder")
         for i, timestep in enumerate(tqdm(timesteps[:-1], desc="sampling")):
             timestep = torch.stack([timestep]).to(dtype=self.model.prior_train_dtype.torch_dtype())
 
@@ -247,9 +234,6 @@ class WuerstchenSampler(BaseModelSampler):
             ).prev_sample
 
             on_update_progress(i + 1, len(timesteps))
-
-        self.model.decoder_decoder_to(self.temp_device)
-        torch_gc()
 
         return latent_image
 
@@ -322,15 +306,14 @@ class WuerstchenSampler(BaseModelSampler):
             )
 
             # decode vqgan
-            self.model.decoder_vqgan_to(self.train_device)
+            self.model.materialize_only("decoder_vqgan")
 
             latents = decoder_vqgan.config.scale_factor * latent_image
             image_tensor = decoder_vqgan.decode(latents).sample.clamp(0, 1)
             image_array = image_tensor.permute(0, 2, 3, 1).cpu().squeeze().float().numpy()
             image_array = (image_array * 255).round().astype("uint8")
 
-            self.model.decoder_vqgan_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
         return ModelSamplerOutput(
             file_type=FileType.IMAGE,

--- a/modules/modelSampler/ZImageSampler.py
+++ b/modules/modelSampler/ZImageSampler.py
@@ -12,7 +12,6 @@ from modules.util.enum.ImageFormat import ImageFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.enum.NoiseScheduler import NoiseScheduler
 from modules.util.enum.VideoFormat import VideoFormat
-from modules.util.torch_util import torch_gc
 
 import torch
 
@@ -65,7 +64,7 @@ class ZImageSampler(BaseModelSampler):
             #patch_size = 2
 
             # prepare prompt
-            self.model.text_encoder_to(self.train_device)
+            self.model.materialize_only("text_encoder")
 
             batch_size = 2 if cfg_scale > 1.0 else 1
             prompt_embedding = self.model.encode_text(
@@ -73,9 +72,6 @@ class ZImageSampler(BaseModelSampler):
                 batch_size=batch_size,
                 train_device=self.train_device,
             )
-
-            self.model.text_encoder_to(self.temp_device)
-            torch_gc()
 
             # prepare latent image
             latent_image = torch.randn(
@@ -94,7 +90,7 @@ class ZImageSampler(BaseModelSampler):
             if "generator" in set(inspect.signature(noise_scheduler.step).parameters.keys()):
                 extra_step_kwargs["generator"] = generator
 
-            self.model.transformer_to(self.train_device)
+            self.model.materialize_only("transformer")
             for i, timestep in enumerate(tqdm(timesteps, desc="sampling")):
                 latent_model_input = latent_image.unsqueeze(2).to(dtype=self.model.train_dtype.torch_dtype())
                 latent_model_input = torch.cat([latent_model_input] * batch_size)
@@ -118,17 +114,14 @@ class ZImageSampler(BaseModelSampler):
 
                 on_update_progress(i + 1, len(timesteps))
 
-            self.model.transformer_to(self.temp_device)
-            torch_gc()
-            self.model.vae_to(self.train_device)
+            self.model.materialize_only("vae")
 
             latents = self.model.unscale_latents(latent_image)
             image = vae.decode(latents, return_dict=False)[0]
 
             image = image_processor.postprocess(image, output_type='pil')
 
-            self.model.vae_to(self.temp_device)
-            torch_gc()
+            self.model.evict()
 
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,

--- a/modules/modelSampler/ZImageSampler.py
+++ b/modules/modelSampler/ZImageSampler.py
@@ -121,8 +121,6 @@ class ZImageSampler(BaseModelSampler):
 
             image = image_processor.postprocess(image, output_type='pil')
 
-            self.model.evict()
-
             return ModelSamplerOutput(
                 file_type=FileType.IMAGE,
                 data=image[0],

--- a/modules/modelSetup/AnimaFineTuneSetup.py
+++ b/modules/modelSetup/AnimaFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.ANIMA, TrainingMethod.FINE_TUNE)
 class AnimaFineTuneSetup(
     BaseAnimaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: AnimaModel,
@@ -70,10 +56,14 @@ class AnimaFineTuneSetup(
             config: TrainConfig,
     ):
         vae_on_train_device = not config.latent_caching
+        text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.temp_device if config.latent_caching else self.train_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.text_conditioner.eval()

--- a/modules/modelSetup/AnimaLoRASetup.py
+++ b/modules/modelSetup/AnimaLoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.ANIMA, TrainingMethod.LORA)
 class AnimaLoRASetup(
     BaseAnimaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: AnimaModel,
@@ -82,10 +68,14 @@ class AnimaLoRASetup(
             config: TrainConfig,
     ):
         vae_on_train_device = not config.latent_caching
+        text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.temp_device if config.latent_caching else self.train_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.text_conditioner.eval()

--- a/modules/modelSetup/BaseAnimaSetup.py
+++ b/modules/modelSetup/BaseAnimaSetup.py
@@ -166,9 +166,7 @@ class BaseAnimaSetup(
         ).mean()
 
     def prepare_text_caching(self, model: AnimaModel, config: TrainConfig):
-        model.to(self.temp_device)
-
-        model.text_encoder_to(self.train_device)
+        model.materialize_only("text_encoder")
 
         model.eval()
         torch_gc()

--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -18,7 +18,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -265,10 +264,9 @@ class BaseChromaSetup(
 
 
     def prepare_text_caching(self, model: ChromaModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseChromaSetup.py
+++ b/modules/modelSetup/BaseChromaSetup.py
@@ -266,7 +266,5 @@ class BaseChromaSetup(
     def prepare_text_caching(self, model: ChromaModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BaseErnieSetup.py
+++ b/modules/modelSetup/BaseErnieSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -160,7 +159,5 @@ class BaseErnieSetup(
         ).mean()
 
     def prepare_text_caching(self, model: ErnieModel, config: TrainConfig):
-        model.to(self.temp_device)
-        model.text_encoder_to(self.train_device)
+        model.materialize_only("text_encoder")
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseFlux2Setup.py
+++ b/modules/modelSetup/BaseFlux2Setup.py
@@ -18,7 +18,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -182,7 +181,5 @@ class BaseFlux2Setup(
         ).mean()
 
     def prepare_text_caching(self, model: FluxModel, config: TrainConfig):
-        model.to(self.temp_device)
-        model.text_encoder_to(self.train_device)
+        model.materialize_only("text_encoder")
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseFluxSetup.py
+++ b/modules/modelSetup/BaseFluxSetup.py
@@ -326,13 +326,12 @@ class BaseFluxSetup(
         ).mean()
 
     def prepare_text_caching(self, model: FluxModel, config: TrainConfig):
-        model.to(self.temp_device)
-
+        parts = []
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
-
+            parts.append("text_encoder")
         if not config.train_text_encoder_2_or_embedding():
-            model.text_encoder_2_to(self.train_device)
+            parts.append("text_encoder_2")
+        model.materialize_only(*parts)
 
         model.eval()
         torch_gc()

--- a/modules/modelSetup/BaseHiDreamSetup.py
+++ b/modules/modelSetup/BaseHiDreamSetup.py
@@ -19,7 +19,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -411,19 +410,15 @@ class BaseHiDreamSetup(
         ).mean()
 
     def prepare_text_caching(self, model: HiDreamModel, config: TrainConfig):
-        model.to(self.temp_device)
-
+        parts = []
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
-
+            parts.append("text_encoder")
         if not config.train_text_encoder_2_or_embedding():
-            model.text_encoder_2_to(self.train_device)
-
+            parts.append("text_encoder_2")
         if not config.train_text_encoder_3_or_embedding():
-            model.text_encoder_3_to(self.train_device)
-
+            parts.append("text_encoder_3")
         if not config.train_text_encoder_4_or_embedding():
-            model.text_encoder_4_to(self.train_device)
+            parts.append("text_encoder_4")
+        model.materialize_only(*parts)
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseHunyuanVideoSetup.py
+++ b/modules/modelSetup/BaseHunyuanVideoSetup.py
@@ -19,7 +19,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -294,13 +293,11 @@ class BaseHunyuanVideoSetup(
         ).mean()
 
     def prepare_text_caching(self, model: HunyuanVideoModel, config: TrainConfig):
-        model.to(self.temp_device)
-
+        parts = []
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
-
+            parts.append("text_encoder")
         if not config.train_text_encoder_2_or_embedding():
-            model.text_encoder_2_to(self.train_device)
+            parts.append("text_encoder_2")
+        model.materialize_only(*parts)
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseIdeogramSetup.py
+++ b/modules/modelSetup/BaseIdeogramSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -204,7 +203,5 @@ class BaseIdeogramSetup(
         ).mean()
 
     def prepare_text_caching(self, model: IdeogramModel, config: TrainConfig):
-        model.to(self.temp_device)
-        model.text_encoder_to(self.train_device)
+        model.materialize_only("text_encoder")
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseKrea2Setup.py
+++ b/modules/modelSetup/BaseKrea2Setup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -178,10 +177,9 @@ class BaseKrea2Setup(
         ).mean()
 
     def prepare_text_caching(self, model: Krea2Model, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseKrea2Setup.py
+++ b/modules/modelSetup/BaseKrea2Setup.py
@@ -179,7 +179,5 @@ class BaseKrea2Setup(
     def prepare_text_caching(self, model: Krea2Model, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -18,7 +18,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -326,10 +325,9 @@ class BasePixArtAlphaSetup(
         ).mean()
 
     def prepare_text_caching(self, model: PixArtAlphaModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BasePixArtAlphaSetup.py
+++ b/modules/modelSetup/BasePixArtAlphaSetup.py
@@ -327,7 +327,5 @@ class BasePixArtAlphaSetup(
     def prepare_text_caching(self, model: PixArtAlphaModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -16,7 +16,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -177,10 +176,9 @@ class BaseQwenSetup(
         ).mean()
 
     def prepare_text_caching(self, model: QwenModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseQwenSetup.py
+++ b/modules/modelSetup/BaseQwenSetup.py
@@ -178,7 +178,5 @@ class BaseQwenSetup(
     def prepare_text_caching(self, model: QwenModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -18,7 +18,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -246,10 +245,9 @@ class BaseSanaSetup(
         ).mean()
 
     def prepare_text_caching(self, model: SanaModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseSanaSetup.py
+++ b/modules/modelSetup/BaseSanaSetup.py
@@ -247,7 +247,5 @@ class BaseSanaSetup(
     def prepare_text_caching(self, model: SanaModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BaseStableDiffusion3Setup.py
+++ b/modules/modelSetup/BaseStableDiffusion3Setup.py
@@ -19,7 +19,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -346,16 +345,13 @@ class BaseStableDiffusion3Setup(
         ).mean()
 
     def prepare_text_caching(self, model: StableDiffusion3Model, config: TrainConfig):
-        model.to(self.temp_device)
-
+        parts = []
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
-
+            parts.append("text_encoder")
         if not config.train_text_encoder_2_or_embedding():
-            model.text_encoder_2_to(self.train_device)
-
+            parts.append("text_encoder_2")
         if not config.train_text_encoder_3_or_embedding():
-            model.text_encoder_3_to(self.train_device)
+            parts.append("text_encoder_3")
+        model.materialize_only(*parts)
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -19,7 +19,6 @@ from modules.util.config.TrainConfig import TrainConfig
 from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -334,10 +333,11 @@ class BaseStableDiffusionSetup(
         ).mean()
 
     def prepare_text_caching(self, model: StableDiffusionModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
+        if model.depth_estimator is not None:
+            model.depth_estimator.to(self.temp_device)
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseStableDiffusionSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionSetup.py
@@ -335,8 +335,6 @@ class BaseStableDiffusionSetup(
     def prepare_text_caching(self, model: StableDiffusionModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
         if model.depth_estimator is not None:
             model.depth_estimator.to(self.temp_device)
 

--- a/modules/modelSetup/BaseStableDiffusionXLSetup.py
+++ b/modules/modelSetup/BaseStableDiffusionXLSetup.py
@@ -19,7 +19,6 @@ from modules.util.config.TrainConfig import TrainConfig
 from modules.util.conv_util import apply_circular_padding_to_conv2d
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -379,13 +378,11 @@ class BaseStableDiffusionXLSetup(
         ).mean()
 
     def prepare_text_caching(self, model: StableDiffusionXLModel, config: TrainConfig):
-        model.to(self.temp_device)
-
+        parts = []
         if not config.train_text_encoder_or_embedding():
-            model.text_encoder_to(self.train_device)
-
+            parts.append("text_encoder")
         if not config.train_text_encoder_2_or_embedding():
-            model.text_encoder_2_to(self.train_device)
+            parts.append("text_encoder_2")
+        model.materialize_only(*parts)
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -20,7 +20,6 @@ from modules.util.dtype_util import (
     disable_fp16_autocast_context,
 )
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -345,10 +344,9 @@ class BaseWuerstchenSetup(
         ).mean()
 
     def prepare_text_caching(self, model: WuerstchenModel, config: TrainConfig):
-        model.to(self.temp_device)
-
         if not config.train_text_encoder_or_embedding():
-            model.prior_text_encoder_to(self.train_device)
+            model.materialize_only("text_encoder")
+        else:
+            model.evict()
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/BaseWuerstchenSetup.py
+++ b/modules/modelSetup/BaseWuerstchenSetup.py
@@ -346,7 +346,5 @@ class BaseWuerstchenSetup(
     def prepare_text_caching(self, model: WuerstchenModel, config: TrainConfig):
         if not config.train_text_encoder_or_embedding():
             model.materialize_only("text_encoder")
-        else:
-            model.evict()
 
         model.eval()

--- a/modules/modelSetup/BaseZImageSetup.py
+++ b/modules/modelSetup/BaseZImageSetup.py
@@ -17,7 +17,6 @@ from modules.util.checkpointing_util import (
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.dtype_util import create_autocast_context, disable_fp16_autocast_context
 from modules.util.quantization_util import quantize_layers
-from modules.util.torch_util import torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -160,8 +159,6 @@ class BaseZImageSetup(
         ).mean()
 
     def prepare_text_caching(self, model: ZImageModel, config: TrainConfig):
-        model.to(self.temp_device)
-        model.text_encoder_to(self.train_device)
+        model.materialize_only("text_encoder")
 
         model.eval()
-        torch_gc()

--- a/modules/modelSetup/ChromaEmbeddingSetup.py
+++ b/modules/modelSetup/ChromaEmbeddingSetup.py
@@ -9,25 +9,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.CHROMA_1, TrainingMethod.EMBEDDING)
 class ChromaEmbeddingSetup(
     BaseChromaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ChromaModel,
@@ -74,9 +60,12 @@ class ChromaEmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/ChromaFineTuneSetup.py
+++ b/modules/modelSetup/ChromaFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.CHROMA_1, TrainingMethod.FINE_TUNE)
 class ChromaFineTuneSetup(
     BaseChromaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ChromaModel,
@@ -87,9 +73,12 @@ class ChromaFineTuneSetup(
             config.train_text_encoder_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/ChromaLoRASetup.py
+++ b/modules/modelSetup/ChromaLoRASetup.py
@@ -11,25 +11,11 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.CHROMA_1, TrainingMethod.LORA)
 class ChromaLoRASetup(
     BaseChromaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ChromaModel,
@@ -114,9 +100,12 @@ class ChromaLoRASetup(
             config.train_text_encoder_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/ErnieFineTuneSetup.py
+++ b/modules/modelSetup/ErnieFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.ERNIE, TrainingMethod.FINE_TUNE)
 class ErnieFineTuneSetup(
     BaseErnieSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ErnieModel,
@@ -67,9 +53,12 @@ class ErnieFineTuneSetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/ErnieLoRASetup.py
+++ b/modules/modelSetup/ErnieLoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.ERNIE, TrainingMethod.LORA)
 class ErnieLoRASetup(
     BaseErnieSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ErnieModel,
@@ -77,9 +63,12 @@ class ErnieLoRASetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/Flux2FineTuneSetup.py
+++ b/modules/modelSetup/Flux2FineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.FLUX_2, TrainingMethod.FINE_TUNE)
 class Flux2FineTuneSetup(
     BaseFlux2Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: Flux2Model,
@@ -67,9 +53,12 @@ class Flux2FineTuneSetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/Flux2LoRASetup.py
+++ b/modules/modelSetup/Flux2LoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.FLUX_2, TrainingMethod.LORA)
 class Flux2LoRASetup(
     BaseFlux2Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: Flux2Model,
@@ -80,9 +66,12 @@ class Flux2LoRASetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/FluxEmbeddingSetup.py
+++ b/modules/modelSetup/FluxEmbeddingSetup.py
@@ -9,26 +9,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.FLUX_DEV_1, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.FLUX_FILL_DEV_1, TrainingMethod.EMBEDDING)
 class FluxEmbeddingSetup(
     BaseFluxSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: FluxModel,
@@ -87,10 +73,14 @@ class FluxEmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.text_encoder_2_to(self.train_device if config.text_encoder_2.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if config.text_encoder_2.train_embedding:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1 is not None:
             model.text_encoder_1.eval()

--- a/modules/modelSetup/FluxFineTuneSetup.py
+++ b/modules/modelSetup/FluxFineTuneSetup.py
@@ -10,26 +10,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.FLUX_DEV_1, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.FLUX_FILL_DEV_1, TrainingMethod.FINE_TUNE)
 class FluxFineTuneSetup(
     BaseFluxSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: FluxModel,
@@ -103,10 +89,14 @@ class FluxFineTuneSetup(
             config.train_text_encoder_2_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/FluxLoRASetup.py
+++ b/modules/modelSetup/FluxLoRASetup.py
@@ -11,26 +11,12 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.FLUX_DEV_1, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.FLUX_FILL_DEV_1, TrainingMethod.LORA)
 class FluxLoRASetup(
     BaseFluxSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: FluxModel,
@@ -146,10 +132,14 @@ class FluxLoRASetup(
             config.train_text_encoder_2_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/HiDreamEmbeddingSetup.py
+++ b/modules/modelSetup/HiDreamEmbeddingSetup.py
@@ -9,25 +9,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.HI_DREAM_FULL, TrainingMethod.EMBEDDING)
 class HiDreamEmbeddingSetup(
     BaseHiDreamSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HiDreamModel,
@@ -106,12 +92,18 @@ class HiDreamEmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.text_encoder_2_to(self.train_device if config.text_encoder_2.train_embedding else self.temp_device)
-        model.text_encoder_3_to(self.train_device if config.text_encoder_3.train_embedding else self.temp_device)
-        model.text_encoder_4_to(self.train_device if config.text_encoder_4.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if config.text_encoder_2.train_embedding:
+            parts.append("text_encoder_2")
+        if config.text_encoder_3.train_embedding:
+            parts.append("text_encoder_3")
+        if config.text_encoder_4.train_embedding:
+            parts.append("text_encoder_4")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1 is not None:
             model.text_encoder_1.eval()

--- a/modules/modelSetup/HiDreamFineTuneSetup.py
+++ b/modules/modelSetup/HiDreamFineTuneSetup.py
@@ -12,25 +12,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.HI_DREAM_FULL, TrainingMethod.FINE_TUNE)
 class HiDreamFineTuneSetup(
     BaseHiDreamSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HiDreamModel,
@@ -137,12 +123,18 @@ class HiDreamFineTuneSetup(
             config.train_text_encoder_4_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.text_encoder_3_to(self.train_device if text_encoder_3_on_train_device else self.temp_device)
-        model.text_encoder_4_to(self.train_device if text_encoder_4_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if text_encoder_3_on_train_device:
+            parts.append("text_encoder_3")
+        if text_encoder_4_on_train_device:
+            parts.append("text_encoder_4")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/HiDreamLoRASetup.py
+++ b/modules/modelSetup/HiDreamLoRASetup.py
@@ -13,25 +13,11 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.HI_DREAM_FULL, TrainingMethod.LORA)
 class HiDreamLoRASetup(
     BaseHiDreamSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HiDreamModel,
@@ -209,12 +195,18 @@ class HiDreamLoRASetup(
             config.train_text_encoder_4_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.text_encoder_3_to(self.train_device if text_encoder_3_on_train_device else self.temp_device)
-        model.text_encoder_4_to(self.train_device if text_encoder_4_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if text_encoder_3_on_train_device:
+            parts.append("text_encoder_3")
+        if text_encoder_4_on_train_device:
+            parts.append("text_encoder_4")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/HunyuanVideoEmbeddingSetup.py
+++ b/modules/modelSetup/HunyuanVideoEmbeddingSetup.py
@@ -9,25 +9,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.HUNYUAN_VIDEO, TrainingMethod.EMBEDDING)
 class HunyuanVideoEmbeddingSetup(
     BaseHunyuanVideoSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HunyuanVideoModel,
@@ -86,10 +72,14 @@ class HunyuanVideoEmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.text_encoder_2_to(self.train_device if config.text_encoder_2.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if config.text_encoder_2.train_embedding:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1 is not None:
             model.text_encoder_1.eval()

--- a/modules/modelSetup/HunyuanVideoFineTuneSetup.py
+++ b/modules/modelSetup/HunyuanVideoFineTuneSetup.py
@@ -17,18 +17,6 @@ import torch
 class HunyuanVideoFineTuneSetup(
     BaseHunyuanVideoSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HunyuanVideoModel,
@@ -103,10 +91,14 @@ class HunyuanVideoFineTuneSetup(
             config.train_text_encoder_2_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/HunyuanVideoLoRASetup.py
+++ b/modules/modelSetup/HunyuanVideoLoRASetup.py
@@ -13,25 +13,11 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.HUNYUAN_VIDEO, TrainingMethod.LORA)
 class HunyuanVideoLoRASetup(
     BaseHunyuanVideoSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: HunyuanVideoModel,
@@ -150,10 +136,14 @@ class HunyuanVideoLoRASetup(
             config.train_text_encoder_2_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/IdeogramFineTuneSetup.py
+++ b/modules/modelSetup/IdeogramFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.IDEOGRAM_4, TrainingMethod.FINE_TUNE)
 class IdeogramFineTuneSetup(
     BaseIdeogramSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: IdeogramModel,
@@ -71,11 +57,14 @@ class IdeogramFineTuneSetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
-        # the unconditional transformer is only needed for sampling; keep it off the train device during training
-        model.unconditional_transformer_to(self.temp_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        # the unconditional transformer is only needed for sampling; materialize_only() evicts it as it's
+        # not in parts, keeping it off the train device during training
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/IdeogramLoRASetup.py
+++ b/modules/modelSetup/IdeogramLoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.IDEOGRAM_4, TrainingMethod.LORA)
 class IdeogramLoRASetup(
     BaseIdeogramSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: IdeogramModel,
@@ -80,11 +66,14 @@ class IdeogramLoRASetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
-        # the unconditional transformer is only needed for sampling; keep it off the train device during training
-        model.unconditional_transformer_to(self.temp_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        # the unconditional transformer is only needed for sampling; materialize_only() evicts it as it's
+        # not in parts, keeping it off the train device during training
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/Krea2FineTuneSetup.py
+++ b/modules/modelSetup/Krea2FineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.KREA_2, TrainingMethod.FINE_TUNE)
 class Krea2FineTuneSetup(
     BaseKrea2Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: Krea2Model,
@@ -73,9 +59,12 @@ class Krea2FineTuneSetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/Krea2LoRASetup.py
+++ b/modules/modelSetup/Krea2LoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.KREA_2, TrainingMethod.LORA)
 class Krea2LoRASetup(
     BaseKrea2Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: Krea2Model,
@@ -83,9 +69,12 @@ class Krea2LoRASetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/PixArtAlphaEmbeddingSetup.py
+++ b/modules/modelSetup/PixArtAlphaEmbeddingSetup.py
@@ -9,26 +9,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.PIXART_ALPHA, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.PIXART_SIGMA, TrainingMethod.EMBEDDING)
 class PixArtAlphaEmbeddingSetup(
     BasePixArtAlphaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: PixArtAlphaModel,
@@ -74,9 +60,10 @@ class PixArtAlphaEmbeddingSetup(
     ):
         vae_on_train_device = self.debug_mode
 
-        model.text_encoder_to(self.train_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer", "text_encoder"]
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/PixArtAlphaFineTuneSetup.py
+++ b/modules/modelSetup/PixArtAlphaFineTuneSetup.py
@@ -10,26 +10,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.PIXART_ALPHA, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.PIXART_SIGMA, TrainingMethod.FINE_TUNE)
 class PixArtAlphaFineTuneSetup(
     BasePixArtAlphaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: PixArtAlphaModel,
@@ -94,9 +80,12 @@ class PixArtAlphaFineTuneSetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/PixArtAlphaLoRASetup.py
+++ b/modules/modelSetup/PixArtAlphaLoRASetup.py
@@ -11,26 +11,12 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.PIXART_ALPHA, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.PIXART_SIGMA, TrainingMethod.LORA)
 class PixArtAlphaLoRASetup(
     BasePixArtAlphaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: PixArtAlphaModel,
@@ -115,9 +101,12 @@ class PixArtAlphaLoRASetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/QwenFineTuneSetup.py
+++ b/modules/modelSetup/QwenFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.QWEN, TrainingMethod.FINE_TUNE)
 class QwenFineTuneSetup(
     BaseQwenSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: QwenModel,
@@ -74,9 +60,12 @@ class QwenFineTuneSetup(
             config.train_text_encoder_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/QwenLoRASetup.py
+++ b/modules/modelSetup/QwenLoRASetup.py
@@ -11,25 +11,11 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.QWEN, TrainingMethod.LORA)
 class QwenLoRASetup(
     BaseQwenSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: QwenModel,
@@ -101,9 +87,12 @@ class QwenLoRASetup(
             config.train_text_encoder_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/SanaEmbeddingSetup.py
+++ b/modules/modelSetup/SanaEmbeddingSetup.py
@@ -9,25 +9,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.SANA, TrainingMethod.EMBEDDING)
 class SanaEmbeddingSetup(
     BaseSanaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: SanaModel,
@@ -73,9 +59,10 @@ class SanaEmbeddingSetup(
     ):
         vae_on_train_device = self.debug_mode
 
-        model.text_encoder_to(self.train_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer", "text_encoder"]
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/SanaFineTuneSetup.py
+++ b/modules/modelSetup/SanaFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.SANA, TrainingMethod.FINE_TUNE)
 class SanaFineTuneSetup(
     BaseSanaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: SanaModel,
@@ -87,9 +73,12 @@ class SanaFineTuneSetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/SanaLoRASetup.py
+++ b/modules/modelSetup/SanaLoRASetup.py
@@ -11,25 +11,11 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.SANA, TrainingMethod.LORA)
 class SanaLoRASetup(
     BaseSanaSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: SanaModel,
@@ -113,9 +99,12 @@ class SanaLoRASetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/StableDiffusion3EmbeddingSetup.py
+++ b/modules/modelSetup/StableDiffusion3EmbeddingSetup.py
@@ -9,26 +9,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_3, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_35, TrainingMethod.EMBEDDING)
 class StableDiffusion3EmbeddingSetup(
     BaseStableDiffusion3Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusion3Model,
@@ -97,11 +83,16 @@ class StableDiffusion3EmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.text_encoder_2_to(self.train_device if config.text_encoder_2.train_embedding else self.temp_device)
-        model.text_encoder_3_to(self.train_device if config.text_encoder_3.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if config.text_encoder_2.train_embedding:
+            parts.append("text_encoder_2")
+        if config.text_encoder_3.train_embedding:
+            parts.append("text_encoder_3")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1 is not None:
             model.text_encoder_1.eval()

--- a/modules/modelSetup/StableDiffusion3FineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusion3FineTuneSetup.py
@@ -10,26 +10,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_3, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_35, TrainingMethod.FINE_TUNE)
 class StableDiffusion3FineTuneSetup(
     BaseStableDiffusion3Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusion3Model,
@@ -117,11 +103,16 @@ class StableDiffusion3FineTuneSetup(
             config.train_text_encoder_3_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.text_encoder_3_to(self.train_device if text_encoder_3_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if text_encoder_3_on_train_device:
+            parts.append("text_encoder_3")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/StableDiffusion3LoRASetup.py
+++ b/modules/modelSetup/StableDiffusion3LoRASetup.py
@@ -11,26 +11,12 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_3, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_35, TrainingMethod.LORA)
 class StableDiffusion3LoRASetup(
     BaseStableDiffusion3Setup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusion3Model,
@@ -176,11 +162,16 @@ class StableDiffusion3LoRASetup(
             config.train_text_encoder_3_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.text_encoder_3_to(self.train_device if text_encoder_3_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if text_encoder_3_on_train_device:
+            parts.append("text_encoder_3")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if model.text_encoder_1:
             if config.text_encoder.train:

--- a/modules/modelSetup/StableDiffusionEmbeddingSetup.py
+++ b/modules/modelSetup/StableDiffusionEmbeddingSetup.py
@@ -9,8 +9,6 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15_INPAINTING, TrainingMethod.EMBEDDING)
@@ -23,18 +21,6 @@ import torch
 class StableDiffusionEmbeddingSetup(
     BaseStableDiffusionSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionModel,
@@ -84,10 +70,12 @@ class StableDiffusionEmbeddingSetup(
     ):
         vae_on_train_device = self.debug_mode or not config.latent_caching
 
-        model.text_encoder_to(self.train_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
-        model.depth_estimator_to(self.temp_device)
+        parts = ["unet", "text_encoder"]
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
+        if model.depth_estimator is not None:
+            model.depth_estimator.to(self.temp_device)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/StableDiffusionFineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusionFineTuneSetup.py
@@ -10,8 +10,6 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15_INPAINTING, TrainingMethod.FINE_TUNE)
@@ -24,18 +22,6 @@ import torch
 class StableDiffusionFineTuneSetup(
     BaseStableDiffusionSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionModel,
@@ -102,10 +88,14 @@ class StableDiffusionFineTuneSetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
-        model.depth_estimator_to(self.temp_device)
+        parts = ["unet"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
+        if model.depth_estimator is not None:
+            model.depth_estimator.to(self.temp_device)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/StableDiffusionFineTuneVaeSetup.py
+++ b/modules/modelSetup/StableDiffusionFineTuneVaeSetup.py
@@ -23,18 +23,6 @@ import torch
 class StableDiffusionFineTuneVaeSetup(
     BaseStableDiffusionSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionModel,
@@ -67,9 +55,7 @@ class StableDiffusionFineTuneVaeSetup(
             model: StableDiffusionModel,
             config: TrainConfig,
     ):
-        model.text_encoder.to(self.temp_device)
-        model.vae.to(self.train_device)
-        model.unet.to(self.temp_device)
+        model.materialize_only("vae")
         if model.depth_estimator is not None:
             model.depth_estimator.to(self.temp_device)
 

--- a/modules/modelSetup/StableDiffusionLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionLoRASetup.py
@@ -11,8 +11,6 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_15_INPAINTING, TrainingMethod.LORA)
@@ -25,18 +23,6 @@ import torch
 class StableDiffusionLoRASetup(
     BaseStableDiffusionSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionModel,
@@ -125,10 +111,14 @@ class StableDiffusionLoRASetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
-        model.depth_estimator_to(self.temp_device)
+        parts = ["unet"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
+        if model.depth_estimator is not None:
+            model.depth_estimator.to(self.temp_device)
 
         if config.text_encoder.train:
             model.text_encoder.train()

--- a/modules/modelSetup/StableDiffusionXLEmbeddingSetup.py
+++ b/modules/modelSetup/StableDiffusionXLEmbeddingSetup.py
@@ -9,26 +9,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING, TrainingMethod.EMBEDDING)
 class StableDiffusionXLEmbeddingSetup(
     BaseStableDiffusionXLSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionXLModel,
@@ -87,10 +73,14 @@ class StableDiffusionXLEmbeddingSetup(
     ):
         vae_on_train_device = not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if config.text_encoder.train_embedding else self.temp_device)
-        model.text_encoder_2_to(self.train_device if config.text_encoder_2.train_embedding else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
+        parts = ["unet"]
+        if config.text_encoder.train_embedding:
+            parts.append("text_encoder")
+        if config.text_encoder_2.train_embedding:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder_1.eval()
         model.text_encoder_2.eval()

--- a/modules/modelSetup/StableDiffusionXLFineTuneSetup.py
+++ b/modules/modelSetup/StableDiffusionXLFineTuneSetup.py
@@ -10,26 +10,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING, TrainingMethod.FINE_TUNE)
 class StableDiffusionXLFineTuneSetup(
     BaseStableDiffusionXLSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionXLModel,
@@ -111,10 +97,14 @@ class StableDiffusionXLFineTuneSetup(
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
+        parts = ["unet"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder_1.train()

--- a/modules/modelSetup/StableDiffusionXLLoRASetup.py
+++ b/modules/modelSetup/StableDiffusionXLLoRASetup.py
@@ -11,26 +11,12 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.STABLE_DIFFUSION_XL_10_BASE_INPAINTING, TrainingMethod.LORA)
 class StableDiffusionXLLoRASetup(
     BaseStableDiffusionXLSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: StableDiffusionXLModel,
@@ -142,10 +128,14 @@ class StableDiffusionXLLoRASetup(
             config.train_text_encoder_2_or_embedding() \
             or not config.latent_caching
 
-        model.text_encoder_1_to(self.train_device if text_encoder_1_on_train_device else self.temp_device)
-        model.text_encoder_2_to(self.train_device if text_encoder_2_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.unet_to(self.train_device)
+        parts = ["unet"]
+        if text_encoder_1_on_train_device:
+            parts.append("text_encoder")
+        if text_encoder_2_on_train_device:
+            parts.append("text_encoder_2")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         if config.text_encoder.train:
             model.text_encoder_1.train()

--- a/modules/modelSetup/WuerstchenEmbeddingSetup.py
+++ b/modules/modelSetup/WuerstchenEmbeddingSetup.py
@@ -9,26 +9,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.WUERSTCHEN_2, TrainingMethod.EMBEDDING)
 @factory.register(BaseModelSetup, ModelType.STABLE_CASCADE_1, TrainingMethod.EMBEDDING)
 class WuerstchenEmbeddingSetup(
     BaseWuerstchenSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: WuerstchenModel,
@@ -78,14 +64,12 @@ class WuerstchenEmbeddingSetup(
     ):
         effnet_on_train_device = not config.latent_caching
 
-        if model.model_type.is_wuerstchen_v2():
-            model.decoder_text_encoder_to(self.temp_device)
-        model.decoder_decoder_to(self.temp_device)
-        model.decoder_vqgan_to(self.temp_device)
-        model.effnet_encoder_to(self.train_device if effnet_on_train_device else self.temp_device)
-
-        model.prior_text_encoder_to(self.train_device)
-        model.prior_prior_to(self.train_device)
+        # decoder/decoder_text_encoder/decoder_vqgan are never needed during prior training; materialize_only()
+        # evicts them (decoder_text_encoder only exists in model_parts() for Wuerstchen v2, not Stable Cascade)
+        parts = ["prior", "text_encoder"]
+        if effnet_on_train_device:
+            parts.append("effnet_encoder")
+        model.materialize_only(*parts)
 
         if model.model_type.is_wuerstchen_v2():
             model.decoder_text_encoder.eval()

--- a/modules/modelSetup/WuerstchenFineTuneSetup.py
+++ b/modules/modelSetup/WuerstchenFineTuneSetup.py
@@ -10,26 +10,12 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.WUERSTCHEN_2, TrainingMethod.FINE_TUNE)
 @factory.register(BaseModelSetup, ModelType.STABLE_CASCADE_1, TrainingMethod.FINE_TUNE)
 class WuerstchenFineTuneSetup(
     BaseWuerstchenSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: WuerstchenModel,
@@ -86,20 +72,19 @@ class WuerstchenFineTuneSetup(
             config: TrainConfig,
     ):
         effnet_on_train_device = not config.latent_caching
-
-        if model.model_type.is_wuerstchen_v2():
-            model.decoder_text_encoder_to(self.temp_device)
-        model.decoder_decoder_to(self.temp_device)
-        model.decoder_vqgan_to(self.temp_device)
-        model.effnet_encoder_to(self.train_device if effnet_on_train_device else self.temp_device)
-
         text_encoder_on_train_device = \
             config.text_encoder.train \
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.prior_text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.prior_prior_to(self.train_device)
+        # decoder/decoder_text_encoder/decoder_vqgan are never needed during prior training; materialize_only()
+        # evicts them (decoder_text_encoder only exists in model_parts() for Wuerstchen v2, not Stable Cascade)
+        parts = ["prior"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if effnet_on_train_device:
+            parts.append("effnet_encoder")
+        model.materialize_only(*parts)
 
         if model.model_type.is_wuerstchen_v2():
             model.decoder_text_encoder.eval()

--- a/modules/modelSetup/WuerstchenLoRASetup.py
+++ b/modules/modelSetup/WuerstchenLoRASetup.py
@@ -11,26 +11,12 @@ from modules.util.optimizer_util import init_model_parameters
 from modules.util.torch_util import state_dict_has_prefix
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.WUERSTCHEN_2, TrainingMethod.LORA)
 @factory.register(BaseModelSetup, ModelType.STABLE_CASCADE_1, TrainingMethod.LORA)
 class WuerstchenLoRASetup(
     BaseWuerstchenSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: WuerstchenModel,
@@ -113,20 +99,19 @@ class WuerstchenLoRASetup(
             config: TrainConfig,
     ):
         effnet_on_train_device = not config.latent_caching
-
-        if model.model_type.is_wuerstchen_v2():
-            model.decoder_text_encoder_to(self.temp_device)
-        model.decoder_decoder_to(self.temp_device)
-        model.decoder_vqgan_to(self.temp_device)
-        model.effnet_encoder_to(self.train_device if effnet_on_train_device else self.temp_device)
-
         text_encoder_on_train_device = \
             config.text_encoder.train \
             or config.train_any_embedding() \
             or not config.latent_caching
 
-        model.prior_text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.prior_prior_to(self.train_device)
+        # decoder/decoder_text_encoder/decoder_vqgan are never needed during prior training; materialize_only()
+        # evicts them (decoder_text_encoder only exists in model_parts() for Wuerstchen v2, not Stable Cascade)
+        parts = ["prior"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if effnet_on_train_device:
+            parts.append("effnet_encoder")
+        model.materialize_only(*parts)
 
         if model.model_type.is_wuerstchen_v2():
             model.decoder_text_encoder.eval()

--- a/modules/modelSetup/ZImageFineTuneSetup.py
+++ b/modules/modelSetup/ZImageFineTuneSetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.Z_IMAGE, TrainingMethod.FINE_TUNE)
 class ZImageFineTuneSetup(
     BaseZImageSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ZImageModel,
@@ -67,9 +53,12 @@ class ZImageFineTuneSetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/modelSetup/ZImageLoRASetup.py
+++ b/modules/modelSetup/ZImageLoRASetup.py
@@ -10,25 +10,11 @@ from modules.util.NamedParameterGroup import NamedParameterGroupCollection
 from modules.util.optimizer_util import init_model_parameters
 from modules.util.TrainProgress import TrainProgress
 
-import torch
-
 
 @factory.register(BaseModelSetup, ModelType.Z_IMAGE, TrainingMethod.LORA)
 class ZImageLoRASetup(
     BaseZImageSetup,
 ):
-    def __init__(
-            self,
-            train_device: torch.device,
-            temp_device: torch.device,
-            debug_mode: bool,
-    ):
-        super().__init__(
-            train_device=train_device,
-            temp_device=temp_device,
-            debug_mode=debug_mode,
-        )
-
     def create_parameters(
             self,
             model: ZImageModel,
@@ -80,9 +66,12 @@ class ZImageLoRASetup(
         vae_on_train_device = not config.latent_caching
         text_encoder_on_train_device = not config.latent_caching
 
-        model.text_encoder_to(self.train_device if text_encoder_on_train_device else self.temp_device)
-        model.vae_to(self.train_device if vae_on_train_device else self.temp_device)
-        model.transformer_to(self.train_device)
+        parts = ["transformer"]
+        if text_encoder_on_train_device:
+            parts.append("text_encoder")
+        if vae_on_train_device:
+            parts.append("vae")
+        model.materialize_only(*parts)
 
         model.text_encoder.eval()
         model.vae.eval()

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -139,9 +139,8 @@ class GenericTrainer(BaseTrainer):
         self.model_setup.setup_optimizations(self.model, self.config)
         self.model_setup.setup_train_device(self.model, self.config)
         self.model_setup.setup_model(self.model, self.config)
-        self.model.to(self.temp_device)
+        self.model.evict()
         self.model.eval()
-        torch_gc()
 
         self.callbacks.on_update_status("creating the data loader/caching")
 
@@ -253,7 +252,7 @@ class GenericTrainer(BaseTrainer):
                 on_sample = on_sample_custom if is_custom_sample else on_sample_default
                 on_update_progress = self.callbacks.on_update_sample_custom_progress if is_custom_sample else self.callbacks.on_update_sample_default_progress
 
-                self.model.to(self.temp_device)
+                self.model.evict()
                 self.model.eval()
 
                 sample_config = copy.copy(sample_config)
@@ -717,7 +716,7 @@ class GenericTrainer(BaseTrainer):
                     backup = self.commands.get_and_reset_backup_command()
                     save = self.commands.get_and_reset_save_command()
                     if multi.is_master() and (backup or save):
-                        self.model.to(self.temp_device)
+                        self.model.evict()
                         if backup:
                             self.__backup(train_progress, True, step_tqdm.write)
                         if save:
@@ -842,7 +841,7 @@ class GenericTrainer(BaseTrainer):
 
     def end(self):
         if self.one_step_trained:
-            self.model.to(self.temp_device)
+            self.model.evict()
 
             if self.config.backup_before_save and multi.is_master():
                 self.__backup(self.model.train_progress)
@@ -875,7 +874,7 @@ class GenericTrainer(BaseTrainer):
                 )
 
         if self.model is not None:
-            self.model.to(self.temp_device)
+            self.model.evict()
 
         if multi.is_master():
             self.tensorboard.close()

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -139,7 +139,6 @@ class GenericTrainer(BaseTrainer):
         self.model_setup.setup_optimizations(self.model, self.config)
         self.model_setup.setup_train_device(self.model, self.config)
         self.model_setup.setup_model(self.model, self.config)
-        self.model.evict()
         self.model.eval()
 
         self.callbacks.on_update_status("creating the data loader/caching")
@@ -252,7 +251,6 @@ class GenericTrainer(BaseTrainer):
                 on_sample = on_sample_custom if is_custom_sample else on_sample_default
                 on_update_progress = self.callbacks.on_update_sample_custom_progress if is_custom_sample else self.callbacks.on_update_sample_default_progress
 
-                self.model.evict()
                 self.model.eval()
 
                 sample_config = copy.copy(sample_config)

--- a/modules/ui/SampleWindowController.py
+++ b/modules/ui/SampleWindowController.py
@@ -96,7 +96,7 @@ class SampleWindowController:
         model_setup.setup_optimizations(model, self.initial_train_config)
         model_setup.setup_train_device(model, self.initial_train_config)
         model_setup.setup_model(model, self.initial_train_config)
-        model.to(torch.device(self.initial_train_config.temp_device))
+        model.evict()
 
         return model
 

--- a/modules/ui/SampleWindowController.py
+++ b/modules/ui/SampleWindowController.py
@@ -96,7 +96,6 @@ class SampleWindowController:
         model_setup.setup_optimizations(model, self.initial_train_config)
         model_setup.setup_train_device(model, self.initial_train_config)
         model_setup.setup_model(model, self.initial_train_config)
-        model.evict()
 
         return model
 
@@ -145,3 +144,7 @@ class SampleWindowController:
                 on_sample=on_sample,
                 on_update_progress=on_update_progress,
             )
+
+            # the sampler materializes parts on demand and no longer self-evicts;
+            # release VRAM now that this standalone sample window is idle again
+            self.model.evict()

--- a/modules/ui/SampleWindowController.py
+++ b/modules/ui/SampleWindowController.py
@@ -135,16 +135,17 @@ class SampleWindowController:
 
             self.model.eval()
 
-            self.model_sampler.sample(
-                sample_config=sample,
-                destination=sample_path,
-                image_format=self.current_train_config.sample_image_format,
-                video_format=self.current_train_config.sample_video_format,
-                audio_format=self.current_train_config.sample_audio_format,
-                on_sample=on_sample,
-                on_update_progress=on_update_progress,
-            )
-
-            # the sampler materializes parts on demand and no longer self-evicts;
-            # release VRAM now that this standalone sample window is idle again
-            self.model.evict()
+            try:
+                self.model_sampler.sample(
+                    sample_config=sample,
+                    destination=sample_path,
+                    image_format=self.current_train_config.sample_image_format,
+                    video_format=self.current_train_config.sample_video_format,
+                    audio_format=self.current_train_config.sample_audio_format,
+                    on_sample=on_sample,
+                    on_update_progress=on_update_progress,
+                )
+            finally:
+                # the sampler materializes parts on demand; release VRAM now that this
+                # standalone sample window is idle again
+                self.model.evict()

--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -618,63 +618,69 @@ class LayerOffloadConductor:
     def offload_activated(self) -> bool:
         return self.__offload_activations or self.__offload_layers
 
-    def to(self, device: torch.device):
+    def evict(self):
         torch_gc()
 
         self.__wait_all_layer_transfers()
         self.__wait_all_activation_transfers()
 
-        if device_equals(device, self.__temp_device):
-            log("to temp device")
+        log("to temp device")
 
-            # deallocate the cache before to take advantage of the gc
-            self.__train_device_layer_allocator.deallocate_cache()
-            self.__temp_device_layer_allocator.deallocate_cache()
-            self.__temp_device_activations_allocator.deallocate_cache()
+        # deallocate the cache before to take advantage of the gc
+        self.__train_device_layer_allocator.deallocate_cache()
+        self.__temp_device_layer_allocator.deallocate_cache()
+        self.__temp_device_activations_allocator.deallocate_cache()
 
-            self.__module_to_device_except_layers(self.__temp_device)
-            for layer_index, layer in enumerate(self.__layers):
-                self.__layers[layer_index].to(self.__temp_device)
-                for module in layer.modules():
-                    offload_quantized(module, self.__temp_device, allocator=clone_tensor_allocator)
-                self.__layer_device_map[layer_index] = None
+        self.__module_to_device_except_layers(self.__temp_device)
+        for layer_index, layer in enumerate(self.__layers):
+            self.__layers[layer_index].to(self.__temp_device)
+            for module in layer.modules():
+                offload_quantized(module, self.__temp_device, allocator=clone_tensor_allocator)
+            self.__layer_device_map[layer_index] = None
 
-            self.__is_active = False
+        self.__is_active = False
 
-        elif device_equals(device, self.__train_device):
-            log("to train device")
+        torch_gc()
 
-            self.__offload_strategy = LayerOffloadStrategy(self.__layers, self.__layer_offload_fraction)
+    def materialize(self):
+        torch_gc()
 
-            self.__train_device_layer_allocator.allocate_cache(
-                self.__layers, self.__offload_strategy.max_loaded_bytes)
-            self.__temp_device_layer_allocator.allocate_cache(
-                self.__layers, self.__offload_strategy.max_offloaded_bytes)
-            self.__module_to_device_except_layers(self.__train_device)
+        self.__wait_all_layer_transfers()
+        self.__wait_all_activation_transfers()
 
-            # move all layers to the train device, then move offloadable tensors back to the temp device
-            for layer_index, layer in enumerate(self.__layers):
-                if self.__layer_device_map[layer_index] is None:
-                    log(f"layer {layer_index} to train device")
-                    layer.to(self.__train_device)
+        log("to train device")
 
-                    if layer_index in self.__offload_strategy.initial_loaded_layers:
-                        allocator = self.__train_device_layer_allocator.get_allocator(
-                            layer_index, allocate_forward=True)
-                        for module in layer.modules():
-                            offload_quantized(module, self.__train_device, allocator=allocator.allocate_like)
-                        self.__layer_device_map[layer_index] = self.__train_device
-                    else:
-                        allocator = self.__temp_device_layer_allocator.get_allocator(layer_index, allocate_forward=True)
-                        for module in layer.modules():
-                            offload_quantized(module, self.__temp_device, allocator=allocator.allocate_like)
-                        self.__layer_device_map[layer_index] = self.__temp_device
+        self.__offload_strategy = LayerOffloadStrategy(self.__layers, self.__layer_offload_fraction)
 
-                    if self.__async_transfer:
-                        event = SyncEvent(self.__train_stream.record_event(), f"train on {self.__train_device}")
-                        self.__layer_train_event_map[layer_index] = event
+        self.__train_device_layer_allocator.allocate_cache(
+            self.__layers, self.__offload_strategy.max_loaded_bytes)
+        self.__temp_device_layer_allocator.allocate_cache(
+            self.__layers, self.__offload_strategy.max_offloaded_bytes)
+        self.__module_to_device_except_layers(self.__train_device)
 
-            self.__is_active = True
+        # move all layers to the train device, then move offloadable tensors back to the temp device
+        for layer_index, layer in enumerate(self.__layers):
+            if self.__layer_device_map[layer_index] is None:
+                log(f"layer {layer_index} to train device")
+                layer.to(self.__train_device)
+
+                if layer_index in self.__offload_strategy.initial_loaded_layers:
+                    allocator = self.__train_device_layer_allocator.get_allocator(
+                        layer_index, allocate_forward=True)
+                    for module in layer.modules():
+                        offload_quantized(module, self.__train_device, allocator=allocator.allocate_like)
+                    self.__layer_device_map[layer_index] = self.__train_device
+                else:
+                    allocator = self.__temp_device_layer_allocator.get_allocator(layer_index, allocate_forward=True)
+                    for module in layer.modules():
+                        offload_quantized(module, self.__temp_device, allocator=allocator.allocate_like)
+                    self.__layer_device_map[layer_index] = self.__temp_device
+
+                if self.__async_transfer:
+                    event = SyncEvent(self.__train_stream.record_event(), f"train on {self.__train_device}")
+                    self.__layer_train_event_map[layer_index] = event
+
+        self.__is_active = True
 
         torch_gc()
 

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -13,6 +13,8 @@ from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.ModelNames import ModelNames
 from modules.util.torch_util import default_device
 
+import torch
+
 
 def main():
     args = SampleArgs.parse_args()
@@ -22,9 +24,13 @@ def main():
     train_config = TrainConfig.default_values()
     train_config.optimizer.optimizer = None
     train_config.ema = EMAMode.OFF
+    train_config.train_device = str(device)
+    train_config.temp_device = "cpu"
+
+    temp_device = torch.device(train_config.temp_device)
 
     model_loader = create.create_model_loader(args.model_type, training_method=training_method)
-    model_setup = create.create_model_setup(args.model_type, device, device, training_method=training_method)
+    model_setup = create.create_model_setup(args.model_type, device, temp_device, training_method=training_method)
 
     print("Loading model " + args.base_model_name)
     weight_dtypes = args.weight_dtypes()
@@ -32,19 +38,19 @@ def main():
     model = model_loader.load(
         model_type=args.model_type,
         model_names=ModelNames(base_model=args.base_model_name),
-        weight_dtypes=weight_dtypes
+        weight_dtypes=weight_dtypes,
+        quantization=train_config.quantization,
     )
     model.train_config = train_config
 
     model_setup.setup_model(model, train_config)
 
-    model.to(device)
     model.eval()
     model.train_dtype = args.weight_dtype
 
     model_sampler = create.create_model_sampler(
         train_device=device,
-        temp_device=device,
+        temp_device=temp_device,
         model=model,
         model_type=args.model_type,
     )


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

Replaces the per-model `{part}_to(device)` methods across all model classes, plus scattered call sites in dataLoader/modelSetup/modelSampler/GenericTrainer, with generic BaseModel methods driven by the existing ModelType.model_parts() registry


Doesn't do anything except refactor, but it's the basis to implement future functionality without duplicating it for each model

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
