### PR TITLE
Add INT_W8A8_CONVROT: W8A8 quantization with Hadamard rotation

### DIFF
--- a/modules/module/quantized/LinearInt8ConvRot.py
+++ b/modules/module/quantized/LinearInt8ConvRot.py
@@ -1,0 +1,185 @@
+import os
+
+from modules.module.quantized.LinearW8A8 import (
+    LinearW8A8,
+    int8_backward_axiswise,
+    int8_forward_tokenwise,
+    run_benchmark,
+)
+from modules.util.hadamard import block_hadamard, hadamard_matrix, pad_to_block
+from modules.util.quantization_util import (
+    dequantize,
+    quantize_int8_tensorwise,
+)
+
+import torch
+from torch import Tensor
+
+# Prototype knobs - env-driven, no UI/config plumbing (see PLAN in-an-new-branch-reflective-cocke).
+# Block size for the group-wise Hadamard rotation. Not empirically validated; 128 is a common
+# group size in block quantization literature, picked as a starting point to sweep from.
+CONVROT_BLOCK_SIZE = int(os.environ.get("CONVROT_BLOCK_SIZE", "128"))
+# Isolates the untested part of this experiment: whether quantizing the backward grad-output
+# to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping it in
+# bf16. Default matches int8w8 so the two paths are directly comparable.
+CONVROT_BF16_DY = os.environ.get("CONVROT_BF16_DY", "0") == "1"
+
+
+class LinearInt8ConvRotFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, weight_scale: Tensor, bias: Tensor | None,
+                compute_dtype: torch.dtype, block_size: int, in_features: int, rotation: Tensor) -> Tensor:
+        ctx.save_for_backward(weight, weight_scale, rotation)
+        ctx.block_size = block_size
+        ctx.in_features = in_features
+
+        x_rotated = block_hadamard(pad_to_block(x, block_size), block_size, rotation)
+        return int8_forward_tokenwise(x_rotated, weight, weight_scale, bias, compute_dtype)
+
+    @staticmethod
+    def backward(ctx, output: Tensor):
+        if ctx.needs_input_grad != (True, False, False, False, False, False, False, False):
+            raise NotImplementedError("Int A8W8 ConvRot cannot be used for full finetuning")
+
+        weight, weight_scale, rotation = ctx.saved_tensors
+        block_size, in_features = ctx.block_size, ctx.in_features
+
+        if CONVROT_BF16_DY:
+            # Debug path: skip int8 quantization of the grad-output entirely, to measure how
+            # much of any gradient-quality gap comes from quantizing dY vs. the rotation itself.
+            w_true = block_hadamard(dequantize(weight, weight_scale), block_size, rotation)[..., :in_features]
+            dx = output.to(torch.float32) @ w_true
+        else:
+            dx_padded = int8_backward_axiswise(output, weight, weight_scale)
+            dx = block_hadamard(dx_padded, block_size, rotation)[..., :in_features]
+
+        return dx.to(output.dtype), None, None, None, None, None, None, None
+
+
+class LinearInt8ConvRot(LinearW8A8):
+    # Group-wise Hadamard-rotated INT8 W8A8: rotates activations/weight/grad-output along the
+    # contraction dim in independent blocks of `block_size` before int8 quantization, so
+    # channel outliers get spread across a block instead of dominating a single channel's
+    # quantization range. The GEMM itself is unchanged from LinearW8A8 (still torch._int_mm) -
+    # rotation is the only added op, applied via block_hadamard (see modules/util/hadamard.py).
+    def __init__(self, block_size: int | None = None, *args, **kwargs):
+        kwargs['dtype'] = torch.int8  # ConvRot is int8-only; no fp8 variant in this experiment.
+        super().__init__(*args, **kwargs)
+        self.block_size = block_size if block_size is not None else CONVROT_BLOCK_SIZE
+        self._is_quantized = False  # own flag; LinearW8A8's is name-mangled and not reachable here
+
+    def original_weight_shape(self) -> tuple[int, ...]:
+        return (self.out_features, self.in_features)
+
+    def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        w = dequantize(self.weight.detach(), self.scale)
+        w = block_hadamard(w, self.block_size, self.rotation)[..., :self.in_features]
+        return w.to(dtype=dtype, device=device)
+
+    @torch.no_grad()
+    def quantize(self, device: torch.device | None = None):
+        if self._is_quantized:
+            return
+        self._is_quantized = True
+
+        weight = self.weight.detach()
+        orig_device = weight.device
+        if device is not None:
+            weight = weight.to(device=device)
+
+        # Precompute the block-Hadamard matrix once and keep it as a buffer (fp32; block_hadamard
+        # casts to the operand dtype). forward/backward run inside torch.compile'd + checkpointed
+        # blocks where the lazy hadamard_matrix() cache write is an illegal in-graph side effect;
+        # a buffer travels with the module across devices and is only read in the graph. persistent
+        # is False so it stays out of the state_dict (it's derivable from block_size).
+        self.register_buffer("rotation", hadamard_matrix(self.block_size, orig_device, torch.float32), persistent=False)
+
+        rotated = block_hadamard(pad_to_block(weight, self.block_size), self.block_size, self.rotation.to(weight.device))
+        weight, scale = quantize_int8_tensorwise(rotated)
+
+        if device is not None:
+            weight = weight.to(device=orig_device)
+
+        self.requires_grad_(False)
+        self.weight = torch.nn.Parameter(weight, requires_grad=False)
+        self.scale.copy_(scale)
+
+    def forward(self, x_orig: torch.Tensor) -> torch.Tensor:
+        assert not self.weight.requires_grad
+        assert self._is_quantized
+        x = x_orig.reshape(-1, x_orig.shape[-1])
+
+        if x.shape[0] > 16:
+            y = LinearInt8ConvRotFunction.apply(
+                x, self.weight, self.scale, self.bias, self.compute_dtype,
+                self.block_size, self.in_features, self.rotation,
+            )
+        else:
+            w = self.unquantized_weight(dtype=x.dtype, device=x.device)
+            y = torch.nn.functional.linear(x, w, self.bias)
+
+        return y.reshape(x_orig.shape[:-1] + (y.shape[-1],))
+
+
+@torch.no_grad()
+def quant_relative_error(x: Tensor, block_size: int | None) -> float:
+    # Round-trips x through int8 quantization (plain per-tensor if block_size is None, else
+    # rotated) and reports ||dequant(quant(x)) - x|| / ||x||: a quick SNR proxy for how much a
+    # given block size actually helps, without needing a full training run.
+    if block_size is None:
+        q, scale = quantize_int8_tensorwise(x)
+        recovered = dequantize(q, scale)
+    else:
+        rotated = block_hadamard(pad_to_block(x, block_size), block_size)
+        q, scale = quantize_int8_tensorwise(rotated)
+        recovered = block_hadamard(dequantize(q, scale), block_size)[..., :x.shape[-1]]
+    return (recovered - x).norm().item() / x.norm().item()
+
+
+def benchmark_snr(n_channels=3072, n_rows=512, outlier_channels=8, outlier_scale=20.0, device='cuda'):
+    # Synthetic outlier-channel weight: a handful of channels scaled up, as in the outlier
+    # patterns published PTQ work targets. Plain per-tensor int8 wastes its dynamic range on
+    # those few channels; a block Hadamard rotation should spread each outlier's magnitude
+    # across its block instead of one channel dominating the whole tensor's scale.
+    torch.manual_seed(0)
+    w = torch.randn(n_rows, n_channels, device=device)
+    outlier_idx = torch.randperm(n_channels)[:outlier_channels]
+    w[:, outlier_idx] *= outlier_scale
+
+    print(f"synthetic outlier tensor: {n_channels} channels, {outlier_channels} scaled {outlier_scale}x")
+    print(f"  plain int8 (no rotation):        rel err = {quant_relative_error(w, None):.4f}")
+    for block_size in (32, 64, 128, 256):
+        print(f"  ConvRot block_size={block_size:<4}:            rel err = {quant_relative_error(w, block_size):.4f}")
+
+
+@torch.no_grad()
+def benchmark_throughput(m, k, n, block_size=128, device='cuda'):
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    y = torch.randn(m, n, device=device, dtype=torch.bfloat16)
+    w_plain = torch.ones(n, k, device=device, dtype=torch.int8)
+    w_scale = torch.ones(1, device=device)
+
+    k_padded = k + (-k) % block_size
+    w_rot = torch.ones(n, k_padded, device=device, dtype=torch.int8)
+
+    def convrot_forward():
+        xr = block_hadamard(pad_to_block(x, block_size), block_size)
+        return int8_forward_tokenwise(xr, w_rot, w_scale, bias=None, compute_dtype=torch.bfloat16)
+
+    def convrot_backward():
+        dx = int8_backward_axiswise(y, w_rot, w_scale)
+        return block_hadamard(dx, block_size)[..., :k]
+
+    run_benchmark(lambda: int8_forward_tokenwise(x, w_plain, w_scale, bias=None, compute_dtype=torch.bfloat16), "plain int8w8 forward")
+    run_benchmark(convrot_forward, "ConvRot forward (incl. rotation)")
+    run_benchmark(lambda: int8_backward_axiswise(y, w_plain, w_scale), "plain int8w8 backward")
+    run_benchmark(convrot_backward, "ConvRot backward (incl. rotation)")
+
+
+if __name__ == "__main__":
+    # Clock/config caveats: throughput numbers here are indicative only - see the plan's
+    # verification section for the locked-clock benchmark this repo normally requires before
+    # trusting a number.
+    benchmark_snr()
+    print()
+    benchmark_throughput(2 * 1024 + 50, 3072, 3088)

--- a/modules/ui/BaseModelTabView.py
+++ b/modules/ui/BaseModelTabView.py
@@ -66,6 +66,7 @@ class BaseModelTabView(ABC):
             options += [
                 ("float W8A8", DataType.FLOAT_W8A8),
                 ("int W8A8", DataType.INT_W8A8),
+                ("int W8A8 ConvRot", DataType.INT_W8A8_CONVROT),
             ]
 
         if include_gguf:

--- a/modules/util/enum/DataType.py
+++ b/modules/util/enum/DataType.py
@@ -14,6 +14,7 @@ class DataType(Enum):
     NFLOAT_4 = 'NFLOAT_4'
     FLOAT_W8A8 = 'FLOAT_W8A8'
     INT_W8A8 = 'INT_W8A8'
+    INT_W8A8_CONVROT = 'INT_W8A8_CONVROT'
     GGUF = 'GGUF'
     GGUF_A8_FLOAT = 'GGUF_A8_FLOAT'
     GGUF_A8_INT = 'GGUF_A8_INT'
@@ -48,6 +49,7 @@ class DataType(Enum):
                         DataType.INT_8,
                         DataType.FLOAT_W8A8,
                         DataType.INT_W8A8,
+                        DataType.INT_W8A8_CONVROT,
                         DataType.NFLOAT_4]
 
     def is_gguf(self):
@@ -66,6 +68,9 @@ class DataType(Enum):
 
     def quantize_intW8A8(self):
         return self == DataType.INT_W8A8
+
+    def quantize_intW8A8_convrot(self):
+        return self == DataType.INT_W8A8_CONVROT
 
     def quantize_nf4(self):
         return self == DataType.NFLOAT_4

--- a/modules/util/hadamard.py
+++ b/modules/util/hadamard.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+# Normalized Sylvester-Hadamard matrices, cached per (size, device, dtype).
+# H is symmetric and involutive (H @ H == I), so the same matrix rotates and un-rotates.
+_hadamard_cache: dict[tuple[int, torch.device, torch.dtype], Tensor] = {}
+
+def hadamard_matrix(n: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+    assert n > 0 and (n & (n - 1)) == 0, f"Hadamard size must be a power of 2, got {n}"
+    key = (n, device, dtype)
+    h = _hadamard_cache.get(key)
+    if h is not None:
+        return h
+
+    h = torch.ones((1, 1), device=device, dtype=torch.float32)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1),
+                        torch.cat([h, -h], dim=1)], dim=0)
+    h = (h / (n ** 0.5)).to(dtype)
+
+    _hadamard_cache[key] = h
+    return h
+
+def pad_to_block(x: Tensor, block_size: int) -> Tensor:
+    # Zero-pads the last dim up to a multiple of block_size. The padded columns are exact
+    # zeros; callers must carry them through block_hadamard uncut and only truncate back
+    # down after undoing the rotation (see block_hadamard) - never in between the two, or
+    # the truncation drops values that real data was mixed into.
+    pad = (-x.shape[-1]) % block_size
+    if pad:
+        x = F.pad(x, (0, pad))
+    return x
+
+def block_hadamard(x: Tensor, block_size: int, h: Tensor | None = None) -> Tensor:
+    # Rotates the last dim in independent blocks of block_size (block-diagonal Hadamard:
+    # O(dim * block_size) cost, not a dense O(dim^2) global rotation). x's last dim must
+    # already be a multiple of block_size (pad with pad_to_block first). This function never
+    # pads or truncates itself: H only inverts itself (H @ H == I) when applied twice to the
+    # same padded width; truncating between the two applications is a lossy projection, not
+    # an inverse, whenever the padding is non-zero.
+    # Pass a precomputed h (any dtype) from callers inside a torch.compile'd + activation-
+    # checkpointed region: the lazy hadamard_matrix() cache write is an in-graph side effect the
+    # checkpoint HOP rejects (it would be replayed on backward recompute). Eager callers leave h
+    # None and take the cached path.
+    assert x.shape[-1] % block_size == 0, "call pad_to_block first"
+    if h is None:
+        h = hadamard_matrix(block_size, x.device, x.dtype)
+    blocks = x.unflatten(-1, (-1, block_size))
+    rotated = blocks @ h.to(blocks.dtype)
+    return rotated.flatten(-2, -1)

--- a/modules/util/quantization_util.py
+++ b/modules/util/quantization_util.py
@@ -78,6 +78,7 @@ def dequantize(q: Tensor, scale: float | Tensor) -> Tensor:
 
 from modules.module.quantized.LinearFp8 import LinearFp8
 from modules.module.quantized.LinearGGUFA8 import LinearGGUFA8
+from modules.module.quantized.LinearInt8ConvRot import LinearInt8ConvRot
 from modules.module.quantized.LinearSVD import BaseLinearSVD, make_svd_linear
 from modules.module.quantized.LinearW8A8 import LinearW8A8
 
@@ -184,6 +185,8 @@ def replace_linear_with_quantized_layers(
     elif dtype.quantize_intW8A8():
         linear_class = LinearW8A8
         kwargs = {'dtype': torch.int8}
+    elif dtype.quantize_intW8A8_convrot():
+        linear_class = LinearInt8ConvRot
     elif dtype.quantize_fpW8A8():
         linear_class=LinearW8A8
         kwargs = {'dtype': torch.float8_e4m3fn}


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

```
# Prototype knobs - env-driven, no UI/config plumbing (see PLAN in-an-new-branch-reflective-cocke).
# Block size for the group-wise Hadamard rotation. Not empirically validated; 128 is a common
# group size in block quantization literature, picked as a starting point to sweep from.
CONVROT_BLOCK_SIZE = int(os.environ.get("CONVROT_BLOCK_SIZE", "128"))
# Isolates the untested part of this experiment: whether quantizing the backward grad-output
# to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping it in
# bf16. Default matches int8w8 so the two paths are directly comparable.
CONVROT_BF16_DY = os.environ.get("CONVROT_BF16_DY", "0") == "1"
```


<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- Early AI prototype — opened for discussion, **not ready for review**

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
