### PR TITLE
Cloud: don't let a broken ssh-agent abort the SSH connect

### DIFF
--- a/modules/util/config/CloudConfig.py
+++ b/modules/util/config/CloudConfig.py
@@ -38,14 +38,16 @@ class CloudSecretsConfig(BaseConfig):
             return ""
         return str(Path(key_file).expanduser())
 
-    def connect_kwargs(self) -> dict[str, str]:
-        kwargs: dict[str, str] = {}
+    def connect_kwargs(self) -> dict:
+        kwargs = {}
         key_file = self.expanded_key_file()
         if key_file:
             kwargs["key_filename"] = key_file
         password = getattr(self, "password", "").strip()
         if password:
             kwargs["password"] = password
+        # Never query the ssh-agent: a broken agent can make paramiko's Agent() raise and abort the connect.
+        kwargs["allow_agent"] = False
         return kwargs
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

paramiko defaults to `allow_agent=True`, so before authenticating it queries the local ssh-agent (`SSH_AUTH_SOCK`) to enumerate identities. When that socket is broken or misconfigured — e.g. `SSH_AUTH_SOCK` left pointing at a dead gnome-keyring socket after a gcr-ssh-agent migration — paramiko's `Agent()` raises `ConnectionResetError` and the whole cloud connect fails before any key is tried, even though `ssh` on the command line works (it falls back to the on-disk key).

This sets `allow_agent=False` so the connect goes straight to the configured `key_filename`/`password`, or paramiko's `look_for_keys` (`~/.ssh/id_*`) — matching OneTrainer's documented key-based cloud setup.


## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change

## AI assistance

AI-assisted — I have read every line in this diff and can defend each change