### PR TITLE
Add torch FlexAttention as an attention mechanism option

### DIFF
--- a/modules/modelSetup/BaseModelSetup.py
+++ b/modules/modelSetup/BaseModelSetup.py
@@ -248,5 +248,7 @@ class BaseModelSetup(
                 component.set_attention_backend("flash")
             case AttentionMechanism.CUDNN:
                 component.set_attention_backend("_native_cudnn")
+            case AttentionMechanism.FLEX:
+                component.set_attention_backend("flex")
             case _:
                 raise NotImplementedError(f"attention mechanism {str(attn)} not implemented")

--- a/modules/ui/TrainingTabController.py
+++ b/modules/ui/TrainingTabController.py
@@ -21,6 +21,7 @@ class TrainingTabController:
             ("torch SDPA", AttentionMechanism.SDP),
             ("flash-attn", AttentionMechanism.FLASH),
             ("torch cuDNN", AttentionMechanism.CUDNN),
+            ("torch FlexAttention", AttentionMechanism.FLEX),
         ]
 
     def get_layer_presets(self) -> dict:

--- a/modules/util/enum/AttentionMechanism.py
+++ b/modules/util/enum/AttentionMechanism.py
@@ -5,6 +5,7 @@ class AttentionMechanism(Enum):
     SDP = 'SDP'
     FLASH = 'FLASH'
     CUDNN = 'CUDNN'
+    FLEX = 'FLEX'
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
Adds AttentionMechanism.FLEX, offers it in the training tab dropdown as "torch FlexAttention", and maps it to the "flex" attention backend in _set_attention_backend. All 17 model setups already route config.attention_mechanism through that helper, so every model gains the option.

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Flux2, Krea2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
