### PR TITLE
Fix additional embeddings not being saved as separate files

### DIFF
--- a/modules/modelSaver/GenericFineTuneModelSaver.py
+++ b/modules/modelSaver/GenericFineTuneModelSaver.py
@@ -38,7 +38,9 @@ def make_fine_tune_model_saver(
 
             if embedding_saver_class is not None:
                 embedding_model_saver = embedding_saver_class()
-                embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+                embedding_model_format = ModelFormat.INTERNAL if output_model_format == ModelFormat.INTERNAL \
+                    else ModelFormat.SAFETENSORS
+                embedding_model_saver.save_multiple(model, embedding_model_format, output_model_destination, dtype)
 
             if output_model_format == ModelFormat.INTERNAL:
                 self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/GenericLoRAModelSaver.py
+++ b/modules/modelSaver/GenericLoRAModelSaver.py
@@ -41,7 +41,9 @@ def make_lora_model_saver(
                 if ((model.train_config is not None and not model.train_config.bundle_additional_embeddings) \
                     or output_model_format == ModelFormat.INTERNAL
                 ):
-                    embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+                    embedding_model_format = ModelFormat.INTERNAL if output_model_format == ModelFormat.INTERNAL \
+                        else ModelFormat.SAFETENSORS
+                    embedding_model_saver.save_multiple(model, embedding_model_format, output_model_destination, dtype)
 
             if output_model_format == ModelFormat.INTERNAL:
                 self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/StableDiffusionFineTuneModelSaver.py
+++ b/modules/modelSaver/StableDiffusionFineTuneModelSaver.py
@@ -30,7 +30,9 @@ class StableDiffusionFineTuneModelSaver(
         embedding_model_saver = StableDiffusionEmbeddingSaver()
 
         base_model_saver.save(model, model_type, output_model_format, output_model_destination, dtype)
-        embedding_model_saver.save_multiple(model, output_model_format, output_model_destination, dtype)
+        embedding_model_format = ModelFormat.INTERNAL if output_model_format == ModelFormat.INTERNAL \
+            else ModelFormat.SAFETENSORS
+        embedding_model_saver.save_multiple(model, embedding_model_format, output_model_destination, dtype)
 
         if output_model_format == ModelFormat.INTERNAL:
             self._save_internal_data(model, output_model_destination)

--- a/modules/modelSaver/chroma/ChromaEmbeddingSaver.py
+++ b/modules/modelSaver/chroma/ChromaEmbeddingSaver.py
@@ -62,6 +62,8 @@ class ChromaEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -105,3 +107,5 @@ class ChromaEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/flux/FluxEmbeddingSaver.py
+++ b/modules/modelSaver/flux/FluxEmbeddingSaver.py
@@ -66,6 +66,8 @@ class FluxEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -109,3 +111,5 @@ class FluxEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/hidream/HiDreamEmbeddingSaver.py
+++ b/modules/modelSaver/hidream/HiDreamEmbeddingSaver.py
@@ -74,6 +74,8 @@ class HiDreamEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -117,3 +119,5 @@ class HiDreamEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/hunyuanVideo/HunyuanVideoEmbeddingSaver.py
+++ b/modules/modelSaver/hunyuanVideo/HunyuanVideoEmbeddingSaver.py
@@ -66,6 +66,8 @@ class HunyuanVideoEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -109,3 +111,5 @@ class HunyuanVideoEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/pixartAlpha/PixArtAlphaEmbeddingSaver.py
+++ b/modules/modelSaver/pixartAlpha/PixArtAlphaEmbeddingSaver.py
@@ -62,6 +62,8 @@ class PixArtAlphaEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -105,3 +107,5 @@ class PixArtAlphaEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/sana/SanaEmbeddingSaver.py
+++ b/modules/modelSaver/sana/SanaEmbeddingSaver.py
@@ -62,6 +62,8 @@ class SanaEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -105,3 +107,5 @@ class SanaEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/stableDiffusion/StableDiffusionEmbeddingSaver.py
+++ b/modules/modelSaver/stableDiffusion/StableDiffusionEmbeddingSaver.py
@@ -62,6 +62,8 @@ class StableDiffusionEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -105,3 +107,5 @@ class StableDiffusionEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/stableDiffusion3/StableDiffusion3EmbeddingSaver.py
+++ b/modules/modelSaver/stableDiffusion3/StableDiffusion3EmbeddingSaver.py
@@ -70,6 +70,8 @@ class StableDiffusion3EmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -113,3 +115,5 @@ class StableDiffusion3EmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/stableDiffusionXL/StableDiffusionXLEmbeddingSaver.py
+++ b/modules/modelSaver/stableDiffusionXL/StableDiffusionXLEmbeddingSaver.py
@@ -66,6 +66,8 @@ class StableDiffusionXLEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -109,3 +111,5 @@ class StableDiffusionXLEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")

--- a/modules/modelSaver/wuerstchen/WuerstchenEmbeddingSaver.py
+++ b/modules/modelSaver/wuerstchen/WuerstchenEmbeddingSaver.py
@@ -62,6 +62,8 @@ class WuerstchenEmbeddingSaver(
                     embedding_uuid,
                     output_model_destination,
                 )
+            case _:
+                raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")
 
     def save_multiple(
             self,
@@ -105,3 +107,5 @@ class WuerstchenEmbeddingSaver(
                         embedding_uuid,
                         output_model_destination,
                     )
+                case _:
+                    raise NotImplementedError(f"Unsupported embedding output format: {output_model_format}")


### PR DESCRIPTION

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->
fixes https://github.com/Nerogar/OneTrainer/issues/1684

- the LoRA-format like COMFY_LORA was passed to the embedding saver
- but the embedding saver only knows 2 formats, SAFETENSORS and INTERNAL for backup
- this was silent because the embedding savers had no `case _`



## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
