### PR TITLE
Auth check for HF repos + better errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ debug*.py
 config.json
 secrets.json
 *.zip
+training_presets/*.json
 
 # environments
 /.venv*

--- a/modules/modelLoader/GenericEmbeddingModelLoader.py
+++ b/modules/modelLoader/GenericEmbeddingModelLoader.py
@@ -45,6 +45,7 @@ def make_embedding_model_loader(
             model.model_spec = self._load_default_model_spec(model_type)
 
             if model_names.base_model is not None:
+                base_model_loader._validate_hf_repo_access(model_names.base_model)
                 base_model_loader.load(model, model_type, model_names, weight_dtypes, quantization)
             embedding_loader.load(model, model_names.embedding.model_name, model_names)
 

--- a/modules/modelLoader/GenericFineTuneModelLoader.py
+++ b/modules/modelLoader/GenericFineTuneModelLoader.py
@@ -50,6 +50,7 @@ def make_fine_tune_model_loader(
             self._load_internal_data(model, model_names.base_model)
             model.model_spec = self._load_default_model_spec(model_type)
 
+            base_model_loader._validate_hf_repo_access(model_names.base_model)
             base_model_loader.load(model, model_type, model_names, weight_dtypes, quantization)
             if embedding_loader_class is not None:
                 embedding_loader.load(model, model_names.base_model, model_names)

--- a/modules/modelLoader/GenericLoRAModelLoader.py
+++ b/modules/modelLoader/GenericLoRAModelLoader.py
@@ -48,6 +48,7 @@ def make_lora_model_loader(
             model.model_spec = self._load_default_model_spec(model_type)
 
             if model_names.base_model is not None:
+                base_model_loader._validate_hf_repo_access(model_names.base_model)
                 base_model_loader.load(model, model_type, model_names, weight_dtypes, quantization)
             lora_model_loader.load(model, model_names)
             if embedding_loader_class is not None:

--- a/modules/modelLoader/mixin/HFModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/HFModelLoaderMixin.py
@@ -22,7 +22,7 @@ import huggingface_hub
 from huggingface_hub import constants as hf_constants
 from huggingface_hub import parse_hf_uri
 from huggingface_hub.errors import HfUriError
-from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
 from safetensors.torch import load_file
 
 # huggingface_hub 1.16+ uses httpx, which logs every HTTP request/response at INFO level.
@@ -68,14 +68,17 @@ class HFModelLoaderMixin(metaclass=ABCMeta):
                 huggingface_hub.whoami(token=token, cache=True)
             except HfHubHTTPError as e:
                 if e.response.status_code == 401:
-                    raise ValueError("Invalid Hugging Face token.") from e
+                    raise ValueError("Invalid Hugging Face token.") from None
                 raise
 
-        huggingface_hub.auth_check(
-            repo_id=repo_id,
-            repo_type="model",
-            token=token,
-        )
+        try:
+            huggingface_hub.auth_check(
+                repo_id=repo_id,
+                repo_type="model",
+                token=token,
+            )
+        except RepositoryNotFoundError as e:
+            raise e.with_traceback(None) from None
         self.__validated_hf_repositories.add(repo_id)
 
     def __load_sub_module(

--- a/modules/modelLoader/mixin/HFModelLoaderMixin.py
+++ b/modules/modelLoader/mixin/HFModelLoaderMixin.py
@@ -19,7 +19,10 @@ from transformers.core_model_loading import rename_source_key
 
 import accelerate
 import huggingface_hub
-from huggingface_hub.utils import EntryNotFoundError
+from huggingface_hub import constants as hf_constants
+from huggingface_hub import parse_hf_uri
+from huggingface_hub.errors import HfUriError
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 from safetensors.torch import load_file
 
 # huggingface_hub 1.16+ uses httpx, which logs every HTTP request/response at INFO level.
@@ -29,6 +32,51 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 class HFModelLoaderMixin(metaclass=ABCMeta):
     def __init__(self):
         super().__init__()
+        self.__validated_hf_repositories: set[str] = set()
+
+    @staticmethod
+    def __normalize_hf_repo_id(repo_id: str) -> str:
+        if not repo_id.startswith(("http://", "https://")):
+            return repo_id
+
+        try:
+            uri = parse_hf_uri(repo_id)
+        except HfUriError:
+            return repo_id
+
+        if uri.type != "model":
+            raise ValueError(f"Expected a Hugging Face model URL, got a {uri.type} URL.")
+
+        return uri.id
+
+    def _validate_hf_repo_access(
+            self,
+            repo_id: str | None,
+    ):
+        if not repo_id \
+                or os.path.exists(repo_id) \
+                or hf_constants.HF_HUB_OFFLINE:
+            return
+
+        repo_id = self.__normalize_hf_repo_id(repo_id)
+        if repo_id in self.__validated_hf_repositories:
+            return
+
+        token = huggingface_hub.get_token()
+        if token is not None:
+            try:
+                huggingface_hub.whoami(token=token, cache=True)
+            except HfHubHTTPError as e:
+                if e.response.status_code == 401:
+                    raise ValueError("Invalid Hugging Face token.") from e
+                raise
+
+        huggingface_hub.auth_check(
+            repo_id=repo_id,
+            repo_type="model",
+            token=token,
+        )
+        self.__validated_hf_repositories.add(repo_id)
 
     def __load_sub_module(
             self,
@@ -198,6 +246,8 @@ class HFModelLoaderMixin(metaclass=ABCMeta):
             pretrained_model_name_or_path: str,
             subfolder: str = "",
     ):
+        self._validate_hf_repo_access(pretrained_model_name_or_path)
+
         user_agent = {
             "file_type": "model",
             "framework": "pytorch",
@@ -235,6 +285,8 @@ class HFModelLoaderMixin(metaclass=ABCMeta):
             subfolder: str | None = None,
             quantization: QuantizationConfig | None = None,
     ):
+        self._validate_hf_repo_access(pretrained_model_name_or_path)
+
         user_agent = {
             "file_type": "model",
             "framework": "pytorch",


### PR DESCRIPTION
Users keep foot gunning on getting access to HF repos, including more experienced users. This attempts suppress the unnecessary parts of the error chain for hf auth. Also modifies the gitignore so that we dont try to commit users presets that sit in ./training_presets (but still track presets in sub folders)

1. Launched UI
2. Selected Krea 2 preset (I dont have access to it)
3. Expectedly fails and prints out:

```
Traceback (most recent call last):
  File "C:\repos\OneTrainer\modules\ui\TrainUIController.py", line 247, in __training_thread_function_impl
    trainer.start()
    ~~~~~~~~~~~~~^^
  File "C:\repos\OneTrainer\modules\trainer\GenericTrainer.py", line 135, in start
    self.model = self.model_loader.load(
                 ~~~~~~~~~~~~~~~~~~~~~~^
        model_type=self.config.model_type,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        quantization=self.config.quantization,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\repos\OneTrainer\modules\modelLoader\GenericLoRAModelLoader.py", line 51, in load
    base_model_loader._validate_hf_repo_access(model_names.base_model)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\OneTrainer\modules\modelLoader\mixin\HFModelLoaderMixin.py", line 81, in _validate_hf_repo_access
    raise e.with_traceback(None) from None
huggingface_hub.errors.GatedRepoError: 403 Client Error. (Request ID: Root=1-6a79c730-65e25faf298604fd20a3aeda;3e346efe-45a6-4544-90a5-86fdac5ab6fb)

Cannot access gated repo for url https://huggingface.co/api/models/krea/Krea-2-Raw/auth-check.
Access to model krea/Krea-2-Raw is restricted and you are not in the authorized list. Visit https://huggingface.co/krea/Krea-2-Raw to ask for access.
```

## AI assistance

AI-assisted. First time trying this, something small scope. CGPT 5.6 Sol. Read every line and tested, online, offline and 'I have access' to the model
