### PR TITLE
fix: Set requires_grad on the prior text encoder WuerstchenModel

### DIFF
--- a/modules/modelSetup/WuerstchenFineTuneSetup.py
+++ b/modules/modelSetup/WuerstchenFineTuneSetup.py
@@ -48,7 +48,7 @@ class WuerstchenFineTuneSetup(
         model.decoder_vqgan.requires_grad_(False)
         model.effnet_encoder.requires_grad_(False)
 
-        self._setup_model_part_requires_grad("text_encoder", model.text_encoder, config.text_encoder, model.train_progress)
+        self._setup_model_part_requires_grad("prior_text_encoder", model.prior_text_encoder, config.text_encoder, model.train_progress)
         self._setup_model_part_requires_grad("prior_prior", model.prior_prior, config.prior, model.train_progress)
 
     def setup_model(


### PR DESCRIPTION
<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
