### PR TITLE
Pin hf_xet download concurrency to bound the connection pool

### DIFF
--- a/modules/util/huggingface_util.py
+++ b/modules/util/huggingface_util.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 from collections.abc import Callable
 
 import huggingface_hub
@@ -11,6 +12,10 @@ def configure_hub(
         cache_dir: str = "",
         on_status: Callable[[str], None] | None = None,
 ):
+    # hf_xet's adaptive controller ramps download concurrency to 64, and the connection pool follows, saturating
+    # a consumer link. A fixed value stops the ramp.
+    os.environ.setdefault("HF_XET_FIXED_DOWNLOAD_CONCURRENCY", "8")
+
     # huggingface_hub reads HF_HUB_OFFLINE and HF_HUB_CACHE from the environment into module constants at import
     # time, and every downstream call reads those constants at call time. transformers and diffusers don't expose
     # a parameter on the internal requests they make (e.g. transformers queries model_info() while loading a


### PR DESCRIPTION
## Summary

XET is still causing issues, even after the upgrade
 - sometimes, it scales down to only 1 parallel connection for no apparent reason
 - sometimes it scales up to 64 parallel connections, which provides good performance for the xet download but can effectively kill all other connections on your WiFi, including other devices

this PR sets the number of parallel connections to 8 for now

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change
