### PR TITLE
workaround for pytorch autotuning issue

### DIFF
--- a/modules/util/triton_mm_8bit.py
+++ b/modules/util/triton_mm_8bit.py
@@ -15,6 +15,21 @@ import torch
 
 import triton
 import triton.language as tl
+from tqdm import tqdm
+
+
+#Print a line when the autotuner actually benchmarks a kernel. bench_fn runs only on a
+#real tune, so memory- and disk-cache hits stay silent. String (dtype) key fields are dropped.
+def announce_autotuning(kernel, name=None):
+    prefix = f"[triton] Autotuning {name} " if name else "[triton] Autotuning "
+    orig_check_disk_cache = kernel.check_disk_cache
+    def check_disk_cache(tuning_key, configs, bench_fn):
+        def announced_bench():
+            shape = tuple(k for k in tuning_key if not isinstance(k, str))
+            tqdm.write(f"{prefix}{shape}...")
+            bench_fn()
+        return orig_check_disk_cache(tuning_key, configs, announced_bench)
+    kernel.check_disk_cache = check_disk_cache
 
 
 @triton.autotune(
@@ -44,6 +59,7 @@ import triton.language as tl
         'K',
         'stride_bk'    #use stride of b as key, to autotune again for a strided rhs matrix (backward pass)
     ],
+    cache_results=True,
 )
 
 @triton.jit
@@ -95,6 +111,14 @@ def _mm_kernel(
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
+announce_autotuning(_mm_kernel, name="8-bit matmul")
+
+#Registered as an opaque custom op to work around pytorch#164124
+#(https://github.com/pytorch/pytorch/issues/164124): torch.compile absorbs traced
+#@triton.autotune kernels and freezes the config benchmarked for the first shape,
+#ignoring the autotune key. As a custom op the call stays a single opaque node in the
+#compiled graph and this body runs eagerly, so Triton's own autotuner selects per key.
+@torch.library.custom_op("onetrainer::mm_8bit", mutates_args=())
 def mm_8bit(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.is_contiguous(), "Matrix A must be contiguous"
@@ -119,3 +143,8 @@ def mm_8bit(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         FLOAT = FLOAT
     )
     return c
+
+@mm_8bit.register_fake
+def _(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    FLOAT = (a.dtype == torch.float8_e4m3fn)
+    return torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float32 if FLOAT else torch.int32)


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

https://github.com/pytorch/pytorch/issues/164124 causes torch.compile to choose a first-fit of the triton kernel instead of a best-fit for each shape as intended

this PR defines the triton kernel a custom op, which makes it opaque to torch.compile and let's triton autotune the kernel.
first step goes from 40s to 50s in one test cold because autotuning now actually happens, but on second run the first step is still about 20s because triton autotunes are cached.

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Flux2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
