### PR TITLE
Cloud: Print the traceback before the final save in case of error

### DIFF
--- a/scripts/train_remote.py
+++ b/scripts/train_remote.py
@@ -88,6 +88,13 @@ def main():
         trainer.start()
         trainer.train()
 
+    except Exception:
+        # print the traceback before end() runs. end() saves the final model, which takes long enough that a log
+        # ending on its "Saving ..." line is indistinguishable from a clean stop until the traceback finally
+        # appears after it.
+        traceback.print_exc()
+        raise
+
     finally:
         if args.command_path:
             stop_event.set()


### PR DESCRIPTION
When a remote run crashes, main()'s finally calls trainer.end(), which saves the final model. That takes long enough that the log ends on its "Saving ..." line and stays there for minutes, so a crash is indistinguishable from a clean stop until the traceback finally appears after the save. Catching, printing and re-raising puts the traceback first.
UI trainer already does that

<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [ ] Tested with at least one real preset / config when relevant (note which: ____)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
