### PR TITLE
Add bitsandbytes to ROCm requirements (Linux) and bump pin to 0.49.2

### DIFF
--- a/requirements-cuda-legacy.txt
+++ b/requirements-cuda-legacy.txt
@@ -12,4 +12,4 @@ nvidia-nvcomp-cu12==5.3.0.16
 triton-windows==3.7.0.post26; sys_platform == "win32"
 
 # optimizers
-bitsandbytes==0.49.1 # bitsandbytes for 8-bit optimizers and weight quantization
+bitsandbytes==0.49.2 # bitsandbytes for 8-bit optimizers and weight quantization

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -8,4 +8,4 @@ nvidia-nvcomp-cu13==5.3.0.16
 triton-windows==3.7.0.post26; sys_platform == "win32"
 
 # optimizers
-bitsandbytes==0.49.1 # bitsandbytes for 8-bit optimizers and weight quantization
+bitsandbytes==0.49.2 # bitsandbytes for 8-bit optimizers and weight quantization

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -8,4 +8,4 @@ torchvision==0.27.0+rocm7.2; sys_platform == "linux"
 onnxruntime==1.23.2
 
 # optimizers
-# TODO
+bitsandbytes==0.49.2 # bitsandbytes for 8-bit optimizers and weight quantization


### PR DESCRIPTION
## Summary

bitsandbytes is pinned to 0.49.1 in the CUDA requirements and missing entirely from the
ROCm requirements. This bumps the CUDA pins to 0.49.2 and adds the same line to
`requirements-rocm.txt`, so 8-bit optimizers and NF4/INT8 quantization work on Linux ROCm.

0.49.2 rather than 0.50.x because 0.50.0 removed `block_wise=` and `percentile_clipping=`
from every bnb optimizer, which `modules/util/create.py` still passes (#1519, #1708). 0.49.2
is the last release before that break and the first with the ROCm 7.2 build
(bitsandbytes#1845), matching `torch==2.12.0+rocm7.2`.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Exercised the change by running OneTrainer's bnb code paths (`create.py` optimizer
      kwargs, `LinearNf4.py`, `Linear8bitLt`) against bnb 0.49.2 on Linux ROCm 7.2 (AMD 890M)
      and Linux CUDA 13.0 (RTX 5060 Ti): 15/16 pass on each. The one failure is the 32-bit
      `LARS` optimizer, a pre-existing bnb bug already present in 0.49.1, not introduced here.
- [ ] Tested with at least one real preset / config when relevant (note which: n/a, dependency
      pin change only)

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change
- Local agent utilized for research. Cross-reference local OneTrainer and bitsandbytes codebases and versions. Building of test, project installations/venv creation, and automated remote function verification across Nvidia and AMD machines.
