### PR TITLE
Non-reentrant offloading, fix race condition, fix activation offloading

### DIFF
--- a/modules/model/BaseModel.py
+++ b/modules/model/BaseModel.py
@@ -11,7 +11,7 @@ from modules.util.enum.ModelFormat import ModelFormat
 from modules.util.enum.ModelType import ModelType
 from modules.util.modelSpec.ModelSpec import ModelSpec
 from modules.util.NamedParameterGroup import NamedParameterGroupCollection
-from modules.util.torch_util import device_equals, torch_gc
+from modules.util.torch_util import create_mem_pool, device_equals, mem_pool_context, supports_mem_pool, torch_gc
 from modules.util.TrainProgress import TrainProgress
 
 import torch
@@ -97,6 +97,8 @@ class BaseModel(metaclass=ABCMeta):
         self.autocast_context = nullcontext()
         self.train_dtype = DataType.FLOAT_32
 
+        self._mem_pools = {}
+
     @property
     def train_device(self) -> torch.device:
         return torch.device(self.train_config.train_device)
@@ -137,22 +139,43 @@ class BaseModel(metaclass=ABCMeta):
         stem = f"{part}_1" if hasattr(self, f"{part}_1") else part
 
         conductor = getattr(self, f"{stem}_offload_conductor", None)
+        lora = getattr(self, f"{stem}_lora", None)
+        # A conductor places its own component, so nothing below moves it. Without one, `getattr` raises if
+        # `part` doesn't name a real attribute, and returns None when the part is excluded from training
+        # (e.g. a text encoder with include_text_encoder off): it stays in model_parts() but the loader never
+        # populated it, so there is nothing to move.
+        component = None if conductor is not None else getattr(self, stem)
+
         if conductor is not None:
             if device_equals(device, self.temp_device):
                 conductor.evict()
             else:
                 assert device_equals(device, self.train_device), f"unexpected device {device} for part {part}"
                 conductor.materialize()
+
+        if component is None and lora is None:
+            return
+
+        if supports_mem_pool(device):
+            # The component (when not conductor-managed) and its LoRA share a per-stem MemPool so both land
+            # contiguously and release together on evict. A conductor keeps its own pool, so the stem pool then
+            # holds only the LoRA, keeping its small tensors out of the default pool across the part's evict/reload.
+            pool = self._mem_pools.get(stem)
+            if pool is None:
+                pool = self._mem_pools[stem] = create_mem_pool(device)
+            with mem_pool_context(pool):
+                if component is not None:
+                    component.to(device=device)
+                if lora is not None:
+                    lora.to(device=device)
         else:
-            component = getattr(self, stem)  # raises if `part` doesn't name a real attribute
-            # None when the part is excluded from training (e.g. a text encoder with include_text_encoder off):
-            # it stays in model_parts() but the loader never populated it, so there is nothing to move.
+            # the target has no MemPool (CPU): move normally and drop this stem's pool from the earlier GPU move,
+            # so evict()'s torch_gc can release its segments
             if component is not None:
                 component.to(device=device)
-
-        lora = getattr(self, f"{stem}_lora", None)
-        if lora is not None:
-            lora.to(device)
+            if lora is not None:
+                lora.to(device=device)
+            self._mem_pools.pop(stem, None)
 
     def eval(self):
         # Put every present component on eval(); driven by the same part registry as materialize()/evict().

--- a/modules/trainer/GenericTrainer.py
+++ b/modules/trainer/GenericTrainer.py
@@ -43,6 +43,12 @@ from torchvision.transforms.functional import pil_to_tensor
 
 from tqdm import tqdm
 
+# OT_DEBUG_PROFILES dumps a CUDA memory snapshot for the first two steps, where the allocator is still
+# growing, and a profiler trace at steps 10 and 40, past compilation and warmup.
+_DEBUG_PROFILES = bool(os.environ.get("OT_DEBUG_PROFILES"))
+_MEMORY_PROFILE_STEPS = (0, 1) if _DEBUG_PROFILES else ()
+_PROFILE_STEPS = (10, 11, 40, 41) if _DEBUG_PROFILES else ()
+
 
 class GenericTrainer(BaseTrainer):
     model_loader: BaseModelLoader
@@ -725,8 +731,8 @@ class GenericTrainer(BaseTrainer):
                 self.callbacks.on_update_status("Training ...")
 
                 with (
-                    TorchMemoryRecorder(enabled=False, filename=f"memory-step{train_progress.global_step}-{get_string_timestamp()}.pickle"),
-                    TorchProfiler      (enabled=False, filename=f"profile-step{train_progress.global_step}-{get_string_timestamp()}.json"),
+                    TorchMemoryRecorder(enabled=train_progress.global_step in _MEMORY_PROFILE_STEPS, filename=f"memory-step{train_progress.global_step}-{get_string_timestamp()}.pickle"),
+                    TorchProfiler      (enabled=train_progress.global_step in _PROFILE_STEPS, filename=f"profile-step{train_progress.global_step}-{get_string_timestamp()}.json"),
                 ):
                     step_seed = train_progress.global_step
                     bf16_stochastic_rounding_set_seed(step_seed, train_device)

--- a/modules/util/LayerOffloadConductor.py
+++ b/modules/util/LayerOffloadConductor.py
@@ -1,5 +1,6 @@
 import math
 import random
+from collections import deque
 from typing import Any
 
 from modules.util.config.TrainConfig import TrainConfig, TrainModelPartConfig
@@ -7,12 +8,8 @@ from modules.util.quantization_util import get_offload_tensor_bytes, offload_qua
 from modules.util.torch_util import (
     create_stream_context,
     device_equals,
-    get_tensor_data,
     pin_tensor_,
-    replace_tensors_,
-    tensors_match_device,
     tensors_record_stream,
-    tensors_to_device_,
     torch_gc,
     unpin_tensor_,
 )
@@ -23,10 +20,33 @@ from torch import nn
 MESSAGES = []
 
 
+# Only relevant with activation offloading. Each layer-call the CPU enqueues ahead of the GPU floats one
+# layer's worth of activations - the forward's copy stays alive until its D2H runs, the backward's reload
+# destination is allocated when the CPU reaches the block - so the run-ahead has to be capped for peak VRAM
+# to be predictable at all. Saturation needs only enough queued work to cover CPU-side jitter (tens of ms)
+# against a layer-call of tens to hundreds of ms, so a small cap costs no throughput. 0 = unbounded.
+#
+# Also the number of trailing layers whose activations are not offloaded: the backward consumes N-1..0, so
+# the offloads still draining when the forward ends - at most this many - are the ones needed first. Keeping
+# those layers resident is free at this cap and saves a D2H/H2D round-trip of the same bytes.
+MAX_LAYER_CALLS_IN_FLIGHT = 2
+
+
 def log(msg: str = ''):
     pass
     # print(msg)
     # MESSAGES.append(msg)
+
+
+def flat_storage_view(tensor: torch.Tensor) -> torch.Tensor | None:
+    # Contiguous 1-D view over a tensor's whole storage region, or None if the strides leave gaps so that the
+    # elements between the first and last are not all part of this tensor. A permuted view of a freshly
+    # allocated tensor (a transpose, a head-split) is dense and yields a view; a slice of something larger
+    # does not. Copying through this view moves the bytes as-is instead of gathering them element by element.
+    span = 1 + sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride(), strict=True))
+    if span != tensor.numel():
+        return None
+    return torch.as_strided(tensor, (tensor.numel(),), (1,), tensor.storage_offset())
 
 
 def clone_tensor_allocator(tensor: torch.Tensor) -> torch.Tensor:
@@ -245,6 +265,10 @@ class StaticActivationAllocator:
         self.__current_cache_tensor_offset = 0
         self.__allocated_bytes = 0
         self.__max_allocated_bytes = 0
+
+    @property
+    def allocated_bytes(self) -> int:
+        return self.__allocated_bytes
 
     def reserve_cache(self, tensors: list[torch.Tensor]):
         num_bytes = sum(tensor.element_size() * tensor.numel() for tensor in tensors) \
@@ -521,6 +545,23 @@ class LayerOffloadStrategy:
             return [x for x in layers if x < layer_index] + [x for x in layers if x >= layer_index]
 
 
+class _BoundaryActivation:
+    # Offloaded copy of a saved activation on the boundary path. Copy semantics (never mutate the saved
+    # tensor in place - it may be shared across blocks, e.g. a conditioning embedding). cpu holds the
+    # temp-device copy; gpu the reloaded train-device copy; event marks the reload transfer.
+    def __init__(self):
+        self.cpu = None
+        self.gpu = None
+        self.event = None
+        # the source tensor's stride, restored on reload. A saved activation is often a permuted view
+        # (an attention output, a head-split), and the compiled backward asserts on exact strides, so
+        # handing it back contiguous fails assert_size_stride rather than silently computing wrong.
+        self.stride = None
+        # whether the source's storage region was dense, so both legs could move it as flat storage rather
+        # than reordering elements through a copy kernel.
+        self.dense = False
+
+
 class LayerOffloadConductor:
     __module: nn.Module
 
@@ -528,7 +569,6 @@ class LayerOffloadConductor:
     __layer_device_map: list[torch.device | None]
     __layer_offload_fraction: float
 
-    __layer_activations_included_offload_param_indices_map: list[list[int]]
 
     __train_device: torch.device
     __temp_device: torch.device
@@ -548,13 +588,10 @@ class LayerOffloadConductor:
     __layer_train_event_map: list[SyncEvent]
     __layer_transfer_event_map: list[SyncEvent]
 
-    __activations_map: dict[int, Any]
-    __call_index_layer_index_map: dict[int, int]
-    __activations_transfer_event_map: dict[int, SyncEvent]
 
     __offload_strategy = LayerOffloadStrategy | None
     __is_forward_pass: bool
-    __keep_graph: bool
+    __backward_follows: bool
 
     __is_active: bool
 
@@ -576,7 +613,6 @@ class LayerOffloadConductor:
         self.__layer_device_map = []
         self.__layer_offload_fraction = part.offload_fraction
 
-        self.__layer_activations_included_offload_param_indices_map = []
 
         self.__train_device = torch.device(config.train_device)
         self.__temp_device = torch.device(config.temp_device)
@@ -601,13 +637,14 @@ class LayerOffloadConductor:
         self.__layer_train_event_map = []
         self.__layer_transfer_event_map = []
 
-        self.__activations_map = {}
-        self.__call_index_layer_index_map = {}
-        self.__activations_transfer_event_map = {}
+        self.__boundary_activations = {}
 
         self.__offload_strategy = None
         self.__is_forward_pass = False
-        self.__keep_graph = False
+        self.__backward_follows = False
+        self.__inflight_call_events = deque()
+        self.__inflight_transfer_events = deque()
+        self.__warned_non_dense = False
 
         self.__is_active = False
 
@@ -618,11 +655,13 @@ class LayerOffloadConductor:
     def offload_activated(self) -> bool:
         return self.__offload_activations or self.__offload_layers
 
+    def offloads_activations(self) -> bool:
+        return self.__offload_activations
+
     def to(self, device: torch.device):
         torch_gc()
 
         self.__wait_all_layer_transfers()
-        self.__wait_all_activation_transfers()
 
         if device_equals(device, self.__temp_device):
             log("to temp device")
@@ -678,18 +717,13 @@ class LayerOffloadConductor:
 
         torch_gc()
 
-    def add_layer(self, layer: nn.Module, included_offload_param_indices: list[int] = None):
-        if included_offload_param_indices is None:
-            included_offload_param_indices = []
-
+    def add_layer(self, layer: nn.Module):
         self.__layers.append(layer)
         self.__layer_device_map.append(None)
         self.__layer_train_event_map.append(SyncEvent())
         self.__layer_transfer_event_map.append(SyncEvent())
 
-        self.__layer_activations_included_offload_param_indices_map.append(included_offload_param_indices)
-
-    def start_forward(self, keep_graph: bool):
+    def start_forward(self, backward_follows: bool):
         log("starting forward")
 
         if not self.__is_active:
@@ -701,89 +735,69 @@ class LayerOffloadConductor:
         self.__clear_activations()
 
         self.__is_forward_pass = True
-        self.__keep_graph = keep_graph
+        self.__backward_follows = backward_follows
+        # events from the previous step refer to work the GPU has long finished; carrying them over would
+        # make the first calls of this pass wait on stale entries.
+        self.__inflight_call_events.clear()
+        self.__inflight_transfer_events.clear()
 
-    def before_layer(self, layer_index: int, call_index: int, activations: Any) -> Any:
-        log()
-        log(f"before layer {layer_index}, {call_index}")
+    def __schedule_layer_offload(self, layer_index: int, is_forward: bool, is_next_forward: bool):
+        # windowed layer load/offload schedule around layer_index, in the direction the caller is
+        # running: the boundaries know whether they are in the forward or the backward pass.
+        if not self.__offload_layers:
+            return
 
-        if not self.__is_active:
-            return activations
+        self.__wait_layer_transfer(layer_index)
 
-        self.__call_index_layer_index_map[call_index] = layer_index
+        self.__schedule_deferred_layers_to_temp(except_layer=layer_index)
+        for i in self.__offload_strategy.get_layers_to_offload(
+                layer_index=layer_index,
+                is_forward=is_forward,
+                is_next_forward=is_next_forward,
+                loaded_layers=self.__get_loaded_layers(),
+        ):
+            self.__schedule_layer_to(i, self.__temp_device, is_forward=is_forward)
 
-        if torch.is_grad_enabled() and self.__is_forward_pass:
-            # Offloading can only be used with the use_reentrant=True checkpointing variant.
-            # Gradients are only enabled during the back pass.
-            log("starting backward")
-            self.__is_forward_pass = False
+        for i in self.__offload_strategy.get_layers_to_load(
+                layer_index=layer_index,
+                is_forward=is_forward,
+                is_next_forward=is_next_forward,
+                loaded_layers=self.__get_loaded_layers(),
+        ):
+            self.__schedule_layer_to(i, self.__train_device, is_forward=is_forward)
 
-        if self.__offload_activations and not self.__is_forward_pass:
-            self.__wait_activations_transfer(call_index)
-
-            tensor_indices = self.__layer_activations_included_offload_param_indices_map[layer_index]
-
-            if call_index in self.__activations_map:
-                # during the back pass, replace activations with saved acitvations
-                replace_tensors_(activations, self.__activations_map.pop(call_index), tensor_indices)
-
-            # if current activations are not on train_device, move them now
-            if not tensors_match_device(
-                    activations, self.__train_device,
-                    tensor_indices):
-                log(f"activations for layer {layer_index} not loaded to train device, transferring now")
-                self.__schedule_activations_to_device(
-                    activations, self.__train_device, call_index, wait_train_stream=False)
-                self.__wait_activations_transfer(call_index)
-
-            # schedule previous activations to the train device
-            if call_index - 1 in self.__activations_map:
-                self.__schedule_activations_to_device(
-                    self.__activations_map[call_index - 1], self.__train_device, call_index - 1,
-                    wait_train_stream=False)
-
-        # schedule loading of the next layer and offloading of the previous layer
-        if self.__offload_layers:
-            self.__wait_layer_transfer(layer_index)
-
-            self.__schedule_deferred_layers_to_temp(except_layer=layer_index)
-            for i in self.__offload_strategy.get_layers_to_offload(
-                    layer_index=layer_index,
-                    is_forward=self.__is_forward_pass,
-                    is_next_forward=not self.__keep_graph,
-                    loaded_layers=self.__get_loaded_layers(),
-            ):
-                self.__schedule_layer_to(i, self.__temp_device, is_forward=self.__is_forward_pass)
-
-            for i in self.__offload_strategy.get_layers_to_load(
-                    layer_index=layer_index,
-                    is_forward=self.__is_forward_pass,
-                    is_next_forward=not self.__keep_graph,
-                    loaded_layers=self.__get_loaded_layers(),
-            ):
-                self.__schedule_layer_to(i, self.__train_device, is_forward=self.__is_forward_pass)
-
-        return activations
-
-    def after_layer(self, layer_index: int, call_index: int, activations: Any):
-        log(f"after layer {layer_index}, {call_index}")
-
+    def before_layer(self, layer_index: int, is_forward: bool):
+        # called before a block runs. Waits for this layer's transfer and slides the load window.
         if not self.__is_active:
             return
 
-        # record stream
-        if self.__async_transfer:
-            tensors_record_stream(self.__train_stream, activations)
+        # block until compute and activation transfers have caught up to within MAX_LAYER_CALLS_IN_FLIGHT,
+        # so the floating activations stay bounded.
+        if MAX_LAYER_CALLS_IN_FLIGHT > 0:
+            queues = (("compute", self.__inflight_call_events), ("transfer", self.__inflight_transfer_events))
+            for name, queue in queues:
+                while len(queue) > MAX_LAYER_CALLS_IN_FLIGHT:
+                    queue.popleft().synchronize(f"layer-calls-in-flight cap ({name})")
 
-        # save activations during the forward pass to make them accessible during the backward pass
-        if self.__offload_activations and self.__keep_graph and self.__is_forward_pass:
-            log(f"saving layer {call_index} activations for back pass")
-            self.__activations_map[call_index] = activations
-            self.__schedule_activations_to_device(activations, self.__temp_device, call_index, wait_train_stream=True)
+        self.__schedule_layer_offload(layer_index, is_forward, not self.__backward_follows)
 
-        if self.__async_transfer:
-            event = SyncEvent(self.__train_stream.record_event(), f"train on {self.__train_device}")
-            self.__layer_train_event_map[layer_index] = event
+    def after_layer(self, layer_index: int, activations: Any):
+        # called once this layer's compute is enqueued. Keeps the block's output/grad alive until the train
+        # stream reaches it, and records the event a later offload of this layer has to wait for.
+        if not self.__is_active or not self.__async_transfer:
+            return
+        tensors_record_stream(self.__train_stream, activations)
+        event = SyncEvent(self.__train_stream.record_event(), f"train on {self.__train_device}")
+        self.__layer_train_event_map[layer_index] = event
+        # the same event, queued in call order, is what the run-ahead cap waits on
+        self.__inflight_call_events.append(event)
+
+        # Second marker, on the activations transfer stream, which trails the train stream by its own queue
+        # (measured ~106ms median, ~12 layer-calls of float against a cap of 2). An offloaded activation's
+        # source block is pinned until its D2H actually executes, so this is the distance that holds memory.
+        if self.__offload_activations:
+            self.__inflight_transfer_events.append(
+                SyncEvent(self.__activations_transfer_stream.record_event(), "activations transfer"))
 
     def __get_loaded_layers(self) -> list[int]:
         return [i for i in range(len(self.__layers)) if device_equals(self.__layer_device_map[i], self.__train_device)]
@@ -803,9 +817,7 @@ class LayerOffloadConductor:
         self.__module._apply(convert)
 
     def __clear_activations(self):
-        self.__activations_map.clear()
-        self.__call_index_layer_index_map.clear()
-        self.__activations_transfer_event_map.clear()
+        self.__boundary_activations.clear()
         self.__temp_device_activations_allocator.deallocate()
 
     def __wait_all_layer_train(self):
@@ -815,11 +827,6 @@ class LayerOffloadConductor:
     def __wait_all_layer_transfers(self):
         for layer_index in range(len(self.__layers)):
             self.__wait_layer_transfer(layer_index)
-
-    def __wait_all_activation_transfers(self):
-        call_indices = list(self.__activations_transfer_event_map.keys())
-        for call_index in call_indices:
-            self.__wait_activations_transfer(call_index)
 
     def __wait_layer_train(self, layer_index: int):
         self.__layer_train_event_map[layer_index] \
@@ -831,12 +838,6 @@ class LayerOffloadConductor:
             self.__layer_transfer_event_map[layer_index] \
                 .wait(self.__train_stream, f"wait layer transfer {layer_index}")
             self.__layer_transfer_event_map[layer_index] = SyncEvent()
-
-    def __wait_activations_transfer(self, call_index: int):
-        event = self.__activations_transfer_event_map.pop(call_index, None)
-
-        if event is not None:
-            event.wait(self.__train_stream, f"wait activations transfer {call_index}")
 
     def __schedule_layer_to(
             self,
@@ -908,40 +909,92 @@ class LayerOffloadConductor:
                 continue
             self.__schedule_layer_to(layer_index, device=self.__temp_device, is_forward=False)
 
-    def __schedule_activations_to_device(
-            self,
-            activations: Any,
-            device: torch.device,
-            call_index: int,
-            wait_train_stream: bool,
-    ):
-        log(f"schedule {call_index} activations to {str(device)}")
-        layer_index = self.__call_index_layer_index_map[call_index]
+    def pack_activation(self, layer_index: int, tensor: torch.Tensor):
+        # Copies rather than moving in place, so a tensor still referenced by other blocks (e.g. a shared
+        # conditioning embedding) is never corrupted. The caller selects which tensors to offload.
+        if not self.__is_active or not self.__offload_activations \
+                or not device_equals(tensor.device, self.__train_device) \
+                or layer_index >= len(self.__layers) - MAX_LAYER_CALLS_IN_FLIGHT:
+            return tensor
 
-        activations_allocator = self.__temp_device_activations_allocator \
-            if device_equals(device, self.__temp_device) \
-            else None
-
-        allocator_fn = activations_allocator.allocate_like if activations_allocator is not None else None
-
-        event = None
-        if wait_train_stream and self.__async_transfer:
-            event = SyncEvent(self.__train_stream.record_event(), f"train before activations transfer {call_index}")
+        handle = _BoundaryActivation()
+        handle.stride = tensor.stride()
+        # Transfer the storage as-is when the tensor is dense, so both sides of the copy are contiguous and
+        # equal-length and the transfer stays a DMA. Non-dense tensors have no flat view and fall back to the
+        # logical copy, which reorders elements through a kernel but is always correct.
+        source = flat_storage_view(tensor)
+        handle.dense = source is not None
+        if source is None:
+            source = tensor
+            if not self.__warned_non_dense:
+                # not expected with the current save set (SDPA and mm outputs are fresh allocations), but a
+                # chunk or slice would land here, so say so rather than silently paying the kernel path.
+                # Warn rather than raise: a save set that widens to include a view should get slower, not
+                # abort a training run.
+                self.__warned_non_dense = True
+                print("non-dense activation offloaded via the logical copy path: "
+                      f"layer {layer_index}, shape {tuple(tensor.shape)}, stride {tensor.stride()}")
 
         with create_stream_context(self.__activations_transfer_stream):
-            tensor_indices = self.__layer_activations_included_offload_param_indices_map[layer_index]
+            if self.__async_transfer:
+                self.__activations_transfer_stream.wait_stream(self.__train_stream)
+            self.__temp_device_activations_allocator.reserve_cache([tensor])
+            handle.cpu = self.__temp_device_activations_allocator.allocate_like(tensor)
+            destination = handle.cpu.view(-1) if handle.dense else handle.cpu
+            destination.copy_(source, non_blocking=self.__async_transfer)
+            if self.__async_transfer:
+                tensors_record_stream(self.__activations_transfer_stream, tensor)  # source alive until copied
 
+        self.__boundary_activations.setdefault(layer_index, []).append(handle)
+        return handle
+
+    def __reload_activation(self, handle: '_BoundaryActivation'):
+        if handle.gpu is not None:
+            return
+        # Allocate under the train stream: the allocator's free lists are per-stream, so a destination
+        # homed on the transfer stream can never be reused by compute and forms a second segment pool.
+        # Dense tensors allocate contiguous and get the recorded layout as_strided over them, so the DMA
+        # moves storage without reordering. empty_strided is the non-dense fallback.
+        with create_stream_context(self.__train_stream):
+            if handle.dense:
+                flat = torch.empty(handle.cpu.numel(), dtype=handle.cpu.dtype, device=self.__train_device)
+                handle.gpu = torch.as_strided(flat, handle.cpu.shape, handle.stride)
+            else:
+                handle.gpu = torch.empty_strided(
+                    handle.cpu.shape, handle.stride, dtype=handle.cpu.dtype, device=self.__train_device)
+
+        # the allocator may have just reclaimed this block from still-queued train work, which the H2D on
+        # the transfer stream would otherwise overwrite. Recorded, not waited on here, so the transfer
+        # still overlaps the current layer's compute.
+        event = SyncEvent(self.__train_stream.record_event(), "train before activation reload") \
+            if self.__async_transfer else None
+
+        with create_stream_context(self.__activations_transfer_stream):
             if event is not None:
                 event.wait(self.__activations_transfer_stream)
-
-            tensors = get_tensor_data(activations, tensor_indices)
-            if activations_allocator is not None:
-                activations_allocator.reserve_cache(tensors)
-            tensors_to_device_(activations, device, tensor_indices, non_blocking=self.__async_transfer, allocator=allocator_fn)
-
+            if handle.dense:
+                flat_storage_view(handle.gpu).copy_(handle.cpu.view(-1), non_blocking=self.__async_transfer)
+            else:
+                handle.gpu.copy_(handle.cpu, non_blocking=self.__async_transfer)
             if self.__async_transfer:
-                tensors_record_stream(self.__activations_transfer_stream, tensors)
-                self.__activations_transfer_event_map[call_index] = \
-                    SyncEvent(self.__activations_transfer_stream.record_event(), f"transfer to {device}")
+                tensors_record_stream(self.__activations_transfer_stream, handle.gpu)
+                handle.event = SyncEvent(self.__activations_transfer_stream.record_event())
 
-            del tensors
+    def prefetch_activations(self, layer_index: int):
+        # reload a block's offloaded activations one block ahead so unpack only waits on the transfer
+        if not self.__is_active or not self.__offload_activations:
+            return
+        for handle in self.__boundary_activations.get(layer_index, []):
+            self.__reload_activation(handle)
+
+    def unpack_activation(self, handle: Any):
+        if not isinstance(handle, _BoundaryActivation):
+            return handle  # was not offloaded
+        self.__reload_activation(handle)  # no-op if already prefetched
+        if self.__async_transfer and handle.event is not None:
+            handle.event.wait(self.__train_stream)
+            tensors_record_stream(self.__train_stream, handle.gpu)
+        gpu = handle.gpu
+        handle.gpu = None
+        handle.event = None
+        return gpu

--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -6,7 +6,6 @@ from typing import Any
 from modules.util.compile_util import init_compile
 from modules.util.config.TrainConfig import TrainConfig, TrainModelPartConfig
 from modules.util.LayerOffloadConductor import LayerOffloadConductor
-from modules.util.torch_util import add_dummy_grad_fn_, has_grad_fn
 
 import torch
 from torch import nn
@@ -45,6 +44,13 @@ def _kwargs_to_args(fun: Callable, args: tuple[Any, ...], kwargs: dict[str, Any]
     return tuple(parameters)
 
 
+def _view_key(tensor: torch.Tensor) -> tuple:
+    # Identifies a tensor by the memory it reads: first-element address, extents, steps, element type.
+    # Two tensors agreeing on all four are the same view of the same data, since live storages cannot
+    # overlap. Used instead of identity because autograd hands back aliases, not the original objects.
+    return tensor.data_ptr(), tensor.shape, tensor.stride(), tensor.dtype
+
+
 def __get_args_indices(fun: Callable, arg_names: list[str]) -> list[int]:
     signature = dict(inspect.signature(fun).parameters)
     indices = []
@@ -56,22 +62,13 @@ def __get_args_indices(fun: Callable, arg_names: list[str]) -> list[int]:
     return indices
 
 
-__current_call_index = 0
-
-
-def _generate_call_index() -> int:
-    global __current_call_index
-    __current_call_index += 1
-    return __current_call_index
-
-
 class BaseCheckpointLayer(torch.nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
 class CheckpointLayer(BaseCheckpointLayer):
-    def __init__(self, orig_module: nn.Module, orig_forward, train_device: torch.device, checkpointing: bool = True):
+    def __init__(self, orig_module: nn.Module, orig_forward, checkpointing: bool = True):
         super().__init__()
 
         assert (orig_module is None or orig_forward is None) and not (orig_module is None and orig_forward is None)
@@ -79,20 +76,13 @@ class CheckpointLayer(BaseCheckpointLayer):
         self.orig_forward = orig_forward
         self.checkpointing = checkpointing
 
-        # dummy tensor that requires grad is needed for checkpointing to work when training a LoRA
-        self.dummy = torch.zeros((1,), device=train_device, requires_grad=True)
-
     def __orig(self, *args, **kwargs):
         return self.orig_forward(*args, **kwargs) if self.checkpoint is None else self.checkpoint(*args, **kwargs)
-
-    def __checkpointing_forward(self, dummy: torch.Tensor, *args, **kwargs):
-        return self.__orig(*args, **kwargs)
 
     def forward(self, *args, **kwargs):
         if self.checkpointing and torch.is_grad_enabled():
             return torch.utils.checkpoint.checkpoint(
-                self.__checkpointing_forward,
-                self.dummy,
+                self.__orig,
                 *args,
                 **kwargs,
                 use_reentrant=False
@@ -100,18 +90,80 @@ class CheckpointLayer(BaseCheckpointLayer):
         else:
             return self.__orig(*args, **kwargs)
 
-class OffloadCheckpointLayer(BaseCheckpointLayer):
-    def __init__(self, orig_module: nn.Module, orig_forward, train_device: torch.device, conductor: LayerOffloadConductor, layer_index: int, checkpointing: bool):
+
+class LoadBoundary(torch.autograd.Function):
+    # Identity op on a block's grad-carrying INPUT tensors, driving the conductor only: forward calls
+    # before_layer, backward calls after_layer. Sitting on the input makes its backward fire LAST in
+    # the block's backward.
+    @staticmethod
+    def forward(ctx, conductor, layer_index, *tensors):
+        ctx.conductor = conductor
+        ctx.layer_index = layer_index
+        conductor.before_layer(layer_index, is_forward=True)
+        return tensors
+    @staticmethod
+    def backward(ctx, *grads):
+        # calling after_layer here, rather than after the forward, makes the train event cover the block's
+        # backward kernels, so this layer's offload transfer cannot overlap them.
+        ctx.conductor.after_layer(ctx.layer_index, list(grads))
+        return (None, None, *grads)
+
+
+class EvictBoundary(torch.autograd.Function):
+    # Identity op on a block's grad-carrying OUTPUT tensors: forward calls after_layer, backward calls
+    # before_layer. Sitting on the output makes its backward fire FIRST - before the checkpoint
+    # rematerializes the block, so the weights are in by then.
+    @staticmethod
+    def forward(ctx, conductor, layer_index, *tensors):
+        ctx.conductor = conductor
+        ctx.layer_index = layer_index
+        conductor.after_layer(layer_index, list(tensors))
+        return tensors
+    @staticmethod
+    def backward(ctx, *grads):
+        # workaround for https://github.com/pytorch/pytorch/issues/186537. This is the block's first
+        # backward node, and it runs on the autograd worker thread - which is where AOTAutograd
+        # compiles the backward graph, and which does not inherit the main thread's dynamo config.
+        init_compile()
+        ctx.conductor.before_layer(ctx.layer_index, is_forward=False)
+        ctx.conductor.prefetch_activations(ctx.layer_index - 1)
+        return (None, None, *grads)
+
+
+def _apply_boundary(boundary, conductor, layer_index, values: tuple) -> tuple:
+    # Wrap all grad-requiring tensors in `values` in a single boundary Function, so its backward fires
+    # exactly once around the checkpoint's recompute and no gradient can reach the checkpoint without
+    # crossing the boundary. Non-tensor and grad-free entries pass through untouched.
+    indices = [i for i, v in enumerate(values) if isinstance(v, torch.Tensor) and v.requires_grad]
+    if not indices:
+        return values
+    wrapped = boundary.apply(conductor, layer_index, *(values[i] for i in indices))
+    values = list(values)
+    for j, i in enumerate(indices):
+        values[i] = wrapped[j]
+    return tuple(values)
+
+
+class BoundaryOffloadCheckpointLayer(BaseCheckpointLayer):
+    # Weight movement driven by the LoadBoundary / EvictBoundary autograd Functions, which run eagerly
+    # outside the compiled region. The block's forward and backward each stay a single traced graph, which
+    # is what makes this path compatible with torch.compile's cudagraph trees. Activation offloading, when
+    # enabled, rides on saved_tensors_hooks around the block.
+    def __init__(self, orig_module: nn.Module, orig_forward, conductor: LayerOffloadConductor, layer_index: int, checkpointing: bool, included_offload_param_indices: list[int], compile: bool):
         super().__init__()
 
         assert (orig_module is None or orig_forward is None) and not (orig_module is None and orig_forward is None)
         self.checkpoint = orig_module
         self.orig_forward = orig_forward
-
-        self.dummy = torch.zeros((1,), device=train_device, requires_grad=True)
         self.conductor = conductor
         self.layer_index = layer_index
         self.checkpointing = checkpointing
+        self.included_offload_param_indices = included_offload_param_indices
+        # compile the block together with its checkpoint, not the bare block: dynamo then traces the
+        # checkpoint as a higher-order op and the min-cut partitioner prunes the recompute to what the
+        # backward needs. With the checkpoint outside the compiled region the backward re-runs the whole
+        # block. Traceable at all only because no conductor call happens in here.
+        self.run_block = torch.compile(self.__checkpointed_block, fullgraph=True) if compile else self.__checkpointed_block
 
     def __deepcopy__(self, memo):
         # conductor holds torch.cuda.Stream/Event objects that cannot be deep-copied or pickled.
@@ -120,57 +172,71 @@ class OffloadCheckpointLayer(BaseCheckpointLayer):
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
+        # run_block is shared for the same reason as conductor: it closes over this instance, and
+        # deepcopy is only used at save time where it is never invoked.
         for key, value in self.__dict__.items():
-            result.__dict__[key] = value if key == "conductor" else copy.deepcopy(value, memo)
+            result.__dict__[key] = value if key in ("conductor", "run_block") else copy.deepcopy(value, memo)
         return result
 
-    def __checkpointing_forward(self, dummy: torch.Tensor, call_id: int, *args):
-        init_compile()  # workaround for https://github.com/pytorch/pytorch/issues/186537
-        if self.layer_index == 0 and not torch.is_grad_enabled():
-            self.conductor.start_forward(True)
+    def __orig(self, *args):
+        return self.orig_forward(*args) if self.checkpoint is None else self.checkpoint(*args)
 
-        args = self.conductor.before_layer(self.layer_index, call_id, args)
-        output = self.orig_forward(*args) if self.checkpoint is None else self.checkpoint(*args)
+    def __checkpointed_block(self, *args):
+        if self.checkpointing:
+            # recompute the block in the backward, pruned by the min-cut partitioner when compiled
+            return torch.utils.checkpoint.checkpoint(self.__orig, *args, use_reentrant=False)
+        # no checkpointing: run once, autograd keeps every activation the backward needs
+        return self.__orig(*args)
 
-        self.conductor.after_layer(self.layer_index, call_id, args)
+    def __run_block(self, args):
+        def run():
+            return self.run_block(*args)
 
-        # make sure at least one of the output tensors has a grad_fn so the output of the checkpoint has a grad_fn.
-        # this can only happen if a checkpointed block has no trainable parameters, because of a layer filter
-        # was used. Adding a dummy grad function is a workaround required by use_reentrant==True checkpointing:
-        if torch.is_grad_enabled() and not has_grad_fn(output):
-            output = add_dummy_grad_fn_(output)
-
-        return output
+        if not self.conductor.offloads_activations():
+            return run()
+        # Offload only the declared activation args. The declaration carries cross-block knowledge the
+        # min-cut partitioner cannot have, seeing one block at a time: a tensor shared by every block
+        # (rotary embeddings, masks) is saved once per block, and offloading those copies frees nothing
+        # because the original stays live for the remaining blocks.
+        #
+        # Matched by view rather than by identity, because autograd saves an alias of the arg rather than
+        # the arg object, so id() misses. Grad-agnostic: a LoRA layer filter can leave an offloaded
+        # activation grad-free.
+        layer_index = self.layer_index
+        targets = {_view_key(args[i]) for i in self.included_offload_param_indices
+                   if i < len(args) and isinstance(args[i], torch.Tensor)}
+        with torch.autograd.graph.saved_tensors_hooks(
+                lambda t: self.conductor.pack_activation(layer_index, t) if _view_key(t) in targets else t,
+                self.conductor.unpack_activation):
+            return run()
 
     def forward(self, *args, **kwargs):
-        call_id = _generate_call_index()
         args = _kwargs_to_args(self.orig_forward if self.checkpoint is None else self.checkpoint.forward, args, kwargs)
-        if torch.is_grad_enabled():
-            # a backward will flow through this layer (grad enabled), so offloading needs use_reentrant=True
-            # checkpointing to move the offloaded tensors back during recompute. Fail loud rather than silently
-            # enabling checkpointing the part disabled. Under no_grad (e.g. sampling a frozen part) the branch
-            # below offloads without checkpointing.
-            if not self.checkpointing:
-                raise NotImplementedError("offloading requires gradient checkpointing")
-            return torch.utils.checkpoint.checkpoint(
-                self.__checkpointing_forward,
-                self.dummy,
-                call_id,
-                *args,
-                use_reentrant=True
-            )
-        else:
-            if self.layer_index == 0:
-                self.conductor.start_forward(False)
 
-            args = self.conductor.before_layer(self.layer_index, call_id, args)
-            output = self.orig_forward(*args) if self.checkpoint is None else self.checkpoint(*args)
-            self.conductor.after_layer(self.layer_index, call_id, args)
+        if not torch.is_grad_enabled():
+            # inference / frozen: no backward flows, so no boundaries are needed. Schedule, run
+            # and record inline.
+            if self.layer_index == 0:
+                self.conductor.start_forward(backward_follows=False)
+            self.conductor.before_layer(self.layer_index, is_forward=True)
+            # still through run_block: under no_grad the checkpoint inside it is a passthrough, and this
+            # keeps sampling on the compiled path (dynamo traces a separate inference variant)
+            output = self.run_block(*args)
+            self.conductor.after_layer(self.layer_index, list(args))
             return output
+
+        if self.layer_index == 0:
+            self.conductor.start_forward(backward_follows=True)
+
+        args = _apply_boundary(LoadBoundary, self.conductor, self.layer_index, args)
+        output = self.__run_block(args)
+        output_tuple = output if isinstance(output, tuple) else (output,)
+        output_tuple = _apply_boundary(EvictBoundary, self.conductor, self.layer_index, output_tuple)
+        return output_tuple if isinstance(output, tuple) else output_tuple[0]
+
 
 def create_checkpoint(
         orig_module: nn.Module,
-        train_device: torch.device,
         include_from_offload_param_names: list[str] = None,
         conductor: LayerOffloadConductor | None = None,
         checkpointing: bool = True,
@@ -182,32 +248,43 @@ def create_checkpoint(
     included_offload_param_indices = __get_args_indices(orig_module.forward, include_from_offload_param_names)
 
     if conductor is not None:
-        conductor.add_layer(orig_module, included_offload_param_indices)
+        conductor.add_layer(orig_module)
 
     if conductor is not None and conductor.offload_activated():
-        # offloading is structurally coupled to use_reentrant=True checkpointing during the back pass: the
-        # recompute is the only thing firing before_layer/after_layer in the backward direction, so both layer
-        # and activation offloading need checkpointing to move tensors back for backward. That coupling only
-        # matters when a backward actually flows, so OffloadCheckpointLayer.forward enforces it per call (fail
-        # loud under grad, offload freely under no_grad) instead of rejecting the frozen/inference case here.
+        # Compiled, the boundary layer compiles the block together with its checkpoint, so orig_module must
+        # not be compiled separately here - that would put the checkpoint back outside the compiled region
+        # and force a full recompute.
         if compile:
-            layer = OffloadCheckpointLayer(orig_module=orig_module, orig_forward=None, train_device=train_device, conductor=conductor, layer_index=layer_index, checkpointing=checkpointing)
-            #don't compile the checkpointing layer - offloading cannot be compiled:
-            orig_module.compile(fullgraph=True)
-            return layer
+            return BoundaryOffloadCheckpointLayer(
+                orig_module=orig_module,
+                orig_forward=None,
+                conductor=conductor,
+                layer_index=layer_index,
+                checkpointing=checkpointing,
+                included_offload_param_indices=included_offload_param_indices,
+                compile=True,
+            )
         else:
             #only patch forward() if possible. Inserting layers is necessary for torch.compile, but causes issues with at least 1 text encoder model. we don't compile text encoders
-            layer = OffloadCheckpointLayer(orig_module=None, orig_forward=orig_module.forward, train_device=train_device, conductor=conductor, layer_index=layer_index, checkpointing=checkpointing)
+            layer = BoundaryOffloadCheckpointLayer(
+                orig_module=None,
+                orig_forward=orig_module.forward,
+                conductor=conductor,
+                layer_index=layer_index,
+                checkpointing=checkpointing,
+                included_offload_param_indices=included_offload_param_indices,
+                compile=False,
+            )
             orig_module.forward = layer.forward
             return orig_module
     else:
         if compile:
-            layer = CheckpointLayer(orig_module=orig_module, orig_forward=None, train_device=train_device, checkpointing=checkpointing)
+            layer = CheckpointLayer(orig_module=orig_module, orig_forward=None, checkpointing=checkpointing)
             #do compile the checkpointing layer - slightly faster
             layer.compile(fullgraph=True)
             return layer
         else:
-            layer = CheckpointLayer(orig_module=None, orig_forward=orig_module.forward, train_device=train_device, checkpointing=checkpointing)
+            layer = CheckpointLayer(orig_module=None, orig_forward=orig_module.forward, checkpointing=checkpointing)
             orig_module.forward = layer.forward
             return orig_module
 
@@ -216,7 +293,6 @@ def _create_checkpoints_for_module_list(
         include_from_offload_param_names: list[str],
         conductor: LayerOffloadConductor,
         checkpointing: bool,
-        train_device: torch.device,
         layer_index: int,
         compile: bool,
 ) -> int:
@@ -225,7 +301,7 @@ def _create_checkpoints_for_module_list(
         if isinstance(module_list[i], BaseCheckpointLayer):
             continue
         module_list[i] = create_checkpoint(
-                layer, train_device,
+                layer,
                 include_from_offload_param_names,
                 conductor, checkpointing, layer_index, compile=compile,
             )
@@ -253,11 +329,13 @@ def enable_checkpointing(
     conductor = LayerOffloadConductor(model, config, part) if offload else None
     checkpointing = part.checkpointing_enabled()
 
-    # a trained part always has grad flowing through it, so offloading without checkpointing is guaranteed to hit
-    # OffloadCheckpointLayer.forward's fail-loud path. Reject it here so the misconfiguration surfaces at setup
-    # instead of the first training step. Frozen parts (part.train == False) are left to the per-call check: e.g.
-    # Ideogram's unconditional transformer runs only under no_grad during sampling, so it offloads without
-    # checkpointing there, while a frozen denoiser/TE still fails loud when a trained embedding routes grad through it.
+    # Offloading requires checkpointing. A block's backward reads its weights through SavedVariables taken
+    # during the forward, which hold a shallow copy - repointing param.data at a reloaded buffer never
+    # redirects them - while the conductor recycles weight buffers between layers, so by then that buffer
+    # can already hold a different layer's weights: plausible but wrong gradients, not an error. The
+    # recompute re-reads the weights after the layer has been loaded back in. Compiled blocks escape this
+    # today (AOTAutograd passes parameters as graph inputs, read at call time), but that is a calling
+    # convention and not a guarantee. Frozen parts run no backward through the block and are exempt.
     if offload and not checkpointing and part.train:
         raise NotImplementedError("offloading requires gradient checkpointing")
 
@@ -272,7 +350,6 @@ def enable_checkpointing(
                 param_names,
                 conductor,
                 checkpointing,
-                torch.device(config.train_device),
                 layer_index,
                 compile = compile,
             )
@@ -287,7 +364,6 @@ def enable_checkpointing(
                         param_names,
                         conductor,
                         checkpointing,
-                        torch.device(config.train_device),
                         layer_index,
                         compile = compile,
                     )

--- a/modules/util/checkpointing_util.py
+++ b/modules/util/checkpointing_util.py
@@ -92,11 +92,11 @@ class CheckpointLayer(BaseCheckpointLayer):
 
 
 class LoadBoundary(torch.autograd.Function):
-    # Identity op on a block's grad-carrying INPUT tensors, driving the conductor only: forward calls
-    # before_layer, backward calls after_layer. Sitting on the input makes its backward fire LAST in
-    # the block's backward.
+    # Identity op on a block's INPUT tensors, driving the conductor only: forward calls before_layer,
+    # backward calls after_layer. Sitting on the input makes its backward fire LAST in the block's
+    # backward. `dummy` keeps the node alive when the inputs carry no grad, see _apply_boundary.
     @staticmethod
-    def forward(ctx, conductor, layer_index, *tensors):
+    def forward(ctx, conductor, layer_index, dummy, *tensors):
         ctx.conductor = conductor
         ctx.layer_index = layer_index
         conductor.before_layer(layer_index, is_forward=True)
@@ -106,7 +106,7 @@ class LoadBoundary(torch.autograd.Function):
         # calling after_layer here, rather than after the forward, makes the train event cover the block's
         # backward kernels, so this layer's offload transfer cannot overlap them.
         ctx.conductor.after_layer(ctx.layer_index, list(grads))
-        return (None, None, *grads)
+        return (None, None, None, *grads)
 
 
 class EvictBoundary(torch.autograd.Function):
@@ -114,7 +114,7 @@ class EvictBoundary(torch.autograd.Function):
     # before_layer. Sitting on the output makes its backward fire FIRST - before the checkpoint
     # rematerializes the block, so the weights are in by then.
     @staticmethod
-    def forward(ctx, conductor, layer_index, *tensors):
+    def forward(ctx, conductor, layer_index, dummy, *tensors):
         ctx.conductor = conductor
         ctx.layer_index = layer_index
         conductor.after_layer(layer_index, list(tensors))
@@ -127,17 +127,24 @@ class EvictBoundary(torch.autograd.Function):
         init_compile()
         ctx.conductor.before_layer(ctx.layer_index, is_forward=False)
         ctx.conductor.prefetch_activations(ctx.layer_index - 1)
-        return (None, None, *grads)
+        return (None, None, None, *grads)
 
 
-def _apply_boundary(boundary, conductor, layer_index, values: tuple) -> tuple:
+def _apply_boundary(boundary, conductor, layer_index, values: tuple, dummy: torch.Tensor | None = None) -> tuple:
     # Wrap all grad-requiring tensors in `values` in a single boundary Function, so its backward fires
     # exactly once around the checkpoint's recompute and no gradient can reach the checkpoint without
     # crossing the boundary. Non-tensor and grad-free entries pass through untouched.
     indices = [i for i, v in enumerate(values) if isinstance(v, torch.Tensor) and v.requires_grad]
+    if not indices and dummy is not None:
+        # Nothing entering the block carries grad, because nothing trainable sits in front of it. A
+        # Function whose inputs all lack grad creates no autograd node, so the boundary would not be
+        # applied at all and the block would run against weights still on the temp device. Force the first
+        # float tensor through against `dummy`, a grad-requiring leaf: the node then exists, and the
+        # block's input gradient - discarded at the boundary - is what fires the backward duty.
+        indices = [i for i, v in enumerate(values) if isinstance(v, torch.Tensor) and v.is_floating_point()][:1]
     if not indices:
         return values
-    wrapped = boundary.apply(conductor, layer_index, *(values[i] for i in indices))
+    wrapped = boundary.apply(conductor, layer_index, dummy, *(values[i] for i in indices))
     values = list(values)
     for j, i in enumerate(indices):
         values[i] = wrapped[j]
@@ -159,6 +166,7 @@ class BoundaryOffloadCheckpointLayer(BaseCheckpointLayer):
         self.layer_index = layer_index
         self.checkpointing = checkpointing
         self.included_offload_param_indices = included_offload_param_indices
+        self.dummy = None
         # compile the block together with its checkpoint, not the bare block: dynamo then traces the
         # checkpoint as a higher-order op and the min-cut partitioner prunes the recompute to what the
         # backward needs. With the checkpoint outside the compiled region the backward re-runs the whole
@@ -228,7 +236,12 @@ class BoundaryOffloadCheckpointLayer(BaseCheckpointLayer):
         if self.layer_index == 0:
             self.conductor.start_forward(backward_follows=True)
 
-        args = _apply_boundary(LoadBoundary, self.conductor, self.layer_index, args)
+        if self.dummy is None:
+            device = next((v.device for v in args if isinstance(v, torch.Tensor)), None)
+            if device is not None:
+                self.dummy = torch.zeros((1,), device=device, requires_grad=True)
+
+        args = _apply_boundary(LoadBoundary, self.conductor, self.layer_index, args, self.dummy)
         output = self.__run_block(args)
         output_tuple = output if isinstance(output, tuple) else (output,)
         output_tuple = _apply_boundary(EvictBoundary, self.conductor, self.layer_index, output_tuple)

--- a/modules/util/torch_util.py
+++ b/modules/util/torch_util.py
@@ -1,7 +1,6 @@
 import gc
 from collections.abc import Callable
 from contextlib import nullcontext
-from typing import Any
 
 import torch
 
@@ -41,73 +40,6 @@ def get_tensor_data(
 
     return tensors
 
-
-def has_grad_fn(
-        data: torch.Tensor | list | tuple | dict,
-        include_parameter_indices: list[int] | None = None,
-) -> bool:
-    if isinstance(data, torch.Tensor) and include_parameter_indices is None:
-        return data.grad_fn is not None
-    elif isinstance(data, list | tuple):
-        for i, elem in enumerate(data):
-            if include_parameter_indices is None or i in include_parameter_indices:
-                if has_grad_fn(elem):
-                    return True
-    elif isinstance(data, dict) and include_parameter_indices is None:
-        for elem in data.values():
-            if has_grad_fn(elem):
-                return True
-
-    return False
-
-def add_dummy_grad_fn_(
-        data: torch.Tensor | list | tuple | dict,
-) -> Any:
-    if isinstance(data, torch.Tensor):
-        if data.grad_fn is not None:
-            return data
-        grad_tensor = torch\
-            .zeros(size=(0, *data.shape[1:]), requires_grad=True, device=data.device, dtype=data.dtype)
-        return torch.cat([data, grad_tensor], dim=0)
-    if isinstance(data, list):
-        for i, elem in enumerate(data):
-            if isinstance(elem, torch.Tensor):
-                if elem.grad_fn is not None:
-                    return data
-                grad_tensor = torch\
-                    .zeros(size=(0, *elem.shape[1:]), requires_grad=True, device=elem.device, dtype=elem.dtype)
-                data[i] = torch.cat([elem, grad_tensor], dim=0)
-                return data
-            else:
-                data[i] = add_dummy_grad_fn_(elem)
-    if isinstance(data, tuple):
-        for i, elem in enumerate(data):
-            if isinstance(elem, torch.Tensor):
-                if elem.grad_fn is not None:
-                    return data
-                grad_tensor = torch\
-                    .zeros(size=(0, *elem.shape[1:]), requires_grad=True, device=elem.device, dtype=elem.dtype)
-                data = list(data)
-                data[i] = torch.cat([elem, grad_tensor], dim=0)
-                data = tuple(data)
-                return data
-            else:
-                data = list(data)
-                data[i] = add_dummy_grad_fn_(elem)
-                data = tuple(data)
-    elif isinstance(data, dict):
-        for key, elem in data.items():
-            if isinstance(elem, torch.Tensor):
-                if elem.grad_fn is not None:
-                    return data
-                grad_tensor = torch \
-                    .zeros(size=(0, *elem.shape[1:]), requires_grad=True, device=elem.device, dtype=elem.dtype)
-                data[key] = torch.cat([elem, grad_tensor], dim=0)
-                return data
-            else:
-                data[key] = add_dummy_grad_fn_(elem)
-
-    return data
 
 def tensors_to_device_(
         data: torch.Tensor | list | tuple | dict,

--- a/modules/util/torch_util.py
+++ b/modules/util/torch_util.py
@@ -1,4 +1,5 @@
 import gc
+import platform
 from collections.abc import Callable
 from contextlib import nullcontext
 
@@ -12,6 +13,20 @@ accelerator = accelerate.Accelerator()
 default_device = accelerator.device
 
 torch_version = packaging.version.parse(torch.__version__)
+
+
+def supports_mem_pool(device: torch.device) -> bool:
+    return device.type == "cuda"
+
+
+def create_mem_pool(device: torch.device):
+    # a dedicated MemPool the caller can allocate into; None on devices without MemPool support (cpu/mps)
+    return torch.cuda.MemPool() if supports_mem_pool(device) else None
+
+
+def mem_pool_context(mem_pool):
+    # route allocations made in this context into the given MemPool; no-op when it is None
+    return torch.cuda.use_mem_pool(mem_pool) if mem_pool is not None else nullcontext()
 
 
 def state_dict_has_prefix(state_dict: dict | None, prefix: str):
@@ -183,14 +198,24 @@ def pin_tensor_(x):
     # not implemented for other device types
     if torch.cuda.is_available():
         cudart = torch.cuda.cudart()
+        num_bytes = x.numel() * x.element_size()
         err = cudart.cudaHostRegister(
             x.data_ptr(),
-            x.numel() * x.element_size(),
+            num_bytes,
             0,
         )
 
         if err.value != 0:
-            raise RuntimeError(f"CUDA Error while trying to pin memory. error: {err.value}, ptr: {x.data_ptr()}, size: {x.numel() * x.element_size()}")
+            hint = ""
+            if err.value == 1 and num_bytes >= 2**31:
+                # the kernel's page list for a registration holds one entry per 4 KiB, so at 2 GiB it reaches
+                # 4 MiB, the largest single kmalloc there is, and the pin is refused whatever the driver or
+                # GPU. cudaErrorInvalidValue at this size has no other cause, so the attribution is safe.
+                hint = (f". A single pinned allocation of {num_bytes / 2**30:.2f} GiB failed: linux "
+                        f"{platform.release()} cannot pin 2 GiB or more in one call, a kernel bug present in "
+                        f"6.11 and 6.12 and fixed in 6.13. Update the kernel, or run on a host with 6.13 or "
+                        f"newer. This attempt leaked {num_bytes / 2**30:.2f} GiB of host memory until reboot")
+            raise RuntimeError(f"CUDA Error while trying to pin memory. error: {err.value}, ptr: {x.data_ptr()}, size: {num_bytes}{hint}")
 
 
 def unpin_tensor_(x):


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

This PR replaces the offloading triggers using reentrant checkpointing with autograd functions and non-reentrant checkpointing.
This does a few things:
 - it fixes https://github.com/Nerogar/OneTrainer/issues/1306 because the "backward done" event is more robust
 - it enables the torch autograd partitioner to build more efficient compile graphs
 - makes future optiomizations possible
 - simplifies the offloading code

This PR also fixes activation offloading: Activation offloading technically worked, but it wasn't of any practical use.
Activations were offloaded, and moved back to GPU when the backward started. But: this wasn't limited. CPU can run ahead of GPU for many layers. This caused vram allocations on GPU too early and you ran out of vram anyway.

With this fix, high batch sizes are actually possible. Tested on Flux2, 4070 16 GB, batch size 20: 7.8 s/it


## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Flux2, Krea2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
