### PR TITLE
Int8 conv rot

### DIFF
--- a/modules/module/quantized/LinearInt8ConvRot.py
+++ b/modules/module/quantized/LinearInt8ConvRot.py
@@ -1,0 +1,185 @@
+import os
+
+from modules.module.quantized.LinearW8A8 import (
+    LinearW8A8,
+    int8_backward_axiswise,
+    int8_forward_tokenwise,
+    run_benchmark,
+)
+from modules.util.hadamard import block_hadamard, hadamard_matrix, pad_to_block
+from modules.util.quantization_util import (
+    dequantize,
+    quantize_int8_tensorwise,
+)
+
+import torch
+from torch import Tensor
+
+# Prototype knobs - env-driven, no UI/config plumbing (see PLAN in-an-new-branch-reflective-cocke).
+# Block size for the group-wise Hadamard rotation. Not empirically validated; 128 is a common
+# group size in block quantization literature, picked as a starting point to sweep from.
+CONVROT_BLOCK_SIZE = int(os.environ.get("CONVROT_BLOCK_SIZE", "128"))
+# Isolates the untested part of this experiment: whether quantizing the backward grad-output
+# to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping it in
+# bf16. Default matches int8w8 so the two paths are directly comparable.
+CONVROT_BF16_DY = os.environ.get("CONVROT_BF16_DY", "0") == "1"
+
+
+class LinearInt8ConvRotFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, weight_scale: Tensor, bias: Tensor | None,
+                compute_dtype: torch.dtype, block_size: int, in_features: int, rotation: Tensor) -> Tensor:
+        ctx.save_for_backward(weight, weight_scale, rotation)
+        ctx.block_size = block_size
+        ctx.in_features = in_features
+
+        x_rotated = block_hadamard(pad_to_block(x, block_size), block_size, rotation)
+        return int8_forward_tokenwise(x_rotated, weight, weight_scale, bias, compute_dtype)
+
+    @staticmethod
+    def backward(ctx, output: Tensor):
+        if ctx.needs_input_grad != (True, False, False, False, False, False, False, False):
+            raise NotImplementedError("Int A8W8 ConvRot cannot be used for full finetuning")
+
+        weight, weight_scale, rotation = ctx.saved_tensors
+        block_size, in_features = ctx.block_size, ctx.in_features
+
+        if CONVROT_BF16_DY:
+            # Debug path: skip int8 quantization of the grad-output entirely, to measure how
+            # much of any gradient-quality gap comes from quantizing dY vs. the rotation itself.
+            w_true = block_hadamard(dequantize(weight, weight_scale), block_size, rotation)[..., :in_features]
+            dx = output.to(torch.float32) @ w_true
+        else:
+            dx_padded = int8_backward_axiswise(output, weight, weight_scale)
+            dx = block_hadamard(dx_padded, block_size, rotation)[..., :in_features]
+
+        return dx.to(output.dtype), None, None, None, None, None, None, None
+
+
+class LinearInt8ConvRot(LinearW8A8):
+    # Group-wise Hadamard-rotated INT8 W8A8: rotates activations/weight/grad-output along the
+    # contraction dim in independent blocks of `block_size` before int8 quantization, so
+    # channel outliers get spread across a block instead of dominating a single channel's
+    # quantization range. The GEMM itself is unchanged from LinearW8A8 (still torch._int_mm) -
+    # rotation is the only added op, applied via block_hadamard (see modules/util/hadamard.py).
+    def __init__(self, block_size: int | None = None, *args, **kwargs):
+        kwargs['dtype'] = torch.int8  # ConvRot is int8-only; no fp8 variant in this experiment.
+        super().__init__(*args, **kwargs)
+        self.block_size = block_size if block_size is not None else CONVROT_BLOCK_SIZE
+        self._is_quantized = False  # own flag; LinearW8A8's is name-mangled and not reachable here
+
+    def original_weight_shape(self) -> tuple[int, ...]:
+        return (self.out_features, self.in_features)
+
+    def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        w = dequantize(self.weight.detach(), self.scale)
+        w = block_hadamard(w, self.block_size, self.rotation)[..., :self.in_features]
+        return w.to(dtype=dtype, device=device)
+
+    @torch.no_grad()
+    def quantize(self, device: torch.device | None = None):
+        if self._is_quantized:
+            return
+        self._is_quantized = True
+
+        weight = self.weight.detach()
+        orig_device = weight.device
+        if device is not None:
+            weight = weight.to(device=device)
+
+        # Precompute the block-Hadamard matrix once and keep it as a buffer (fp32; block_hadamard
+        # casts to the operand dtype). forward/backward run inside torch.compile'd + checkpointed
+        # blocks where the lazy hadamard_matrix() cache write is an illegal in-graph side effect;
+        # a buffer travels with the module across devices and is only read in the graph. persistent
+        # is False so it stays out of the state_dict (it's derivable from block_size).
+        self.register_buffer("rotation", hadamard_matrix(self.block_size, orig_device, torch.float32), persistent=False)
+
+        rotated = block_hadamard(pad_to_block(weight, self.block_size), self.block_size, self.rotation.to(weight.device))
+        weight, scale = quantize_int8_tensorwise(rotated)
+
+        if device is not None:
+            weight = weight.to(device=orig_device)
+
+        self.requires_grad_(False)
+        self.weight = torch.nn.Parameter(weight, requires_grad=False)
+        self.scale.copy_(scale)
+
+    def forward(self, x_orig: torch.Tensor) -> torch.Tensor:
+        assert not self.weight.requires_grad
+        assert self._is_quantized
+        x = x_orig.reshape(-1, x_orig.shape[-1])
+
+        if x.shape[0] > 16:
+            y = LinearInt8ConvRotFunction.apply(
+                x, self.weight, self.scale, self.bias, self.compute_dtype,
+                self.block_size, self.in_features, self.rotation,
+            )
+        else:
+            w = self.unquantized_weight(dtype=x.dtype, device=x.device)
+            y = torch.nn.functional.linear(x, w, self.bias)
+
+        return y.reshape(x_orig.shape[:-1] + (y.shape[-1],))
+
+
+@torch.no_grad()
+def quant_relative_error(x: Tensor, block_size: int | None) -> float:
+    # Round-trips x through int8 quantization (plain per-tensor if block_size is None, else
+    # rotated) and reports ||dequant(quant(x)) - x|| / ||x||: a quick SNR proxy for how much a
+    # given block size actually helps, without needing a full training run.
+    if block_size is None:
+        q, scale = quantize_int8_tensorwise(x)
+        recovered = dequantize(q, scale)
+    else:
+        rotated = block_hadamard(pad_to_block(x, block_size), block_size)
+        q, scale = quantize_int8_tensorwise(rotated)
+        recovered = block_hadamard(dequantize(q, scale), block_size)[..., :x.shape[-1]]
+    return (recovered - x).norm().item() / x.norm().item()
+
+
+def benchmark_snr(n_channels=3072, n_rows=512, outlier_channels=8, outlier_scale=20.0, device='cuda'):
+    # Synthetic outlier-channel weight: a handful of channels scaled up, as in the outlier
+    # patterns published PTQ work targets. Plain per-tensor int8 wastes its dynamic range on
+    # those few channels; a block Hadamard rotation should spread each outlier's magnitude
+    # across its block instead of one channel dominating the whole tensor's scale.
+    torch.manual_seed(0)
+    w = torch.randn(n_rows, n_channels, device=device)
+    outlier_idx = torch.randperm(n_channels)[:outlier_channels]
+    w[:, outlier_idx] *= outlier_scale
+
+    print(f"synthetic outlier tensor: {n_channels} channels, {outlier_channels} scaled {outlier_scale}x")
+    print(f"  plain int8 (no rotation):        rel err = {quant_relative_error(w, None):.4f}")
+    for block_size in (32, 64, 128, 256):
+        print(f"  ConvRot block_size={block_size:<4}:            rel err = {quant_relative_error(w, block_size):.4f}")
+
+
+@torch.no_grad()
+def benchmark_throughput(m, k, n, block_size=128, device='cuda'):
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    y = torch.randn(m, n, device=device, dtype=torch.bfloat16)
+    w_plain = torch.ones(n, k, device=device, dtype=torch.int8)
+    w_scale = torch.ones(1, device=device)
+
+    k_padded = k + (-k) % block_size
+    w_rot = torch.ones(n, k_padded, device=device, dtype=torch.int8)
+
+    def convrot_forward():
+        xr = block_hadamard(pad_to_block(x, block_size), block_size)
+        return int8_forward_tokenwise(xr, w_rot, w_scale, bias=None, compute_dtype=torch.bfloat16)
+
+    def convrot_backward():
+        dx = int8_backward_axiswise(y, w_rot, w_scale)
+        return block_hadamard(dx, block_size)[..., :k]
+
+    run_benchmark(lambda: int8_forward_tokenwise(x, w_plain, w_scale, bias=None, compute_dtype=torch.bfloat16), "plain int8w8 forward")
+    run_benchmark(convrot_forward, "ConvRot forward (incl. rotation)")
+    run_benchmark(lambda: int8_backward_axiswise(y, w_plain, w_scale), "plain int8w8 backward")
+    run_benchmark(convrot_backward, "ConvRot backward (incl. rotation)")
+
+
+if __name__ == "__main__":
+    # Clock/config caveats: throughput numbers here are indicative only - see the plan's
+    # verification section for the locked-clock benchmark this repo normally requires before
+    # trusting a number.
+    benchmark_snr()
+    print()
+    benchmark_throughput(2 * 1024 + 50, 3072, 3088)

--- a/modules/module/quantized/LinearInt8ConvRot.py
+++ b/modules/module/quantized/LinearInt8ConvRot.py
@@ -96,7 +96,8 @@ class LinearInt8ConvRot(LinearW8A8):
         return (self.out_features, self.in_features)
 
     def unquantized_weight(self, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
-        w = dequantize(self.weight.detach(), self.scale)
+        weight = self._decompress(self.weight.detach()) if self._compressed else self.weight.detach()
+        w = dequantize(weight, self.scale.to(device=weight.device))
         w = block_hadamard(w, self.block_size, self.rotation)[..., :self.in_features]
         return w.to(dtype=dtype, device=device)
 
@@ -127,6 +128,11 @@ class LinearInt8ConvRot(LinearW8A8):
         self.requires_grad_(False)
         self.weight = torch.nn.Parameter(weight, requires_grad=False)
         self.scale.copy_(scale)
+
+        # this override replaces LinearW8A8.quantize entirely, so the compression step has to be
+        # repeated here; forward() decompresses on the way in
+        if self.compress:
+            self._compress_weight(device=device)
 
     def forward(self, x_orig: torch.Tensor) -> torch.Tensor:
         assert not self.weight.requires_grad

--- a/modules/module/quantized/LinearInt8ConvRot.py
+++ b/modules/module/quantized/LinearInt8ConvRot.py
@@ -15,13 +15,14 @@ from modules.util.quantization_util import (
 import torch
 from torch import Tensor
 
-# Prototype knobs - env-driven, no UI/config plumbing (see PLAN in-an-new-branch-reflective-cocke).
+# Tuning knobs, env-driven rather than config-plumbed: these select between behaviours that are
+# still being characterized, so they are deliberately not exposed in the UI.
 # Block size for the group-wise Hadamard rotation. Not empirically validated; 128 is a common
 # group size in block quantization literature, picked as a starting point to sweep from.
 CONVROT_BLOCK_SIZE = int(os.environ.get("CONVROT_BLOCK_SIZE", "128"))
-# Isolates the untested part of this experiment: whether quantizing the backward grad-output
-# to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping it in
-# bf16. Default matches int8w8 so the two paths are directly comparable.
+# Isolates the part of the design that is still unmeasured: whether quantizing the backward
+# grad-output to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping
+# it in bf16. Default matches int8w8 so the two paths are directly comparable.
 CONVROT_BF16_DY = os.environ.get("CONVROT_BF16_DY", "0") == "1"
 # Which forward to run once the weight is stored as rotated int8. "int8" uses the fused kernel; "bf16"
 # dequantizes the weight and hands the matmul to the vendor BF16 GEMM. Accuracy and speed pull in opposite
@@ -126,7 +127,10 @@ class LinearInt8ConvRot(LinearW8A8):
             weight = weight.to(device=orig_device)
 
         self.requires_grad_(False)
-        self.weight = torch.nn.Parameter(weight, requires_grad=False)
+        # assign through .data rather than rebinding self.weight, so the Parameter object's identity
+        # survives quantization -- matches every other quantized layer, and anything already holding
+        # a reference to it (offloading, param groups) keeps seeing the live tensor
+        self.weight.data = weight
         self.scale.copy_(scale)
 
         # this override replaces LinearW8A8.quantize entirely, so the compression step has to be
@@ -228,9 +232,9 @@ def benchmark_throughput(m, k, n, block_size=128, device='cuda'):
 
 
 if __name__ == "__main__":
-    # Clock/config caveats: throughput numbers here are indicative only - see the plan's
-    # verification section for the locked-clock benchmark this repo normally requires before
-    # trusting a number.
+    # Clock/config caveats: throughput numbers here are indicative only - they are taken without
+    # locked clocks, so treat them as relative comparisons between the routes rather than absolute
+    # figures.
     benchmark_snr()
     print()
     benchmark_throughput(2 * 1024 + 50, 3072, 3088)

--- a/modules/module/quantized/LinearInt8ConvRot.py
+++ b/modules/module/quantized/LinearInt8ConvRot.py
@@ -23,6 +23,30 @@ CONVROT_BLOCK_SIZE = int(os.environ.get("CONVROT_BLOCK_SIZE", "128"))
 # to int8 (matching plain int8w8's backward) hurts LoRA gradient quality vs keeping it in
 # bf16. Default matches int8w8 so the two paths are directly comparable.
 CONVROT_BF16_DY = os.environ.get("CONVROT_BF16_DY", "0") == "1"
+# Which forward to run once the weight is stored as rotated int8. "int8" uses the fused kernel; "bf16"
+# dequantizes the weight and hands the matmul to the vendor BF16 GEMM. Accuracy and speed pull in opposite
+# directions, so this is a trade rather than a free choice.
+#
+# Measured here on a 5090, 5376 -> 7168, against the dequantized weight as reference:
+#
+#     tokens    fused int8    bf16
+#      2048       1.27 ms    2.74 ms
+#     12000      10.13 ms   11.70 ms
+#     error      9.43e-03   3.61e-03
+#
+# So bf16 is ~2.6x more accurate and 1.15-2.2x slower. Both routes carry the rotation's own quantization error
+# identically -- that is fixed when the weight is stored -- and what separates them is that the fused kernel
+# additionally quantizes the ACTIVATIONS per row on every call.
+#
+# musubi measures bf16 as both more accurate AND faster on an H100 (4.10 vs 6.22 s/it), noting "INT8 arithmetic
+# is not the problem, since an H100 runs INT8 and FP8 at the same rate -- the fused kernel is". That half does
+# not transfer: torch._int_mm on consumer hardware is fast, so the speed ordering reverses while the accuracy
+# ordering holds. Benchmark before assuming either.
+#
+# Default int8, which is the faster route here and matches the behaviour before this knob existed. Prefer bf16
+# when gradient quality matters more than throughput: the base is frozen, so a LoRA's entire gradient arrives
+# through this layer, and activation quantization lands directly on it.
+CONVROT_FWD = os.environ.get("CONVROT_FWD", "int8").lower()
 
 
 class LinearInt8ConvRotFunction(torch.autograd.Function):
@@ -109,14 +133,35 @@ class LinearInt8ConvRot(LinearW8A8):
         assert self._is_quantized
         x = x_orig.reshape(-1, x_orig.shape[-1])
 
-        if x.shape[0] > 16:
+        # The row floor is a HARD REQUIREMENT of torch._int_mm, not a performance heuristic -- do not remove it
+        # or relax it to >=. Measured on torch 2.12.0+cu130 / RTX 5090, int8 5376 -> 7168:
+        #     rows 15 -> RuntimeError: self.size(0) needs to be greater than 16, but got 15
+        #     rows 16 -> RuntimeError: self.size(0) needs to be greater than 16, but got 16
+        #     rows 17 -> ok
+        # so 16 itself fails and strictly-greater is correct. Anything at or below it must take the bf16 route,
+        # which is why that branch is the fallback rather than an alternative: it is the only path that works
+        # for small inputs, whatever CONVROT_FWD asks for.
+        if CONVROT_FWD == "int8" and x.shape[0] > 16:
+            # Decompress first: LinearW8A8 inherits CompressedWeightMixin, so self.weight may be a compressed
+            # blob rather than the int8 tensor, and LinearInt8ConvRotFunction consumes the int8 weight directly.
+            weight = self._decompress(self.weight) if self._compressed else self.weight
             y = LinearInt8ConvRotFunction.apply(
-                x, self.weight, self.scale, self.bias, self.compute_dtype,
+                x, weight, self.scale, self.bias, self.compute_dtype,
                 self.block_size, self.in_features, self.rotation,
             )
         else:
-            w = self.unquantized_weight(dtype=x.dtype, device=x.device)
-            y = torch.nn.functional.linear(x, w, self.bias)
+            # Rotate the ACTIVATIONS and leave the weight rotated as stored, rather than un-rotating the
+            # weight. The Hadamard is orthogonal, so (xR)(WR)^T == x W^T either way, but the costs are not
+            # symmetric: rotating x is tokens x in_features, un-rotating W is out_features x in_features and
+            # runs on every call. Measured on 12000x5376 -> 7168, this is the whole difference between the
+            # bf16 route being slower than the fused int8 kernel and being faster.
+            #
+            # unquantized_weight() still un-rotates, because its callers -- LoRA decompose, offload sizing --
+            # want the weight in its original basis. Only this forward can exploit the stored basis directly.
+            weight = self._decompress(self.weight) if self._compressed else self.weight
+            w_rotated = dequantize(weight, self.scale.to(device=weight.device)).to(x.dtype)
+            x_rotated = block_hadamard(pad_to_block(x, self.block_size), self.block_size, self.rotation)
+            y = torch.nn.functional.linear(x_rotated, w_rotated, self.bias)
 
         return y.reshape(x_orig.shape[:-1] + (y.shape[-1],))
 

--- a/modules/ui/BaseModelTabView.py
+++ b/modules/ui/BaseModelTabView.py
@@ -74,6 +74,8 @@ class BaseModelTabView(ABC):
             if include_compressed:
                 options.append(("int W8A8 compressed", DataType.INT_W8A8_COMPRESSED))
             options.append(("int W8A8 ConvRot", DataType.INT_W8A8_CONVROT))
+            if include_compressed:
+                options.append(("int W8A8 ConvRot compressed", DataType.INT_W8A8_CONVROT_COMPRESSED))
 
         if include_gguf:
             options.append(("GGUF", DataType.GGUF))

--- a/modules/ui/BaseModelTabView.py
+++ b/modules/ui/BaseModelTabView.py
@@ -73,6 +73,7 @@ class BaseModelTabView(ABC):
             options.append(("int W8A8", DataType.INT_W8A8))
             if include_compressed:
                 options.append(("int W8A8 compressed", DataType.INT_W8A8_COMPRESSED))
+            options.append(("int W8A8 ConvRot", DataType.INT_W8A8_CONVROT))
 
         if include_gguf:
             options.append(("GGUF", DataType.GGUF))

--- a/modules/util/enum/DataType.py
+++ b/modules/util/enum/DataType.py
@@ -15,6 +15,7 @@ class DataType(Enum):
     FLOAT_W8A8 = 'FLOAT_W8A8'
     INT_W8A8 = 'INT_W8A8'
     INT_W8A8_CONVROT = 'INT_W8A8_CONVROT'
+    INT_W8A8_CONVROT_COMPRESSED = 'INT_W8A8_CONVROT_COMPRESSED'
     FLOAT_W8A8_COMPRESSED = 'FLOAT_W8A8_COMPRESSED'
     INT_W8A8_COMPRESSED = 'INT_W8A8_COMPRESSED'
     GGUF = 'GGUF'
@@ -52,12 +53,15 @@ class DataType(Enum):
                 return DataType.FLOAT_W8A8
             case DataType.INT_W8A8_COMPRESSED:
                 return DataType.INT_W8A8
+            case DataType.INT_W8A8_CONVROT_COMPRESSED:
+                return DataType.INT_W8A8_CONVROT
             case _:
                 return self
 
     def is_compressed(self):
         return self in [DataType.FLOAT_W8A8_COMPRESSED,
-                        DataType.INT_W8A8_COMPRESSED]
+                        DataType.INT_W8A8_COMPRESSED,
+                        DataType.INT_W8A8_CONVROT_COMPRESSED]
 
     def is_quantized(self):
         return self.uncompressed() in [DataType.FLOAT_8,
@@ -85,7 +89,7 @@ class DataType(Enum):
         return self.uncompressed() == DataType.INT_W8A8
 
     def quantize_intW8A8_convrot(self):
-        return self == DataType.INT_W8A8_CONVROT
+        return self.uncompressed() == DataType.INT_W8A8_CONVROT
 
     def quantize_nf4(self):
         return self == DataType.NFLOAT_4

--- a/modules/util/enum/DataType.py
+++ b/modules/util/enum/DataType.py
@@ -14,6 +14,7 @@ class DataType(Enum):
     NFLOAT_4 = 'NFLOAT_4'
     FLOAT_W8A8 = 'FLOAT_W8A8'
     INT_W8A8 = 'INT_W8A8'
+    INT_W8A8_CONVROT = 'INT_W8A8_CONVROT'
     FLOAT_W8A8_COMPRESSED = 'FLOAT_W8A8_COMPRESSED'
     INT_W8A8_COMPRESSED = 'INT_W8A8_COMPRESSED'
     GGUF = 'GGUF'
@@ -63,6 +64,7 @@ class DataType(Enum):
                                        DataType.INT_8,
                                        DataType.FLOAT_W8A8,
                                        DataType.INT_W8A8,
+                                       DataType.INT_W8A8_CONVROT,
                                        DataType.NFLOAT_4]
 
     def is_gguf(self):
@@ -81,6 +83,9 @@ class DataType(Enum):
 
     def quantize_intW8A8(self):
         return self.uncompressed() == DataType.INT_W8A8
+
+    def quantize_intW8A8_convrot(self):
+        return self == DataType.INT_W8A8_CONVROT
 
     def quantize_nf4(self):
         return self == DataType.NFLOAT_4

--- a/modules/util/hadamard.py
+++ b/modules/util/hadamard.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+# Normalized Sylvester-Hadamard matrices, cached per (size, device, dtype).
+# H is symmetric and involutive (H @ H == I), so the same matrix rotates and un-rotates.
+_hadamard_cache: dict[tuple[int, torch.device, torch.dtype], Tensor] = {}
+
+def hadamard_matrix(n: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+    assert n > 0 and (n & (n - 1)) == 0, f"Hadamard size must be a power of 2, got {n}"
+    key = (n, device, dtype)
+    h = _hadamard_cache.get(key)
+    if h is not None:
+        return h
+
+    h = torch.ones((1, 1), device=device, dtype=torch.float32)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1),
+                        torch.cat([h, -h], dim=1)], dim=0)
+    h = (h / (n ** 0.5)).to(dtype)
+
+    _hadamard_cache[key] = h
+    return h
+
+def pad_to_block(x: Tensor, block_size: int) -> Tensor:
+    # Zero-pads the last dim up to a multiple of block_size. The padded columns are exact
+    # zeros; callers must carry them through block_hadamard uncut and only truncate back
+    # down after undoing the rotation (see block_hadamard) - never in between the two, or
+    # the truncation drops values that real data was mixed into.
+    pad = (-x.shape[-1]) % block_size
+    if pad:
+        x = F.pad(x, (0, pad))
+    return x
+
+def block_hadamard(x: Tensor, block_size: int, h: Tensor | None = None) -> Tensor:
+    # Rotates the last dim in independent blocks of block_size (block-diagonal Hadamard:
+    # O(dim * block_size) cost, not a dense O(dim^2) global rotation). x's last dim must
+    # already be a multiple of block_size (pad with pad_to_block first). This function never
+    # pads or truncates itself: H only inverts itself (H @ H == I) when applied twice to the
+    # same padded width; truncating between the two applications is a lossy projection, not
+    # an inverse, whenever the padding is non-zero.
+    # Pass a precomputed h (any dtype) from callers inside a torch.compile'd + activation-
+    # checkpointed region: the lazy hadamard_matrix() cache write is an in-graph side effect the
+    # checkpoint HOP rejects (it would be replayed on backward recompute). Eager callers leave h
+    # None and take the cached path.
+    assert x.shape[-1] % block_size == 0, "call pad_to_block first"
+    if h is None:
+        h = hadamard_matrix(block_size, x.device, x.dtype)
+    blocks = x.unflatten(-1, (-1, block_size))
+    rotated = blocks @ h.to(blocks.dtype)
+    return rotated.flatten(-2, -1)

--- a/modules/util/quantization_util.py
+++ b/modules/util/quantization_util.py
@@ -171,6 +171,7 @@ def replace_linear_with_quantized_layers(
 ):
     from modules.module.quantized.LinearFp8 import LinearFp8
     from modules.module.quantized.LinearGGUFA8 import LinearGGUFA8
+    from modules.module.quantized.LinearInt8ConvRot import LinearInt8ConvRot
     from modules.module.quantized.LinearSVD import make_svd_linear
     from modules.module.quantized.LinearW8A8 import LinearW8A8
 
@@ -185,6 +186,8 @@ def replace_linear_with_quantized_layers(
     elif dtype.quantize_intW8A8():
         linear_class = LinearW8A8
         kwargs = {'dtype': torch.int8}
+    elif dtype.quantize_intW8A8_convrot():
+        linear_class = LinearInt8ConvRot
     elif dtype.quantize_fpW8A8():
         linear_class=LinearW8A8
         kwargs = {'dtype': torch.float8_e4m3fn}


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary
Adds INT_W8A8_CONVROT: INT8 W8A8 quantization with a block-Hadamard rotation applied along the contraction dimension before quantizing, so channel outliers are spread across a block instead of dominating one channel's quantization range. The GEMM is unchanged from LinearW8A8 (torch._int_mm); the rotation is the only added op.

  Two commits:

  - 738cc0ce (dxqb, unmodified) — the original implementation.
  - 6515b393 — three changes in forward, plus documentation of an existing constraint:
    a. CONVROT_FWD selects the forward route. The bf16 route already existed but was only reachable below the int8 row floor, so real training always took the fused kernel. On a 5090 (5376→7168) bf16 is ~2.6× more accurate and 1.15–2.2× slower; default stays int8, preserving  existing behaviour. musubi measures bf16 as faster on an H100 — that half doesn't transfer to consumer hardware, the accuracy half does.
    b. The bf16 route rotates the activations rather than un-rotating the weight. The Hadamard is orthogonal so (xR)(WR)ᵀ == xWᵀ, but rotating x is tokens × in_features against out_features × in_features every call — 3.33 → 2.74 ms at 2048 tokens.
    c. Bug fix: decompress before the fused kernel. LinearW8A8 inherits CompressedWeightMixin, so self.weight may be a compressed blob and LinearInt8ConvRotFunction consumes the int8 weight directly — enabling weight compression with INT_W8A8_CONVROT otherwise hands the blob to torch._int_mm.

  Also documents why the x.shape[0] > 16 floor exists, because it reads as arbitrary and isn't: torch._int_mm requires strictly more than 16 rows (15 and 16 both raise self.size(0) needs to be greater than 16; 17 works), which also makes the bf16 branch the only path that works for small inputs regardless of CONVROT_FWD.

  Worth knowing: rotation and weight compression are substitutes. On the same MiniMax-H3 transformer, ConvRot compresses to 25% saved where plain int8 saves 46% — plain int8 compresses because outliers force a large tensorwise scale and leave everything else low-entropy, which is exactly the structure ConvRot removes.

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: not on this branch. Long training runs with this code happened on a downstream integration branch, not here. Accuracy was instead measured directly against real MiniMax-H3 transformer weights:
<img width="714" height="175" alt="image" src="https://github.com/user-attachments/assets/e7408ae9-946d-4752-ab3d-a206dd295c61" />

The benefit tracks the outlier ratio, and is neutral-to-slightly-negative where outliers are mild — consistent with what the rotation is for.

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change
 (Note: commit 738cc0ce is dxqb's own work, included unmodified for attribution; the declaration above covers 6515b393.)

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
