### PR TITLE
Pre-import matplotlib to avoid shiboken getsource crash on Python 3.12.0

### DIFF
--- a/scripts/train_ui_qt.py
+++ b/scripts/train_ui_qt.py
@@ -1,5 +1,12 @@
 import sys
 
+# Force matplotlib into sys.modules before PySide6/shiboken installs its import
+# hooks.  Its dateutil->six.moves chain builds a synthetic module whose repr()
+# crashes on Python 3.12.0 (AttributeError: no '_path'; fixed in 3.12.1) when
+# shiboken's getsource() scans it, aborting UI startup.  Caching it now keeps
+# six.moves off the scanner's path.
+import matplotlib.pyplot  # noqa: F401, ICN001
+
 # Force pydantic internals into sys.modules before PySide6/shiboken installs its
 # import hooks.  Without this, shiboken's inspect.getsource() fires on a
 # partially-initialized pydantic module, causing a circular import error.


### PR DESCRIPTION


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->
Works around https://github.com/Nerogar/OneTrainer/issues/1603


## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
