### PR TITLE
Fix RunPod pod creation

### DIFF
--- a/modules/cloud/RunpodCloud.py
+++ b/modules/cloud/RunpodCloud.py
@@ -6,7 +6,6 @@ from modules.util.config.TrainConfig import TrainConfig
 from modules.util.enum.CloudAction import CloudAction
 
 import runpod
-from runpod.api.graphql import run_graphql_query
 
 
 class RunpodCloud(LinuxCloud):
@@ -64,25 +63,13 @@ class RunpodCloud(LinuxCloud):
             self.__get_host_port()
         super()._connect()
 
-    __TEMPLATE_ID = "1a33vbssq9"
-
-    def __get_template_image_name(self, template_id: str) -> str:
-        # RunPod's create_pod requires a non-empty image_name even when a template_id is given,
-        # so look up the template's current image instead of hardcoding a version tag here.
-        result = run_graphql_query("query myself { myself { podTemplates { id imageName } } }")
-        templates = result["data"]["myself"]["podTemplates"]
-        for template in templates:
-            if template["id"] == template_id:
-                return template["imageName"]
-        raise ValueError(f"RunPod template {template_id} not found")
-
     def _create(self):
         config=self.config.cloud
         secrets=self.config.secrets.cloud
         pod=runpod.create_pod(
             name=config.name,
-            image_name=self.__get_template_image_name(self.__TEMPLATE_ID),
-            template_id=self.__TEMPLATE_ID,
+            image_name="dxqbyd/runpod-onetrainer-cli:latest",
+            template_id="1a33vbssq9",
             gpu_type_id=config.gpu_type,
             cloud_type=config.sub_type,
             support_public_ip=True,

--- a/modules/util/config/CloudConfig.py
+++ b/modules/util/config/CloudConfig.py
@@ -91,7 +91,7 @@ class CloudConfig(BaseConfig):
         data.append(("enabled", False, bool, False))
         data.append(("type", CloudType.RUNPOD, CloudType, False))
         data.append(("file_sync", CloudFileSync.NATIVE_SCP, CloudFileSync, False))
-        data.append(("create", True, bool, False))
+        data.append(("create", False, bool, False))
         data.append(("name", "OneTrainer", str, False))
         data.append(("tensorboard_tunnel", True, bool, False))
         data.append(("sub_type", "", str, False))

--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -52,7 +52,7 @@ customtkinter==5.2.2
 PySide6==6.11.1
 
 # cloud
-runpod==1.7.10
+runpod==1.11.0
 fabric==3.2.2
 
 # debug


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

- still a workaround for https://github.com/runpod/runpod-python/issues/385
- image name lookup doesn't work reliably, hardcode image name instead
- added a `:latest" tag to dockerhub, to avoid hardcoding a version
- changed defaut of "create runpod via API" to False. Reason: GPU availability has gotten worse and there often is no machine of a specific GPU available. Creating your RunPod on the website where you see what's available is now the preferred way
- Bumped RunPod version to check if the bug is still there - it is, but left the bump anyway

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- No AI involvement

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
