### PR TITLE
Show absolute epoch number in resume progress bar

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -635,7 +635,9 @@ class GenericTrainer(BaseTrainer):
         ema_loss_steps = 0
         epochs = range(train_progress.epoch, self.config.epochs, 1)
 
-        for _epoch in tqdm(epochs, desc="epoch") if multi.is_master() else epochs:
+        if multi.is_master():
+            epochs = tqdm(epochs, desc="epoch", initial=train_progress.epoch, total=self.config.epochs)
+        for _epoch in epochs:
             multi.sync_commands(self.commands)
             if self.commands.get_stop_command():
                 return


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

The epoch progress bar iterated `range(resume_epoch, total_epochs)` with no `initial`/`total`, so on resume it showed the count of *remaining* epochs starting from 0 (e.g. `1/50`) instead of the absolute position (`51/100`). This adds `initial=train_progress.epoch, total=self.config.epochs`, matching how the step bar just below it already resumes.

Cosmetic only -- `train_progress.epoch` and the LR schedule were already correct; this only fixes the display. Surfaced while investigating Nerogar/OneTrainer#1604.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [ ] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

- AI-assisted -- I have read every line in this diff and can defend each change
