### PR TITLE
Bump tensorboard to 2.21.0, setuptools to 83.0.0

### DIFF
--- a/lib.include.sh
+++ b/lib.include.sh
@@ -388,7 +388,7 @@ function install_requirements_in_active_env {
     # when running in existing environments. It ensures that all libraries will
     # be upgraded to the same versions as a fresh reinstall of requirements.txt.
     print "Installing requirements in active environment..."
-    run_pip_in_active_env install --upgrade --upgrade-strategy eager pip setuptools==81.0.0
+    run_pip_in_active_env install --upgrade --upgrade-strategy eager pip setuptools==83.0.0
     run_pip_in_active_env install --upgrade --upgrade-strategy eager -r requirements-global.txt -r "$(get_platform_requirements_path)"
     export OT_MUST_INSTALL_REQUIREMENTS="false"
 

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -12,12 +12,12 @@ av==16.1.0
 yt-dlp  #no pinned version, frequently updated for compatibility with sites
 scenedetect==0.7
 parse==1.20.2
-setuptools==81.0.0
+setuptools==83.0.0
 
 # pytorch
 accelerate==1.12.0
 safetensors==0.8.0
-tensorboard==2.20.0
+tensorboard==2.21.0
 
 # diffusion models
 -e git+https://github.com/huggingface/diffusers.git@1ffa423#egg=diffusers

--- a/update.bat
+++ b/update.bat
@@ -128,7 +128,7 @@ goto :install_dependencies
 :install_dependencies
 echo Installing dependencies...
 echo Upgrading pip and setuptools...
-"%PYTHON%" -m pip install --upgrade --upgrade-strategy eager pip setuptools==81.0.0
+"%PYTHON%" -m pip install --upgrade --upgrade-strategy eager pip setuptools==83.0.0
 if errorlevel 1 (
     echo Error: pip upgrade failed.
     goto :end_error


### PR DESCRIPTION
## Summary


tensorboard 2.21.0 no longer imports the `pkg_resources` API removed in setuptools 82, so the `setuptools<82` constraint added in #1305 is no longer needed. setuptools stays pinned like everything else in `requirements-global.txt`, just moved to the current 83.0.0.

The pip/setuptools bootstrap in `lib.include.sh` and `update.bat` pinned setuptools to 81.0.0 to stay under that constraint; both are bumped to 83.0.0 so the bootstrap installs the intended version directly.

Fixes #1307.

probably waiting on https://github.com/Nerogar/OneTrainer/pull/1244 to not cause any more unnecessary conflicts, or might even be obsolete after https://github.com/Nerogar/OneTrainer/pull/1244?
@hameerabbasi 


## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change
