### PR TITLE
Bump psutil and requests for runpod 1.11.0

### DIFF
--- a/requirements-global.txt
+++ b/requirements-global.txt
@@ -56,6 +56,6 @@ runpod==1.11.0
 fabric==3.2.2
 
 # debug
-psutil==7.0.0
-requests==2.33.0
+psutil==7.2.2
+requests==2.34.2
 deepdiff==8.6.2 # output easy to read diff for troublshooting


### PR DESCRIPTION
runpod 1.11.0 requires psutil>=7.2.2 and requests>=2.34.2, which the pinned 7.0.0 / 2.33.0 conflict with. Both bumps go to the current latest release.
