### PR TITLE
REST API PR

### DIFF
--- a/docs/CliTraining.md
+++ b/docs/CliTraining.md
@@ -9,3 +9,18 @@ this `python scripts/create_train_files.py -h`.
 
 To simplify the creation of the training config, you can export your settings from the UI by using the export button.
 This will create a single file that contains every setting.
+
+### REST server
+
+There is also a simple REST implementation that lets a client on the same machine start and stop training, request
+samples and backups, and read the progress of a run. It needs the two extra packages
+in `requirements-api.txt`, then:
+
+`python scripts/train_rest_server.py --port 7800`
+
+Note this deliberately binds to `127.0.0.1` only, so that no other machine can reach it and remotely initiate
+training. This opens up opportunities for other web clients running on the machine (like ComfyUI) to start training
+from their own software, and for automation tools.
+
+Every endpoint is one call onto the same `TrainCallbacks` / `TrainCommands` pair the UI uses, so it drives local,
+multi-GPU and cloud runs without any backend-specific code. `GET /docs` on the running server lists the endpoints.

--- a/modules/api/rest/ApiError.py
+++ b/modules/api/rest/ApiError.py
@@ -1,0 +1,37 @@
+class ApiError(Exception):
+    """
+    Base for every error the REST API reports.
+
+    Subclasses set error_type/status_code. RestApi installs a single handler
+    that renders any ApiError through envelope(), so a client only ever has to
+    parse one error shape.
+    """
+
+    error_type = "internal"
+    status_code = 500
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+
+    def envelope(self) -> dict:
+        return {"error": {"type": self.error_type, "message": self.message, "details": self.details}}
+
+
+class InvalidConfigError(ApiError):
+    error_type = "invalid_config"
+    status_code = 422
+
+
+class ConflictError(ApiError):
+    error_type = "conflict"
+    status_code = 409
+
+    def __init__(self, message: str, run_id: str):
+        super().__init__(message, {"run_id": run_id})
+
+
+class NoActiveRunError(ApiError):
+    error_type = "no_active_run"
+    status_code = 409

--- a/modules/api/rest/ConfigSource.py
+++ b/modules/api/rest/ConfigSource.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from modules.api.rest.ApiError import InvalidConfigError
+from modules.util.config.SecretsConfig import SecretsConfig
+from modules.util.config.TrainConfig import TrainConfig
+
+from pydantic import BaseModel, ConfigDict
+
+DEFAULT_SECRETS_PATH = "secrets.json"
+
+
+class ConfigSource(BaseModel):
+    """
+    Where a training run's config comes from, and how to turn it into one.
+
+    Mirrors the arguments of scripts/train.py, and resolve() assembles them in
+    the same order the CLI does -- preset, then config, then overrides -- so the
+    two entry points can never disagree about what a given set of inputs means.
+
+    Credentials are never carried here. They are read server-side from
+    secrets_path; a config that tries to bring its own is rejected.
+    """
+
+    # Unknown fields are an error, so a body carrying a top-level "secrets"
+    # block is told no rather than quietly ignored.
+    model_config = ConfigDict(extra="forbid")
+
+    config: dict[str, Any] | None = None
+    config_path: str | None = None
+    preset_path: str | None = None
+    config_values: list[str] | None = None
+    secrets_path: str | None = None
+
+    def resolve(self) -> TrainConfig:
+        if (self.config is None) == (self.config_path is None):
+            raise InvalidConfigError("Provide exactly one of 'config' or 'config_path'")
+
+        if self.config is not None and "secrets" in self.config:
+            raise InvalidConfigError(
+                "Inline secrets are not accepted. Use 'secrets_path' to point at a secrets file."
+            )
+
+        train_config = TrainConfig.default_values()
+
+        if self.preset_path is not None:
+            self.__apply_document(train_config, self.__read_json(self.preset_path, "preset"), migrate=False)
+
+        document = self.config if self.config is not None else self.__read_json(self.config_path, "config")
+        self.__apply_document(train_config, document, migrate=self.preset_path is None)
+
+        for config_value in self.config_values or []:
+            self.__apply_override(train_config, config_value)
+
+        train_config.secrets = self.__load_secrets(self.secrets_path)
+        return train_config
+
+    @staticmethod
+    def __read_json(path: str, label: str) -> dict:
+        try:
+            return json.loads(Path(path).read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            raise InvalidConfigError(f"{label} file not found: {path}") from None
+        except json.JSONDecodeError as e:
+            raise InvalidConfigError(f"{label} file is not valid JSON: {path} ({e})") from e
+
+    @staticmethod
+    def __apply_document(train_config: TrainConfig, document: dict, migrate: bool) -> None:
+        try:
+            train_config.from_dict(document, migrate=migrate)
+        except Exception as e:
+            raise InvalidConfigError(f"Invalid config: {e}") from e
+
+    @staticmethod
+    def __apply_override(train_config: TrainConfig, config_value: str) -> None:
+        key, separator, value = config_value.partition("=")
+        if not separator:
+            raise InvalidConfigError(f"Override must be KEY=VALUE: {config_value!r}")
+
+        if key == "secrets" or key.startswith("secrets."):
+            raise InvalidConfigError(
+                "Overrides may not set 'secrets'. Use 'secrets_path' to point at a secrets file."
+            )
+
+        *parent_keys, leaf_key = key.split(".")
+
+        try:
+            target = train_config
+            for parent_key in parent_keys:
+                target = getattr(target, parent_key)
+            # Subscript, not .get(): an unknown key must raise KeyError here, or
+            # from_dict silently ignores it and a typo'd override starts a run
+            # with the wrong config. scripts/train.py:34 subscripts too.
+            if target.types[leaf_key] is bool:
+                value = value.lower() in ("true", "1", "yes")
+            target.from_dict({leaf_key: value}, migrate=False)
+        except Exception as e:
+            raise InvalidConfigError(f"Invalid override {config_value!r}: {e}") from e
+
+    @staticmethod
+    def __load_secrets(secrets_path: str | None) -> SecretsConfig:
+        explicit = secrets_path is not None
+        path = Path(secrets_path or DEFAULT_SECRETS_PATH)
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            # Mirrors scripts/train.py: the implicit secrets.json may be absent,
+            # but a path the caller named explicitly must exist.
+            if explicit:
+                raise InvalidConfigError(f"secrets file not found: {path}") from None
+            return SecretsConfig.default_values()
+        except json.JSONDecodeError as e:
+            raise InvalidConfigError(f"secrets file is not valid JSON: {path} ({e})") from e
+        return SecretsConfig.default_values().from_dict(document)

--- a/modules/api/rest/RestApi.py
+++ b/modules/api/rest/RestApi.py
@@ -1,0 +1,114 @@
+from typing import Any
+
+from modules.api.rest.ApiError import ApiError, InvalidConfigError
+from modules.api.rest.ConfigSource import ConfigSource
+from modules.api.rest.TrainingService import TrainingService
+from modules.util.config.SampleConfig import SampleConfig
+from modules.util.config.TrainConfig import TrainConfig
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+
+class SampleRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sample: dict[str, Any] | None = None
+
+
+class RestApi:
+    """
+    The complete HTTP contract: eight endpoints over a TrainingService.
+
+    This is an adapter, not a new abstraction. Every POST is a single call onto
+    the TrainCommands object the trainer polls at step boundaries, and every
+    field of the status response arrives from a TrainCallbacks hook. Commands
+    answer 202 rather than 200 because none of them happen synchronously.
+
+    It binds no socket and knows nothing about hosts or ports. install() adds
+    the routes and the error contract to a FastAPI application somebody else
+    owns, so the same contract can be served by scripts/train_rest_server.py or
+    mounted inside a larger application.
+    """
+
+    def __init__(self, training_service: TrainingService, version: str = "unknown"):
+        self.__training_service = training_service
+        self.__version = version
+
+        self.__router = APIRouter()
+        self.__router.add_api_route("/health", self.health, methods=["GET"])
+        self.__router.add_api_route("/config/defaults", self.config_defaults, methods=["GET"])
+        self.__router.add_api_route("/training/status", self.training_status, methods=["GET"])
+        self.__router.add_api_route("/training/start", self.training_start, methods=["POST"], status_code=202)
+        self.__router.add_api_route("/training/stop", self.training_stop, methods=["POST"], status_code=202)
+        self.__router.add_api_route("/training/sample", self.training_sample, methods=["POST"], status_code=202)
+        self.__router.add_api_route("/training/backup", self.training_backup, methods=["POST"], status_code=202)
+        self.__router.add_api_route("/training/save", self.training_save, methods=["POST"], status_code=202)
+
+    # Adds the routes and the error contract to an application the caller owns.
+    # prefix namespaces the routes for a host that already serves its own API.
+    def install(self, app: FastAPI, prefix: str = "") -> None:
+        app.include_router(self.__router, prefix=prefix)
+        app.add_exception_handler(ApiError, self.__handle_api_error)
+        app.add_exception_handler(RequestValidationError, self.__handle_validation_error)
+
+    # --- endpoints ---
+    # Handlers are plain `def`, not `async def`: FastAPI runs them in a
+    # threadpool, so the config file reads never block the event loop.
+
+    def health(self) -> dict:
+        return {
+            "status": "ok",
+            "version": self.__version,
+            "state": self.__training_service.status()["state"],
+        }
+
+    def config_defaults(self) -> dict:
+        # to_settings_dict(secrets=False) is the existing secrets-stripping
+        # serializer, so the no-secrets guarantee is enforced by core code.
+        return TrainConfig.default_values().to_settings_dict(secrets=False)
+
+    def training_status(self) -> dict:
+        return self.__training_service.status()
+
+    def training_start(self, body: ConfigSource) -> dict:
+        run_id = self.__training_service.start(body.resolve())
+        return {"run_id": run_id, "state": "starting"}
+
+    def training_stop(self) -> dict:
+        self.__training_service.stop()
+        return {"accepted": True}
+
+    def training_sample(self, body: SampleRequest | None = None) -> dict:
+        sample = None
+        if body is not None and body.sample is not None:
+            try:
+                sample = SampleConfig.default_values().from_dict(body.sample)
+            except Exception as e:
+                raise InvalidConfigError(f"Invalid sample config: {e}") from e
+        self.__training_service.sample(sample)
+        return {"accepted": True}
+
+    def training_backup(self) -> dict:
+        self.__training_service.backup()
+        return {"accepted": True}
+
+    def training_save(self) -> dict:
+        self.__training_service.save()
+        return {"accepted": True}
+
+    # --- error contract ---
+
+    @staticmethod
+    def __handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content=exc.envelope())
+
+    @staticmethod
+    def __handle_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+        # Override FastAPI's default 422 body so a client only ever parses one
+        # error shape.
+        error = InvalidConfigError("Request body is invalid", {"errors": jsonable_encoder(exc.errors())})
+        return JSONResponse(status_code=error.status_code, content=error.envelope())

--- a/modules/api/rest/TrainingService.py
+++ b/modules/api/rest/TrainingService.py
@@ -1,0 +1,256 @@
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import partial
+from threading import Lock, Thread
+from time import monotonic
+from uuid import uuid4
+
+from modules.api.rest.ApiError import ConflictError, NoActiveRunError
+from modules.util.callbacks.TrainCallbacks import TrainCallbacks
+from modules.util.commands.TrainCommands import TrainCommands
+from modules.util.config.SampleConfig import SampleConfig
+from modules.util.config.TrainConfig import TrainConfig
+
+ACTIVE_STATES = frozenset({"starting", "running", "stopping"})
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class _Run:
+    run_id: str
+    state: str
+    commands: TrainCommands
+    message: str = ""
+    epoch: int = 0
+    max_epochs: int = 0
+    epoch_step: int = 0
+    epoch_length: int = 0
+    step: int = 0
+    started_at: str = ""
+    started_monotonic: float = 0.0
+    ended_monotonic: float | None = None
+    error: dict | None = None
+
+
+class TrainingService:
+    """
+    Adapts OneTrainer's TrainCallbacks/TrainCommands pair to HTTP.
+
+    Callbacks come in from the trainer thread and are accumulated into a
+    pollable status dict; commands go out to the TrainCommands object the
+    trainer polls at step boundaries.
+
+    Locking rules -- the only two ways this class goes wrong:
+      1. Never hold self._lock while calling into the trainer or a subclass
+         hook. Trainer calls take minutes; hooks are somebody else's code.
+      2. status() builds its entire dict under the lock, so a poll can never
+         observe a half-updated run.
+    """
+
+    def __init__(self, trainer_factory=None) -> None:
+        self._lock = Lock()
+        self._run: _Run | None = None
+        self._trainer_factory = trainer_factory
+
+    # --- queries ---
+
+    def status(self) -> dict:
+        with self._lock:
+            run = self._run
+            if run is None:
+                return {
+                    "run_id": None,
+                    "state": "idle",
+                    "message": "",
+                    "epoch": 0,
+                    "max_epochs": 0,
+                    "epoch_step": 0,
+                    "epoch_length": 0,
+                    "step": 0,
+                    "max_steps": 0,
+                    "started_at": None,
+                    "elapsed_seconds": 0.0,
+                    "error": None,
+                }
+            end = run.ended_monotonic if run.ended_monotonic is not None else monotonic()
+            return {
+                "run_id": run.run_id,
+                "state": run.state,
+                "message": run.message,
+                "epoch": run.epoch,
+                "max_epochs": run.max_epochs,
+                "epoch_step": run.epoch_step,
+                "epoch_length": run.epoch_length,
+                "step": run.step,
+                "max_steps": run.epoch_length * run.max_epochs,
+                "started_at": run.started_at,
+                "elapsed_seconds": round(end - run.started_monotonic, 3),
+                "error": dict(run.error) if run.error is not None else None,
+            }
+
+    # --- lifecycle ---
+
+    def start(self, config: TrainConfig) -> str:
+        with self._lock:
+            if self._run is not None and self._run.state in ACTIVE_STATES:
+                raise ConflictError("A training run is already active", run_id=self._run.run_id)
+            run = _Run(
+                run_id=uuid4().hex[:16],
+                state="starting",
+                commands=TrainCommands(),
+                started_at=_utcnow_iso(),
+                started_monotonic=monotonic(),
+            )
+            self._run = run
+
+        Thread(
+            target=self._worker,
+            args=(run, config),
+            daemon=True,
+            name=f"onetrainer-run-{run.run_id}",
+        ).start()
+        return run.run_id
+
+    # --- commands ---
+    # Each is a single call onto the TrainCommands object the trainer polls at
+    # step boundaries. Nothing here happens synchronously; that is why the HTTP
+    # layer answers 202 rather than 200.
+
+    def stop(self) -> None:
+        with self._lock:
+            run = self._require_active_locked()
+            run.state = "stopping"
+            commands = run.commands
+        commands.stop()
+
+    def sample(self, sample: SampleConfig | None = None) -> None:
+        if sample is None:
+            self._dispatch(lambda commands: commands.sample_default())
+        else:
+            self._dispatch(lambda commands: commands.sample_custom(sample))
+
+    def backup(self) -> None:
+        self._dispatch(lambda commands: commands.backup())
+
+    def save(self) -> None:
+        self._dispatch(lambda commands: commands.save())
+
+    def _dispatch(self, action: Callable[[TrainCommands], None]) -> None:
+        with self._lock:
+            commands = self._require_active_locked().commands
+        action(commands)
+
+    def _require_active_locked(self) -> _Run:
+        # Caller must hold self._lock.
+        if self._run is None or self._run.state not in ACTIVE_STATES:
+            raise NoActiveRunError("There is no active training run")
+        return self._run
+
+    def _worker(self, run: _Run, config: TrainConfig) -> None:
+        self._safe_hook(self._on_run_begin, run.run_id, config)
+        try:
+            trainer_factory = self._trainer_factory
+            if trainer_factory is None:
+                # Lazy: keeps diffusers/transformers/model setup out of import
+                # time, so create_app() and the tests stay cheap.
+                from modules.util import create
+
+                trainer_factory = create.create_trainer
+
+            callbacks = TrainCallbacks(
+                on_update_status=partial(self._handle_status, run),
+                on_update_train_progress=partial(self._handle_progress, run),
+                on_sample_default=partial(self._handle_sample_default, run),
+            )
+            trainer = trainer_factory(config, callbacks, run.commands)
+
+            trainer.start()
+            self._set_state(run, "running", expect="starting")
+            trainer.train()
+
+            # Same condition as scripts/train.py:55 -- deliberately identical to
+            # the CLI. Cancellation reaches us as a stop flag, not KeyboardInterrupt.
+            canceled = run.commands.get_stop_command()
+            if not canceled or config.backup_before_save:
+                trainer.end()
+            self._finish(run, "canceled" if canceled else "completed")
+        except Exception as e:
+            print(f"training run {run.run_id} failed")
+            traceback.print_exc()
+            self._finish(run, "failed", error={"type": type(e).__name__, "message": str(e)})
+        finally:
+            with self._lock:
+                final_state = run.state
+            self._safe_hook(self._on_run_end, run.run_id, final_state)
+
+    # --- callback sinks ---
+
+    def _handle_status(self, run: _Run, status: str) -> None:
+        with self._lock:
+            run.message = status
+        self._safe_hook(self._on_status, status)
+
+    def _handle_progress(self, run: _Run, train_progress, max_step: int, max_epoch: int) -> None:
+        # max_step is the *epoch length* (GenericTrainer.py:832), not a total
+        # step count. Total steps is epoch_length * max_epochs, computed in status().
+        with self._lock:
+            run.epoch = train_progress.epoch
+            run.epoch_step = train_progress.epoch_step
+            run.step = train_progress.global_step
+            run.epoch_length = max_step
+            run.max_epochs = max_epoch
+        self._safe_hook(self._on_progress, train_progress, max_step, max_epoch)
+
+    def _handle_sample_default(self, run: _Run, sampler_output) -> None:
+        self._safe_hook(self._on_sample_default, sampler_output)
+
+    # --- state transitions ---
+
+    def _set_state(self, run: _Run, state: str, expect: str | None = None) -> None:
+        # expect guards against clobbering a concurrent transition: a stop()
+        # during a slow model load sets "stopping", and without it the worker
+        # would drop the run back to "running" once trainer.start() returned.
+        with self._lock:
+            if expect is not None and run.state != expect:
+                return
+            run.state = state
+
+    def _finish(self, run: _Run, state: str, error: dict | None = None) -> None:
+        with self._lock:
+            run.state = state
+            run.error = error
+            run.ended_monotonic = monotonic()
+
+    @staticmethod
+    def _safe_hook(hook, *args) -> None:
+        # TrainCallbacks suppresses every exception a callback raises, so a
+        # broken handler would vanish without a trace. Report it here instead.
+        try:
+            hook(*args)
+        except Exception:
+            print(f"error in training service hook {getattr(hook, '__name__', hook)}")
+            traceback.print_exc()
+
+    # --- subclass extension points ---
+    # Deliberately no-ops. Our Web UI fork overrides these to drive its event
+    # hub, metrics store, checkpoint store and gallery without forking this class.
+
+    def _on_run_begin(self, run_id: str, config: TrainConfig) -> None:
+        pass
+
+    def _on_run_end(self, run_id: str, state: str) -> None:
+        pass
+
+    def _on_status(self, message: str) -> None:
+        pass
+
+    def _on_progress(self, train_progress, max_step: int, max_epoch: int) -> None:
+        pass
+
+    def _on_sample_default(self, sampler_output) -> None:
+        pass

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,4 @@
+# Optional extra for the REST API server (scripts/train_rest_server.py).
+# Not required for training, the desktop UI, or the CLI.
+fastapi
+uvicorn[standard]

--- a/scripts/train_rest_server.py
+++ b/scripts/train_rest_server.py
@@ -1,0 +1,70 @@
+from util.import_util import script_imports
+
+script_imports(allow_zluda=False)
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from modules.api.rest.RestApi import RestApi
+from modules.api.rest.TrainingService import TrainingService
+
+import uvicorn
+from fastapi import FastAPI
+
+# Not a flag. This server is loopback-only by design: it can start training and
+# read config files, and an exposed HTTP port has no transport security under
+# it. Anything that needs remote access must put its own authenticated server in
+# front.
+HOST = "127.0.0.1"
+
+DEFAULT_PORT = 7800
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OneTrainer REST API server")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        dest="port",
+        help=f"Port to listen on (default: {DEFAULT_PORT})",
+    )
+    return parser.parse_args(args)
+
+
+def resolve_version(root_dir: Path) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip()
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def create_app(root_dir: Path) -> FastAPI:
+    app = FastAPI(title="OneTrainer REST API", redoc_url=None)
+    RestApi(TrainingService(), version=resolve_version(root_dir)).install(app)
+    return app
+
+
+def main() -> None:
+    args = parse_args()
+    root_dir = Path(__file__).resolve().parent.parent
+
+    print(f"OneTrainer REST API  ->  http://{HOST}:{args.port}")
+    print("  Only this machine can reach it.")
+
+    uvicorn.run(create_app(root_dir), host=HOST, port=args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an optional HTTP control plane for training runs, at `modules/api/rest`, with a
`scripts/train_rest_server.py` entry point.

It is an **adapter, not a new abstraction**. Every `POST` is one call onto a `TrainCommands`
object, and every field in `GET /training/status` arrives from a `TrainCallbacks` hook — the
same pair the desktop UI already drives:

| Endpoint | What it calls |
|---|---|
| `POST /training/start` | `create_trainer(config, callbacks, commands)` on a worker thread |
| `POST /training/stop` | `commands.stop()` |
| `POST /training/sample` | `commands.sample_default()` / `sample_custom(cfg)` |
| `POST /training/backup` | `commands.backup()` |
| `POST /training/save` | `commands.save()` |
| `GET /training/status` | `on_update_train_progress` + `on_update_status` |
| `GET /health`, `GET /config/defaults` | — |

Because it binds at the same `(config, callbacks, commands)` seam `create_trainer()` uses, it
drives local, multi-GPU and cloud runs with no backend-specific code.

**Why it's useful:** control training on a box you've only SSH'd into, and let other software
already running on that machine — ComfyUI, a scheduler, a shell script — start a run without a
desktop session.

**Self-contained on purpose**, so it costs nothing to carry and nothing to remove:

- No existing code is modified. The only change to an existing file is 15 lines appended to
  `docs/CliTraining.md`. Nothing under `modules/` imports `modules/api/`, and
  `modules.util.create` is imported lazily inside the worker so the model stack stays out of
  import time.
- `fastapi` and `uvicorn` are an optional extra in `requirements-api.txt`. A normal training
  install is unchanged and never needs them.
- Deleting `modules/api/`, `scripts/train_rest_server.py` and `requirements-api.txt`, and
  dropping the `CliTraining.md` section, restores the tree exactly.

**Security posture:** binds `127.0.0.1` with no `--host` flag — it can start training and read
files on the machine, and a plain HTTP port has no transport security under it. Credentials are
never accepted over the wire: secrets resolve server-side from a path exactly as
`scripts/train.py` does, and an inline `secrets` block or a `secrets.*` override is refused.
Unknown request fields are rejected rather than silently ignored.

I'm happy to maintain this module and to handle any issues that land against it.

7 files, +611.

## Test plan

- [x] `pre-commit run --all-files` passes — all 11 hooks, including `ruff`
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: **SD1.5
      `FINE_TUNE`, 165 steps/epoch × 100 epochs, real dataset**)

Ran `python scripts/train_rest_server.py --port 7899` and drove it with `curl`:

- **A real run, end to end.** `POST /training/start` → `202 {"run_id":"481901cd…"}`, status
  moved `starting` ("loading the model") → `running` ("Sampling …") → `running`
  ("Training …") with live counters — `epoch_step 134/165`, `step 134`, `max_steps 16500`.
  `POST /training/sample` mid-run → `202`, samples written, training continued.
  `POST /training/stop` → status moved to `stopping` and the trainer ran its shutdown.
- **Conflicts.** A second `POST /training/start` while a run is active → `409` carrying the
  active `run_id`. `stop` and `save` with no run → `409 no_active_run`.
- **Rejections.** A typo'd override (`epocs=1`) → `422`, matching `scripts/train.py` rather
  than silently starting a 16,500-step run with the wrong config. An inline secret and a
  `secrets.*` override → `422`. An unknown request field → `422`.
- **Schema.** `GET /openapi.json` lists exactly the 8 paths above; `GET /docs` renders.

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change
