### PR TITLE
Fix text_encoder LoRA wrapper claiming text_encoder_2 keys

### DIFF
--- a/modules/module/LoRAModule.py
+++ b/modules/module/LoRAModule.py
@@ -1045,8 +1045,10 @@ class LoRAModuleWrapper:
             state_dict: the state dict
             strict: whether to strictly enforce that the keys in state_dict match the module's parameters
         """
-        # create a copy, so the modules can pop states
-        state_dict = {k: v for (k, v) in state_dict.items() if k.startswith(self.prefix)}
+        # create a copy, so the modules can pop states. the trailing dot keeps the "text_encoder"
+        # wrapper from also matching the "text_encoder_2" keys
+        prefix = self.prefix + "." if self.prefix else ""
+        state_dict = {k: v for (k, v) in state_dict.items() if k.startswith(prefix)}
 
         check_fusion_match(state_dict.keys(), self.fuse, self.fusion_spec)
         # FIXME: disabled rank check, false positive on Flux2 LoHA loading


### PR DESCRIPTION
fixes pre-existing weakness of LoRAModuleWrapper when loading from a file, that matched any prefix like "text_encoder" even without a dot-delimiter - so "text_encoder_2" matches the prefix "text_encoder"

triggered and turned into a regression by https://github.com/Nerogar/OneTrainer/pull/1563 because before, `lora_te1` and `lora_te2` was used. Now, the LoRA loader normalizes those prefixes to diffusers component names first, and the "text_encoder" names end up in LoRAModuleWrapper to be loaded.

fixes https://github.com/Nerogar/OneTrainer/issues/1661
