### PR TITLE
Dequantize against the scale on the weight's device

### DIFF
--- a/modules/module/quantized/LinearFp8.py
+++ b/modules/module/quantized/LinearFp8.py
@@ -25,8 +25,9 @@ class LinearFp8(
         return self.weight.shape
 
     def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        # 'scale' is not offloaded, so it can sit on the train device while 'weight' is parked on the temp device
         if self._scale is not None:
-            return self.weight.detach().to(dtype) * self._scale.to(dtype=dtype)
+            return self.weight.detach().to(dtype) * self._scale.to(dtype=dtype, device=self.weight.device)
         else:
             return self.weight.detach().to(dtype=dtype)
 

--- a/modules/module/quantized/LinearW8A8.py
+++ b/modules/module/quantized/LinearW8A8.py
@@ -94,7 +94,8 @@ class LinearW8A8(
         return self.weight.shape
 
     def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
-        return dequantize(self.weight.detach(), self.scale).to(dtype)
+        # 'scale' is not offloaded, so it can sit on the train device while 'weight' is parked on the temp device
+        return dequantize(self.weight.detach(), self.scale.to(device=self.weight.device)).to(dtype)
 
     @torch.no_grad()
     def quantize(self, device: torch.device | None = None):

--- a/modules/module/quantized/mixin/QuantizedLinearMixin.py
+++ b/modules/module/quantized/mixin/QuantizedLinearMixin.py
@@ -8,6 +8,10 @@ class QuantizedLinearMixin(metaclass=ABCMeta):
     def original_weight_shape(self) -> tuple[int, ...]:
         pass
 
+    # 'device' only says where to run the dequantization, like in quantize(); the device of the returned
+    # tensor is unspecified, so callers needing it somewhere specific have to move it themselves.
+    # Layer offloading relocates only 'weight' and 'bias', so separate quantization state (scales, absmax)
+    # can be left behind on another device and has to be brought back together here.
     @abstractmethod
     def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
         pass


### PR DESCRIPTION
Layer offloading relocates only 'weight' and 'bias', leaving the 'scale' buffer of LinearW8A8 / LinearFp8 on the train device while the weight is parked on the temp device. unquantized_weight() then multiplied tensors on two devices, which raised a device mismatch for W8A8 and silently computed on the CPU for Fp8, hitting DoRA and weight-decomposed LoKr during adapter initialization.

fixes https://github.com/Nerogar/OneTrainer/issues/1571