### PR TITLE
Fix Flux2/Ernie dynamic shift 4x-too-small token count

### DIFF
--- a/modules/modelSetup/BaseErnieSetup.py
+++ b/modules/modelSetup/BaseErnieSetup.py
@@ -74,10 +74,11 @@ class BaseErnieSetup(
             )
 
             # Patchify: [B, 32, H, W] -> [B, 128, H/2, W/2]
-            latent_image = model.patchify_latents(batch['latent_image'].float())
-            latent_height = latent_image.shape[-2]
-            latent_width = latent_image.shape[-1]
-            scaled_latent_image = model.scale_latents(latent_image)
+            patchified_latent_image = model.patchify_latents(batch['latent_image'].float())
+            # calculate_timestep_shift patchifies by 2 internally, so its token count is over the raw VAE latent dims.
+            latent_height = batch['latent_image'].shape[-2]
+            latent_width = batch['latent_image'].shape[-1]
+            scaled_latent_image = model.scale_latents(patchified_latent_image)
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 

--- a/modules/modelSetup/BaseFlux2Setup.py
+++ b/modules/modelSetup/BaseFlux2Setup.py
@@ -75,10 +75,11 @@ class BaseFlux2Setup(
                 text_encoder_output=batch.get('text_encoder_hidden_state'),
                 text_encoder_dropout_probability=config.text_encoder.dropout_probability if not deterministic else None,
             )
-            latent_image = model.patchify_latents(batch['latent_image'].float())
-            latent_height = latent_image.shape[-2]
-            latent_width = latent_image.shape[-1]
-            scaled_latent_image = model.scale_latents(latent_image)
+            patchified_latent_image = model.patchify_latents(batch['latent_image'].float())
+            # calculate_timestep_shift patchifies by 2 internally, so its token count is over the raw VAE latent dims.
+            latent_height = batch['latent_image'].shape[-2]
+            latent_width = batch['latent_image'].shape[-1]
+            scaled_latent_image = model.scale_latents(patchified_latent_image)
 
             latent_noise = self._create_noise(scaled_latent_image, config, generator)
 


### PR DESCRIPTION
The Flux 2 and Ernie setups patchified the latent (packing 2x2 into channels, halving the spatial dims) before reading latent_height and latent_width, then passed those to calculate_timestep_shift, which patchifies by 2 again. The resulting token count was 4x too small, so the dynamic timestep shift came out systematically too low.


<!--
Thanks for contributing to OneTrainer.
Please read docs/Contributing.md / docs/ProjectStructure.md for the project guide.
-->

## Summary

<!-- What this PR changes and why. Link an issue or discussion if relevant. -->

## Test plan

<!--
OneTrainer has no automated test suite. Manual verification is expected.
Describe what you actually did, not what you "would do".
-->

- [x] `pre-commit run --all-files` passes
- [x] Launched the affected UI or script and exercised the change
- [x] Tested with at least one real preset / config when relevant (note which: Flux2)

## AI assistance

<!--
This project welcomes AI-assisted contributions but the reviewer should not have to be
your co-author. Pick exactly one option below, delete the others.
-->

- AI-assisted — I have read every line in this diff and can defend each change

<!-- By opening this PR (and not marking it as an early prototype, aka a draft) I confirm I have read every line in this diff and have tested it locally. -->
