### PR TITLE
Add Offline Mode and configurable Hugging Face cache directory

### DIFF
--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -1,4 +1,3 @@
-import contextlib
 import copy
 import json
 import math
@@ -16,7 +15,7 @@ from modules.modelSampler.BaseModelSampler import BaseModelSampler, ModelSampler
 from modules.modelSaver.BaseModelSaver import BaseModelSaver
 from modules.modelSetup.BaseModelSetup import BaseModelSetup
 from modules.trainer.BaseTrainer import BaseTrainer
-from modules.util import create, path_util
+from modules.util import create, huggingface_util, path_util
 from modules.util.bf16_stochastic_rounding import set_seed as bf16_stochastic_rounding_set_seed
 from modules.util.callbacks.TrainCallbacks import TrainCallbacks
 from modules.util.commands.TrainCommands import TrainCommands
@@ -42,8 +41,6 @@ from torch.utils.hooks import RemovableHandle
 from torch.utils.tensorboard import SummaryWriter
 from torchvision.transforms.functional import pil_to_tensor
 
-import huggingface_hub
-from requests.exceptions import ConnectionError
 from tqdm import tqdm
 
 
@@ -115,10 +112,12 @@ class GenericTrainer(BaseTrainer):
             else:
                 print("No backup found, continuing without backup...")
 
-        if self.config.secrets.huggingface_token != "":
-            self.callbacks.on_update_status("logging into Hugging Face")
-            with contextlib.suppress(ConnectionError):
-                huggingface_hub.login(token=self.config.secrets.huggingface_token)
+        huggingface_util.configure_hub(
+            self.config.secrets.huggingface_token,
+            offline_mode=self.config.offline_mode,
+            cache_dir=self.config.huggingface_cache_dir,
+            on_status=self.callbacks.on_update_status,
+        )
 
         self.callbacks.on_update_status("loading the model")
 

--- a/modules/ui/BaseModelTabView.py
+++ b/modules/ui/BaseModelTabView.py
@@ -6,6 +6,8 @@ from modules.util.enum.ConfigPart import ConfigPart
 from modules.util.enum.DataType import DataType
 from modules.util.enum.PathIOType import PathIOType
 
+from huggingface_hub.constants import HF_HUB_CACHE
+
 
 class BaseModelTabView(ABC):
     def __init__(self, components):
@@ -85,6 +87,25 @@ class BaseModelTabView(ABC):
                                  "Go to https://huggingface.co/settings/tokens to create an access token.",
                          wide_tooltip=True)
         self.components.entry(frame, row, 1, ui_state, "secrets.huggingface_token")
+
+        # offline mode
+        self.components.label(frame, row, 3, "Offline Mode",
+                         tooltip="Skip the Hugging Face login and resolve every model from the local cache only. "
+                                 "Enable this when you have no internet connection; only already-downloaded models can be loaded.",
+                         wide_tooltip=True)
+        self.components.switch(frame, row, 4, ui_state, "offline_mode")
+
+        row += 1
+
+        # huggingface cache directory
+        self.components.label(frame, row, 0, "Hugging Face Cache Directory",
+                         tooltip="Directory used to cache Hugging Face model downloads. "
+                                 "Leave empty to use the default Hugging Face cache directory shown as the placeholder.",
+                         wide_tooltip=True)
+        self.components.path_entry(
+            frame, row, 1, ui_state, "huggingface_cache_dir",
+            mode="dir", placeholder=HF_HUB_CACHE,
+        )
 
         row += 1
 

--- a/modules/ui/ConceptWindowController.py
+++ b/modules/ui/ConceptWindowController.py
@@ -6,7 +6,7 @@ import threading
 import time
 import traceback
 
-from modules.util import concept_stats, path_util
+from modules.util import concept_stats, huggingface_util, path_util
 from modules.util.config.ConceptConfig import ConceptConfig
 from modules.util.config.TrainConfig import TrainConfig
 from modules.util.image_util import load_image
@@ -55,8 +55,11 @@ class ConceptWindowController:
 
     def download_dataset(self):
         try:
-            if self.train_config.secrets.huggingface_token != "":
-                huggingface_hub.login(token=self.train_config.secrets.huggingface_token)
+            huggingface_util.configure_hub(
+                self.train_config.secrets.huggingface_token,
+                offline_mode=self.train_config.offline_mode,
+                cache_dir=self.train_config.huggingface_cache_dir,
+            )
             huggingface_hub.snapshot_download(repo_id=self.concept.path, repo_type="dataset")
         except Exception:
             traceback.print_exc()

--- a/modules/ui/ConvertModelUIController.py
+++ b/modules/ui/ConvertModelUIController.py
@@ -1,8 +1,7 @@
-import contextlib
 import traceback
 from uuid import uuid4
 
-from modules.util import create
+from modules.util import create, huggingface_util
 from modules.util.args.ConvertModelArgs import ConvertModelArgs
 from modules.util.config.TrainConfig import QuantizationConfig
 from modules.util.enum.ModelFormat import ModelFormat
@@ -10,8 +9,6 @@ from modules.util.enum.ModelType import ModelType
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.ModelNames import EmbeddingName, ModelNames
 from modules.util.torch_util import torch_gc
-
-import huggingface_hub
 
 
 class ConvertModelUIController:
@@ -65,9 +62,7 @@ class ConvertModelUIController:
                 training_method=self.convert_model_args.training_method
             )
 
-            if self.convert_model_args.huggingface_token != "":
-                with contextlib.suppress(ConnectionError):
-                    huggingface_hub.login(token=self.convert_model_args.huggingface_token)
+            huggingface_util.configure_hub(self.convert_model_args.huggingface_token)
 
             print("Loading model " + self.convert_model_args.input_name)
             if self.convert_model_args.training_method in [TrainingMethod.FINE_TUNE]:

--- a/modules/util/config/TrainConfig.py
+++ b/modules/util/config/TrainConfig.py
@@ -373,6 +373,8 @@ class TrainConfig(BaseConfig):
     debug_dir: str
     workspace_dir: str
     cache_dir: str
+    huggingface_cache_dir: str
+    offline_mode: bool
     tensorboard: bool
     tensorboard_expose: bool
     tensorboard_always_on: bool
@@ -1015,6 +1017,8 @@ class TrainConfig(BaseConfig):
         data.append(("debug_dir", "debug", str, False))
         data.append(("workspace_dir", "workspace/run", str, False))
         data.append(("cache_dir", "workspace-cache/run", str, False))
+        data.append(("huggingface_cache_dir", "", str, False))
+        data.append(("offline_mode", False, bool, False))
         data.append(("tensorboard", True, bool, False))
         data.append(("tensorboard_expose", False, bool, False))
         data.append(("tensorboard_always_on", False, bool, False))

--- a/modules/util/huggingface_util.py
+++ b/modules/util/huggingface_util.py
@@ -1,0 +1,27 @@
+import contextlib
+from collections.abc import Callable
+
+import huggingface_hub
+from huggingface_hub import constants as hf_constants
+
+
+def configure_hub(
+        token: str = "",
+        offline_mode: bool = False,
+        cache_dir: str = "",
+        on_status: Callable[[str], None] | None = None,
+):
+    # huggingface_hub reads HF_HUB_OFFLINE and HF_HUB_CACHE from the environment into module constants at import
+    # time, and every downstream call reads those constants at call time. transformers and diffusers don't expose
+    # a parameter on the internal requests they make (e.g. transformers queries model_info() while loading a
+    # large-vocab tokenizer), so overriding the constants here is the only lever that reaches those calls and
+    # redirects every HF request for the rest of the process.
+    hf_constants.HF_HUB_OFFLINE = offline_mode
+    if cache_dir:
+        hf_constants.HF_HUB_CACHE = cache_dir
+
+    if not offline_mode and token != "":
+        if on_status is not None:
+            on_status("logging into Hugging Face")
+        with contextlib.suppress(ConnectionError):
+            huggingface_hub.login(token=token)

--- a/modules/util/ui/ctk_components.py
+++ b/modules/util/ui/ctk_components.py
@@ -59,13 +59,14 @@ def entry(
         validator_factory: Callable[..., FieldValidator] | None = None,
         extra_validate: Callable[[str], str | None] | None = None,
         required: bool = False,
+        placeholder: str = "",
 ):
     var = ui_state.get_var(var_name)
     trace_id = None
     if command:
         trace_id = ui_state.add_var_trace(var_name, command)
 
-    component = ctk.CTkEntry(master, textvariable=var, width=width)
+    component = ctk.CTkEntry(master, textvariable=var, width=width, placeholder_text=placeholder)
     component.grid(row=row, column=column, padx=PAD, pady=PAD, sticky=sticky)
 
     if validator_factory is not None:
@@ -123,6 +124,7 @@ def path_entry(
         extra_validate: Callable[[str], str | None] | None = None,
         required: bool = False,
         columnspan: int = 1,
+        placeholder: str = "",
 ):
     frame = ctk.CTkFrame(master, fg_color="transparent")
     frame.grid(row=row, column=column, padx=0, pady=0, sticky="new", columnspan=columnspan)
@@ -137,6 +139,7 @@ def path_entry(
         validator_factory=_path_validator_factory,
         extra_validate=extra_validate,
         required=required,
+        placeholder=placeholder,
     )
 
     trace_ids = []

--- a/modules/util/ui/pyside6_components.py
+++ b/modules/util/ui/pyside6_components.py
@@ -203,11 +203,14 @@ def entry(
         validator_factory: Callable[..., PySide6FieldValidator] | None = None,
         extra_validate: Callable[[str], str | None] | None = None,
         required: bool = False,
+        placeholder: str = "",
 ) -> QLineEdit:
     var = ui_state.get_var(var_name)
 
     component = QLineEdit(master)
     component.setMinimumWidth(width)
+    if placeholder:
+        component.setPlaceholderText(placeholder)
     _add(_layout(master), component, row, column, sticky=sticky)
 
     if command:
@@ -252,6 +255,7 @@ def path_entry(
         extra_validate: Callable[[str], str | None] | None = None,
         required: bool = False,
         columnspan: int = 1,
+        placeholder: str = "",
 ) -> QWidget:
     frame = QWidget(master)
     frame_lo = QGridLayout(frame)
@@ -268,6 +272,7 @@ def path_entry(
         validator_factory=_path_validator_factory,
         extra_validate=extra_validate,
         required=required,
+        placeholder=placeholder,
     )
 
     dep_trace_ids: list[tuple] = []

--- a/scripts/convert_model.py
+++ b/scripts/convert_model.py
@@ -2,24 +2,19 @@ from util.import_util import script_imports
 
 script_imports()
 
-import contextlib
 from uuid import uuid4
 
-from modules.util import create
+from modules.util import create, huggingface_util
 from modules.util.args.ConvertModelArgs import ConvertModelArgs
 from modules.util.config.TrainConfig import QuantizationConfig
 from modules.util.enum.TrainingMethod import TrainingMethod
 from modules.util.ModelNames import EmbeddingName, ModelNames
 
-import huggingface_hub
-
 
 def main():
     args = ConvertModelArgs.parse_args()
 
-    if args.huggingface_token != "":
-        with contextlib.suppress(ConnectionError):
-            huggingface_hub.login(token=args.huggingface_token)
+    huggingface_util.configure_hub(args.huggingface_token)
 
     model_loader = create.create_model_loader(model_type=args.model_type, training_method=args.training_method)
     model_saver = create.create_model_saver(model_type=args.model_type, training_method=args.training_method)


### PR DESCRIPTION
## Summary

Two related Hugging Face controls on the model tab.

**Offline Mode** (switch next to the token): skips the hub login and resolves every model from the local cache by setting `huggingface_hub.constants.HF_HUB_OFFLINE`. This is the only lever that reaches the requests transformers/diffusers make internally for cached models (e.g. transformers queries `model_info()` while loading a large-vocab tokenizer), which don't expose a parameter to suppress them. Previously such a request would fail the whole load without a connection.

**Hugging Face Cache Directory** (path field, defaults to the standard cache shown as placeholder): redirects downloads by setting `HF_HUB_CACHE`. Both constants are read at call time, so the override reaches transformers and diffusers too - verified they delegate to `hf_hub_download` rather than capturing the path at import.

All four hub logins (training, concept-window dataset download, and the two convert paths) now go through a single `huggingface_util.configure_hub()`, which applies the constants and, when online with a token, logs in.

The constant approach is deliberate: threading an equivalent parameter through every model loader would touch dozens of files and still miss the library-internal calls.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Krea)

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change