### PR TITLE
UI fixes in Concept Window

### DIFF
--- a/modules/ui/CtkConceptWindowView.py
+++ b/modules/ui/CtkConceptWindowView.py
@@ -91,8 +91,8 @@ class CtkConceptWindowView(BaseConceptWindowView, ctk.CTkToplevel):
         # text augmentation tab
         text_aug_frame = ctk.CTkScrollableFrame(tabview.add("text augmentation"), fg_color="transparent")
         text_aug_frame.grid_columnconfigure(0, weight=0)
-        text_aug_frame.grid_columnconfigure(1, weight=0)
-        text_aug_frame.grid_columnconfigure(2, weight=0)
+        text_aug_frame.grid_columnconfigure(1, weight=1)
+        text_aug_frame.grid_columnconfigure(2, weight=1)
         text_aug_frame.grid_columnconfigure(3, weight=1)
         self.build_text_augmentation_tab(text_aug_frame, controller, text_ui_state)
         text_aug_frame.pack(fill="both", expand=1)

--- a/modules/ui/PySide6ConceptWindowView.py
+++ b/modules/ui/PySide6ConceptWindowView.py
@@ -22,6 +22,11 @@ from PySide6.QtWidgets import (
 )
 
 
+class NonZoomingFigureCanvas(FigureCanvasQTAgg):
+    def wheelEvent(self, event):
+        event.ignore()
+
+
 class PySide6ConceptWindowView(BaseConceptWindowView, QDialog):
     def __init__(
             self,
@@ -149,7 +154,7 @@ class PySide6ConceptWindowView(BaseConceptWindowView, QDialog):
 
         plt.set_loglevel('WARNING')
         self.bucket_fig, self.bucket_ax = plt.subplots(figsize=(7, 3))
-        self.canvas = FigureCanvasQTAgg(self.bucket_fig)
+        self.canvas = NonZoomingFigureCanvas(self.bucket_fig)
         self.bucket_fig.tight_layout()
         self.bucket_fig.subplots_adjust(bottom=0.15)
 

--- a/modules/ui/PySide6ConceptWindowView.py
+++ b/modules/ui/PySide6ConceptWindowView.py
@@ -127,6 +127,8 @@ class PySide6ConceptWindowView(BaseConceptWindowView, QDialog):
         text_frame = QWidget()
         text_scroll.setWidget(text_frame)
         pyside6_components._layout(text_frame).setContentsMargins(_pad, _pad, _pad, _pad)
+        pyside6_components._layout(text_frame).setColumnStretch(1, 1)
+        pyside6_components._layout(text_frame).setColumnStretch(2, 1)
         pyside6_components._layout(text_frame).setColumnStretch(3, 1)
         self.build_text_augmentation_tab(text_frame, controller, text_ui_state)
         pyside6_components._pack_form(text_frame)


### PR DESCRIPTION
## Summary

UI fixes in Concept window:
- fixed mouse wheel not scrolling over the histogram in "statistics" tab in Qt version.
- fixed column stretch in "text augmentations" tab.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change

## AI assistance

- No AI involvement

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->