### PR TITLE
fix Chroma training

### DIFF
--- a/modules/util/ui/pyside6_util.py
+++ b/modules/util/ui/pyside6_util.py
@@ -1,3 +1,4 @@
+import locale
 import signal
 import sys
 from abc import ABCMeta
@@ -20,6 +21,13 @@ def create_application() -> QApplication:
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     app = QApplication(sys.argv)
+    # QApplication initializes the C locale from the environment (setlocale(LC_ALL, "")), which sets LC_NUMERIC
+    # to a locale whose decimal separator may be a comma. C libraries then misparse '.' floats: protobuf's upb
+    # backend rejects sentencepiece's schema ("Invalid default '0.9995'"), breaking every sentencepiece tokenizer
+    # (T5/Chroma/Flux), and the Kineto profiler writes comma decimals into its JSON traces. Restore the C numeric
+    # locale, which Python itself uses by default. Qt's own display uses QLocale, which is independent of this and
+    # keeps formatting numbers per the system locale.
+    locale.setlocale(locale.LC_NUMERIC, "C")
     # Force Fusion everywhere: native styles (e.g. windowsvista) draw standard
     # controls via OS theme APIs, which breaks once an application stylesheet
     # is set, producing a flatter look than Fusion's own stylesheet-aware painting.


### PR DESCRIPTION
## Summary

the Qt6 UI has broken Chroma training in a long chain of events depending on the locale:

On systems with a comma-decimal locale, models failed to load in the UI with `Invalid default '0.9995' for field ... character_coverage of type 2`, and profiler traces came out corrupted.

Root cause is `QApplication` calling `setlocale(LC_ALL, "")` at startup, which sets `LC_NUMERIC` to the user's locale. C libraries then misparse `.`-decimal floats: protobuf's `upb` backend rejects sentencepiece's schema — breaking every sentencepiece tokenizer (T5/Chroma/Flux) — and the Kineto profiler emits `,`-decimals into its JSON traces. It only surfaces in the UI; the CLI entry points keep Python's default C numeric locale and never hit it.

The fix resets `LC_NUMERIC` to `C` right after `QApplication` is created — the single chokepoint every Qt entry point goes through. Qt's own number display uses `QLocale`, which Qt6 reads from the environment once at init and keeps independent of the C locale, so system-locale formatting in the UI is unchanged (and OneTrainer's fields render numbers via `str()` anyway).

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Chroma)

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change