### PR TITLE
minor UI fix: Fix clipped concept names in the Qt concept tab

### DIFF
--- a/modules/ui/PySide6ConceptTabView.py
+++ b/modules/ui/PySide6ConceptTabView.py
@@ -125,7 +125,6 @@ class PySide6ConceptWidgetView(BaseConceptWidgetView, QWidget):
         )
 
         self.name_label = QLabel(self._get_display_name(), self)
-        self.name_label.setWordWrap(True)
         self.name_label.setFixedWidth(140)
         self.name_label.move(5, 153)
 


### PR DESCRIPTION
Disable word wrap for concept names. When it wraps over, the bottom half of the first line and the top half of the second line was displayed because there is only space for one line.
