### PR TITLE
Krea 2 OOM fix for batch sizes >= 2

### DIFF
--- a/modules/modelSampler/Krea2Sampler.py
+++ b/modules/modelSampler/Krea2Sampler.py
@@ -70,7 +70,7 @@ class Krea2Sampler(BaseModelSampler):
             self.model.text_encoder_to(self.train_device)
 
             batch_size = 2 if cfg_scale > 1.0 else 1
-            combined_prompt_embedding, text_attention_mask = self.model.encode_text(
+            combined_prompt_embedding, _ = self.model.encode_text(
                 text=[prompt, negative_prompt] if cfg_scale > 1.0 else prompt,
                 batch_size=batch_size,
                 train_device=self.train_device,
@@ -113,7 +113,11 @@ class Krea2Sampler(BaseModelSampler):
                     encoder_hidden_states=combined_prompt_embedding.to(dtype=self.model.train_dtype.torch_dtype()),
                     timestep=expanded_timestep / 1000,
                     position_ids=position_ids,
-                    encoder_attention_mask=text_attention_mask,
+                    # deliberately no encoder_attention_mask: a mask forces SDPA's math fallback,
+                    # materializing (batch*heads, seq, seq) attention matrices in every block.
+                    # Padding embeddings are zeros and attending them is a close approximation -
+                    # and keeps sampling consistent with training (see BaseKrea2Setup.predict()).
+                    encoder_attention_mask=None,
                     return_dict=False,
                 )[0]
 

--- a/modules/modelSetup/BaseKrea2Setup.py
+++ b/modules/modelSetup/BaseKrea2Setup.py
@@ -123,8 +123,15 @@ class BaseKrea2Setup(
                 text_seq_len, grid_height, grid_width, self.train_device
             )
 
-            if torch.all(text_attention_mask):
-                text_attention_mask = None
+            # Never pass the text padding mask to the transformer. With any attn_mask present,
+            # torch's scaled_dot_product_attention rejects the fused flash/cuDNN/efficient
+            # kernels and falls back to the math backend, which materializes the full
+            # (batch*heads, seq, seq) attention matrix in every block - several GiB per block
+            # at batch_size > 1, enough to OOM even 96GB cards. The padded positions hold
+            # zero embeddings, so letting them be attended is a close approximation (the same
+            # trade-off kohya-family trainers make), and it matches what the model already
+            # sees whenever a batch has uniform caption lengths (always true at batch size 1).
+            text_attention_mask = None
 
             packed_predicted_flow = model.transformer(
                 hidden_states=packed_latent_input.to(dtype=model.train_dtype.torch_dtype()),


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

I was running into OOM errors on an RTX 6000 Pro (96 GB VRAM) with batch sizes that should have fit (e.g. 8, 4).

With the assistance of Claude, I was able to pin it on a text encoding mask that was being passed to every attention call. This isn't an issue with a batch size of 1, where no padding is needed. When any mask is present, PyTorch's attention can't use its fast fused kernel and falls back to a slow path that builds the full attention matrix (batch × heads × seq × seq, ~6GiB a pop at batch size 8) in every block.

I can now run batch size 8 on an RTX 6000 Pro.

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x ] `pre-commit run --all-files` passes.
- [ x] Launched the affected UI or script and exercised the change.
- [ x] Tested with at least one real preset / config when relevant (note which: Krea 2 LoRA training with batch size 8).

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- Early AI prototype — opened for discussion, **not ready for review**

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
