### PR TITLE
Fix resuming quantized models from backup

### DIFF
--- a/modules/modelLoader/mixin/HFModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/HFModelLoaderMixin.py
@@ -162,12 +162,15 @@ class HFModelLoaderMixin(metaclass=ABCMeta):
                     else:
                         value = value.to(dtype=dtype.torch_dtype())
 
-                new_value = old_type(value)
-
                 if is_buffer:
-                    module._buffers[tensor_name].data = new_value
+                    module._buffers[tensor_name].data = old_type(value)
+                elif torch.is_floating_point(value):
+                    module._parameters[tensor_name] = old_type(value)
                 else:
-                    module._parameters[tensor_name] = new_value
+                    # weights restored from a backup are already in their quantized storage dtype
+                    # (e.g. nf4's uint8 or int8 W8A8); an integer tensor can't back a grad-enabled
+                    # Parameter, and these weights are frozen anyway
+                    module._parameters[tensor_name] = old_type(value, requires_grad=False)
 
         del state_dict
 

--- a/modules/module/quantized/LinearNf4.py
+++ b/modules/module/quantized/LinearNf4.py
@@ -69,7 +69,7 @@ class LinearNf4(
 
         weight = self.weight.data
         orig_device = weight.device
-        if weight.dtype != torch.int8:
+        if weight.dtype != torch.uint8:
             if device is not None:
                 weight = weight.to(device=device)
 

--- a/modules/module/quantized/LinearW8A8.py
+++ b/modules/module/quantized/LinearW8A8.py
@@ -103,21 +103,24 @@ class LinearW8A8(
         self.__is_quantized = True
 
         weight = self.weight.detach()
-        orig_device = weight.device
-        if device is not None:
-            weight = weight.to(device=device)
-        if self._dtype == torch.int8:
-            weight, scale = quantize_int8_tensorwise(weight)
-        else:
-            weight, scale = quantize_fp8_tensorwise(weight)
+        # a backup restores the weight already in its quantized dtype together with its scale buffer;
+        # re-quantizing would recompute the scale from already-quantized values and corrupt the weight
+        if weight.dtype != self._dtype:
+            orig_device = weight.device
+            if device is not None:
+                weight = weight.to(device=device)
+            if self._dtype == torch.int8:
+                weight, scale = quantize_int8_tensorwise(weight)
+            else:
+                weight, scale = quantize_fp8_tensorwise(weight)
 
-        if device is not None:
-            weight = weight.to(device=orig_device)
+            if device is not None:
+                weight = weight.to(device=orig_device)
+
+            self.scale.copy_(scale)
 
         self.requires_grad_(False)
         self.weight.data = weight
-
-        self.scale.copy_(scale)
 
     def forward(self, x_orig: torch.Tensor) -> torch.Tensor:
         assert not self.weight.requires_grad


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

A backup stores frozen quantized modules (e.g. Ideogram4's nf4 text encoder and unconditional transformer) in their quantized storage dtype. Reloading them was broken in two ways:

- HFModelLoaderMixin wrapped the restored weight in a grad-enabled Parameter, which raises for integer tensors ("Only Tensors of floating point and complex dtype can require gradients") on nf4 (uint8) and int8 W8A8. Restore such pre-quantized weights as frozen Parameters instead.
- quantize() would then re-quantize the already-quantized weight, recomputing the scale from quantized values and corrupting it. LinearNf4's guard checked int8 but nf4 packs into uint8; LinearW8A8 had no guard at all. Both now skip quantization when the weight is already in its quantized dtype.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
